### PR TITLE
Update OpenTofu installer path

### DIFF
--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -7,5 +7,6 @@ param(
 if ($Config.InstallOpenTofu -eq $true) {
     
     $Cosign = Join-Path $Config.CosignPath "cosign-windows-amd64.exe"
-    & .\runner_scripts\OpenTofuInstaller.ps1 -installMethod standalone -cosignPath $Cosign
+    $installer = Join-Path $PSScriptRoot "..\runner_utility_scripts\OpenTofuInstaller.ps1"
+    & $installer -installMethod standalone -cosignPath $Cosign
 }


### PR DESCRIPTION
## Summary
- reference OpenTofuInstaller from runner_utility_scripts

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*
- `pwsh -Command "Write-Host test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461fbc1bac833198ba8aa1d245087b