### PR TITLE
Fix kicker-bootstrap call

### DIFF
--- a/iso_tools/bootstrap.ps1
+++ b/iso_tools/bootstrap.ps1
@@ -2,4 +2,9 @@ Set-ExecutionPolicy -ExecutionPolicy Bypass
 
 Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/dev/kicker-bootstrap.ps1' -OutFile '.\kicker-bootstrap.ps1'
 
-& .\kicker-boostrap.ps1
+if (Test-Path '.\kicker-bootstrap.ps1') {
+  Write-Host "Downloaded kicker-bootstrap.ps1 to $(Resolve-Path '.\kicker-bootstrap.ps1')"
+  & .\kicker-bootstrap.ps1
+} else {
+  Write-Error 'kicker-bootstrap.ps1 was not found after download.'
+}


### PR DESCRIPTION
## Summary
- invoke the `kicker-bootstrap.ps1` script from `iso_tools/bootstrap.ps1`
- check that the file was downloaded correctly before execution

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68461fc2d95c8331be63c22daceb1e17