### PR TITLE
Add variables for switch and docs

### DIFF
--- a/example-infrastructure/README.md
+++ b/example-infrastructure/README.md
@@ -12,6 +12,18 @@ tofu plan
 tofu apply
 ```
 
+## Customizing variables
+
+Default values for network adapter names, ISO locations and VM counts are
+defined in `variables.tf`.  Create a `terraform.tfvars` file or pass `-var`
+arguments to override them.  Example `terraform.tfvars`:
+
+```hcl
+wan_switch_name   = "lab"
+wan_adapter_names = ["Ethernet 2"]
+windows_11_vm_count = 2
+```
+
 If you need to reset your working copy run:
 
 ```

--- a/example-infrastructure/WAN-vSwitch.tf
+++ b/example-infrastructure/WAN-vSwitch.tf
@@ -1,8 +1,8 @@
 # Declare the hyperv_network_switch resource
 # Get-NetAdapter
 resource "hyperv_network_switch" "wan" {
-  name                = "wan"
+  name                = var.wan_switch_name
   allow_management_os = true
   switch_type         = "External"
-  net_adapter_names   = ["Ethernet"]
+  net_adapter_names   = var.wan_adapter_names
 }

--- a/example-infrastructure/variables.tf
+++ b/example-infrastructure/variables.tf
@@ -22,6 +22,19 @@ variable "hyperv_vm_path" {
   default = "B:\\hyper-v\\"
 }
 
+###############################################################################
+# Network switch configuration
+###############################################################################
+variable "wan_switch_name" {
+  type    = string
+  default = "wan"
+}
+
+variable "wan_adapter_names" {
+  type    = list(string)
+  default = ["Ethernet"]
+}
+
 variable "server_2025_iso_path" {
     type  = string
     default = "\\B:\\share\\isos\\core_windows_server_2025_feb_2025_CustomWinISO.iso"


### PR DESCRIPTION
## Summary
- parameterize Hyper-V switch name and adapter names via `variables.tf`
- document overriding variables in the example infrastructure

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `tofu fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461fd4fd408331ac2e2ca442d08b0a