### PR TITLE
Fix stable branch path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ```
 
 
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/stable/kicker-bootstrap.ps1' -OutFile '.\kicker-bootstrap.ps1'; .\kicker-bootstrap.ps1"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/main/kicker-bootstrap.ps1' -OutFile '.\kicker-bootstrap.ps1'; .\kicker-bootstrap.ps1"
 
 ```
 

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -14,8 +14,8 @@
   5) Invokes runner.ps1 from that repo.
 #>
 
-$targetBranch = 'stable'
-$defaultConfig = "https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/stable/config_files/default-config.json"
+$targetBranch = 'main'
+$defaultConfig = "https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/main/config_files/default-config.json"
 
 # example: https://raw.githubusercontent.com/wizzense/tofu-base-lab/refs/heads/main/configs/bootstrap-config.json
 


### PR DESCRIPTION
## Summary
- fix README example to use `main` branch
- update kicker-bootstrap.ps1 default branch

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68463aaf9e388331ac8d87a31bb7d5d3