### PR TITLE
Fix branch checkout in kicker script

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -268,6 +268,17 @@ if (!(Test-Path $repoPath)) {
     Pop-Location
 }
 
+# Ensure the desired branch is checked out and up to date
+Push-Location $repoPath
+& "$gitPath" fetch --all
+& "$gitPath" checkout $targetBranch 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "Branch '$targetBranch' not found. Using current branch."
+} else {
+    & "$gitPath" pull origin $targetBranch
+}
+Pop-Location
+
 # ------------------------------------------------
 # (5) Invoke the Runner Script
 # ------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure kicker-bootstrap.ps1 checks out desired branch after cloning or pulling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68463c184b1483319b681592cc85ba2b