### PR TITLE
Fix logger variable interpolation issue

### DIFF
--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -13,7 +13,7 @@ function Write-Log {
         try {
             $formatted | Out-File -FilePath $LogFile -Encoding utf8 -Append
         } catch {
-            Write-Host "[ERROR] Failed to write to log file $LogFile: $_"
+            Write-Host "[ERROR] Failed to write to log file ${LogFile}: $_"
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix variable interpolation in `Write-Log`

## Testing
- `pwsh -NoProfile -Command Invoke-Pester -Path tests` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684646e23d3c833191a07e5b438704d9