### PR TITLE
Add unified config loader

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -44,6 +44,11 @@ if (-not (Test-Path $loggerPath)) {
 }
 . $loggerPath
 
+# Load config helper
+$labUtilsDir = Join-Path $PSScriptRoot 'lab_utils'
+$labConfigScript = Join-Path $labUtilsDir 'Get-LabConfig.ps1'
+. $labConfigScript
+
 
 # ------------------------------------------------
 # (0) clever? message, take a second...
@@ -102,16 +107,11 @@ else {
 # (1) Load Configuration
 # ------------------------------------------------
 Write-Log "==== Loading configuration file ===="
-if (!(Test-Path $ConfigFile)) {
-    Write-Error "ERROR: Could not find config.json at $ConfigFile"
-    exit 1
-}
-
 try {
-    $config = Get-Content -Raw -Path $ConfigFile | ConvertFrom-Json
+    $config = Get-LabConfig -Path $ConfigFile
     Write-Log "Config file loaded from $ConfigFile."
 } catch {
-    Write-Error "ERROR: Failed to parse JSON from $ConfigFile. $($_.Exception.Message)"
+    Write-Error "ERROR: $($_.Exception.Message)"
     exit 1
 }
 

--- a/lab_utils/Get-LabConfig.ps1
+++ b/lab_utils/Get-LabConfig.ps1
@@ -1,0 +1,23 @@
+function Get-LabConfig {
+    [CmdletBinding()]
+    param(
+        [string]$Path = (Join-Path $PSScriptRoot '..' 'config_files' 'default-config.json')
+    )
+
+    if (-not (Test-Path $Path)) {
+        throw "Config file not found at $Path"
+    }
+
+    try {
+        $content = Get-Content -Path $Path -Raw
+        $ext = [IO.Path]::GetExtension($Path).ToLowerInvariant()
+        switch ($ext) {
+            '.json' { return $content | ConvertFrom-Json }
+            '.yml' { if (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue) { return $content | ConvertFrom-Yaml } else { throw 'YAML parsing requires ConvertFrom-Yaml cmdlet.' } }
+            '.yaml' { if (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue) { return $content | ConvertFrom-Yaml } else { throw 'YAML parsing requires ConvertFrom-Yaml cmdlet.' } }
+            default { throw "Unsupported file extension: $ext" }
+        }
+    } catch {
+        throw "Failed to parse configuration: $($_.Exception.Message)"
+    }
+}

--- a/runner.ps1
+++ b/runner.ps1
@@ -4,8 +4,9 @@ param(
     [string]$RunScripts
 )
 
-# Load logging helper
+# Load helpers
 . "$PSScriptRoot\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\lab_utils\Get-LabConfig.ps1"
 
 function ConvertTo-Hashtable {
     param(
@@ -46,17 +47,11 @@ function Customize-Config {
 }
 
 Write-Log "==== Loading configuration ===="
-if (!(Test-Path $ConfigFile)) {
-    Write-Log "ERROR: Cannot find config file at $ConfigFile"
-    exit 1
-}
-
 try {
-    $jsonContent = Get-Content -Path $ConfigFile -Raw
-    $ConfigRaw = ConvertFrom-Json $jsonContent
+    $ConfigRaw = Get-LabConfig -Path $ConfigFile
     $Config = ConvertTo-Hashtable $ConfigRaw
 } catch {
-    Write-Log "ERROR: Failed to parse JSON from $ConfigFile. $_"
+    Write-Log "ERROR: $_"
     exit 1
 }
 

--- a/tests/Get-LabConfig.Tests.ps1
+++ b/tests/Get-LabConfig.Tests.ps1
@@ -1,0 +1,25 @@
+Describe 'Get-LabConfig' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\lab_utils\Get-LabConfig.ps1')
+    }
+
+    It 'successfully loads default configuration' {
+        $config = Get-LabConfig
+        ($config -is [pscustomobject]) | Should -BeTrue
+        $config.ConfigFile | Should -Match 'default-config.json'
+    }
+
+    It 'throws if file is missing' {
+        { Get-LabConfig -Path 'nope.json' } | Should -Throw
+    }
+
+    It 'throws on malformed JSON' {
+        $bad = Join-Path $PSScriptRoot 'bad.json'
+        Set-Content -Path $bad -Value '{bad json'
+        try {
+            { Get-LabConfig -Path $bad } | Should -Throw
+        } finally {
+            Remove-Item $bad
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Get-LabConfig` helper for JSON/YAML config files
- use `Get-LabConfig` in `runner.ps1`
- use `Get-LabConfig` in `kicker-bootstrap.ps1`
- test configuration loader

## Testing
- `Invoke-Pester -Path tests`

------
https://chatgpt.com/codex/tasks/task_e_68464758da308331b712ec2fdd96e449