### PR TITLE
Add Get-LabConfig and extend runner tests

### DIFF
--- a/lab_utils/Get-LabConfig.ps1
+++ b/lab_utils/Get-LabConfig.ps1
@@ -1,0 +1,26 @@
+function Get-LabConfig {
+    [CmdletBinding()]
+    param(
+        [string]$Path = (Join-Path $PSScriptRoot '..\config_files\default-config.json')
+    )
+
+    if (-not (Test-Path $Path)) {
+        throw "Config file not found at $Path"
+    }
+
+    try {
+        $content = Get-Content -Raw -Path $Path
+        if ($Path -match '\.ya?ml$') {
+            if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+                throw 'YAML support not available'
+            }
+            return $content | ConvertFrom-Yaml
+        }
+        else {
+            return $content | ConvertFrom-Json
+        }
+    }
+    catch {
+        throw "Failed to parse config file $Path. $_"
+    }
+}

--- a/tests/Get-LabConfig.Tests.ps1
+++ b/tests/Get-LabConfig.Tests.ps1
@@ -1,0 +1,27 @@
+Describe 'Get-LabConfig' {
+    It 'returns PSCustomObject for valid JSON' {
+        $modulePath = Join-Path $PSScriptRoot '..\lab_utils\Get-LabConfig.ps1'
+        . $modulePath
+        $configPath = Join-Path $PSScriptRoot '..\config_files\default-config.json'
+        $result = Get-LabConfig -Path $configPath
+        $result | Should -BeOfType 'System.Management.Automation.PSCustomObject'
+    }
+
+    It 'throws when file does not exist' {
+        $modulePath = Join-Path $PSScriptRoot '..\lab_utils\Get-LabConfig.ps1'
+        . $modulePath
+        { Get-LabConfig -Path 'nonexistent.json' } | Should -Throw
+    }
+
+    It 'throws on invalid JSON' {
+        $modulePath = Join-Path $PSScriptRoot '..\lab_utils\Get-LabConfig.ps1'
+        . $modulePath
+        $badFile = Join-Path $PSScriptRoot 'bad.json'
+        Set-Content -Path $badFile -Value '{bad json}'
+        try {
+            { Get-LabConfig -Path $badFile } | Should -Throw
+        } finally {
+            Remove-Item $badFile
+        }
+    }
+}

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -1,6 +1,57 @@
 Describe 'runner.ps1 configuration' {
     It 'loads default configuration without errors' {
+        $modulePath = Join-Path $PSScriptRoot '..\lab_utils\Get-LabConfig.ps1'
+        . $modulePath
         $configPath = Join-Path $PSScriptRoot '..\config_files\default-config.json'
-        { Get-Content -Raw $configPath | ConvertFrom-Json } | Should -Not -Throw
+        { Get-LabConfig -Path $configPath } | Should -Not -Throw
+    }
+}
+
+Describe 'runner.ps1 script selection' {
+    BeforeAll {
+        $runnerPath = Join-Path $PSScriptRoot '..\runner.ps1'
+        $modulePath = Join-Path $PSScriptRoot '..\lab_utils\Get-LabConfig.ps1'
+        . $modulePath
+    }
+
+    It 'runs non-interactively when -RunScripts is supplied' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $tempDir
+        try {
+            Copy-Item $runnerPath -Destination $tempDir
+            $scriptsDir = Join-Path $tempDir 'runner_scripts'
+            $null = New-Item -ItemType Directory -Path $scriptsDir
+            $dummy = Join-Path $scriptsDir '0001_Test.ps1'
+            'Param([PSCustomObject]$Config)' | Set-Content -Path $dummy
+
+            Push-Location $tempDir
+            Mock Read-Host { throw 'Read-Host should not be called' }
+            & "$tempDir/runner.ps1" -RunScripts '0001' -AutoAccept | Out-Null
+            Pop-Location
+        } finally {
+            Remove-Item -Recurse -Force $tempDir
+        }
+    }
+
+    It 'prompts for script selection when no -RunScripts argument is supplied' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $tempDir
+        try {
+            Copy-Item $runnerPath -Destination $tempDir
+            $scriptsDir = Join-Path $tempDir 'runner_scripts'
+            $null = New-Item -ItemType Directory -Path $scriptsDir
+            $dummy = Join-Path $scriptsDir '0001_Test.ps1'
+            'Param([PSCustomObject]$Config)' | Set-Content -Path $dummy
+
+            $responses = @('0001')
+            $index = 0
+            Mock Read-Host { $responses[$index++] }
+            Push-Location $tempDir
+            & "$tempDir/runner.ps1" -AutoAccept | Out-Null
+            Pop-Location
+            Assert-MockCalled Read-Host -Times 1 -Exactly
+        } finally {
+            Remove-Item -Recurse -Force $tempDir
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `Get-LabConfig` helper to load configuration files
- cover `Get-LabConfig` with new tests
- extend `Runner.Tests.ps1` for non-interactive `-RunScripts` execution and
  interactive selection using mocked `Read-Host`

## Testing
- `Invoke-Pester -Path tests` *(fails: `Invoke-Pester: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846476e6ca083318c78c1a8e999f3f0