### PR TITLE
Fix Git verification

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -144,7 +144,8 @@ if (Test-Path $gitPath) {
 
 # Double-check Git
 try {
-    & "$gitPath" --version | Write-Log
+    $gitVersion = & "$gitPath" --version
+    Write-Log $gitVersion
     Write-Log "Git is installed and working."
 } catch {
     Write-Error "ERROR: Git installation failed or is not accessible. Exiting."


### PR DESCRIPTION
## Summary
- avoid piping to `Write-Log` when checking Git version

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684647f187d483318c85a1d9f8b967cd