### PR TITLE
Fix bootstrap dependency

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -47,6 +47,13 @@ if (-not (Test-Path $loggerPath)) {
 # Load config helper
 $labUtilsDir = Join-Path $PSScriptRoot 'lab_utils'
 $labConfigScript = Join-Path $labUtilsDir 'Get-LabConfig.ps1'
+if (-not (Test-Path $labConfigScript)) {
+    if (-not (Test-Path $labUtilsDir)) {
+        New-Item -ItemType Directory -Path $labUtilsDir -Force | Out-Null
+    }
+    $labConfigUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/lab_utils/Get-LabConfig.ps1'
+    Invoke-WebRequest -Uri $labConfigUrl -OutFile $labConfigScript
+}
 . $labConfigScript
 
 


### PR DESCRIPTION
## Summary
- auto-download `Get-LabConfig.ps1` in `kicker-bootstrap.ps1`

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846494178948331b304de9d7cfcf670