### PR TITLE
Fix git pull branch selection in bootstrap

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -291,7 +291,7 @@ if (!(Test-Path $repoPath)) {
 } else {
     Write-Log "Repository already exists. Pulling latest changes..."
     Push-Location $repoPath
-    & "$gitPath" pull
+    & "$gitPath" pull origin $targetBranch
     Pop-Location
 }
 


### PR DESCRIPTION
## Summary
- pull target branch explicitly when repository already exists

## Testing
- `Invoke-Pester -CI tests` *(fails: CommandNotFoundException in Runner.Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68464da501608331b20d2cd8dd4df108