### PR TITLE
Switch ISO bootstrap to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -U
 
 ```
 
+The repo expects the latest stable code on the `main` branch. When running
+`iso_tools/bootstrap.ps1`, you can override the branch with the `-Branch`
+parameter if needed.
+
 It will prompt print the current config and prompt you to customize it interactively. 
 
 Example opentofu-infra repo: https://github.com/wizzense/tofu-base-lab.git

--- a/iso_tools/bootstrap.ps1
+++ b/iso_tools/bootstrap.ps1
@@ -1,6 +1,11 @@
+param(
+    [string]$Branch = 'main'
+)
+
 Set-ExecutionPolicy -ExecutionPolicy Bypass
 
-Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/dev/kicker-bootstrap.ps1' -OutFile '.\kicker-bootstrap.ps1'
+$bootstrapUrl = "https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/$Branch/kicker-bootstrap.ps1"
+Invoke-WebRequest -Uri $bootstrapUrl -OutFile '.\kicker-bootstrap.ps1'
 
 if (Test-Path '.\kicker-bootstrap.ps1') {
   Write-Host "Downloaded kicker-bootstrap.ps1 to $(Resolve-Path '.\kicker-bootstrap.ps1')"


### PR DESCRIPTION
## Summary
- parametrize ISO bootstrap script with a `-Branch` option and default to `main`
- clarify in README that `main` is the expected branch and how to override

## Testing
- `pwsh -NoProfile -Command Invoke-Pester -CI` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464f1623448331a087fad1caa5555f