### PR TITLE
Add logging for PXE firewall rules

### DIFF
--- a/runner_scripts/0112_Enable-PXE.ps1
+++ b/runner_scripts/0112_Enable-PXE.ps1
@@ -6,9 +6,15 @@ Param(
 
 if ($Config.ConfigPXE -eq $true) {
 
+    Write-Log "Adding inbound firewall rule 'prov-pxe-67' (UDP 67)"
     New-NetFirewallRule -DisplayName prov-pxe-67 -Enabled True -Direction inbound -Protocol udp -LocalPort 67 -Action Allow -RemoteAddress any
+    Write-Log "Adding inbound firewall rule 'prov-pxe-69' (UDP 69)"
     New-NetFirewallRule -DisplayName prov-pxe-69 -Enabled True -Direction inbound -Protocol udp -LocalPort 69 -Action Allow -RemoteAddress any
+    Write-Log "Adding inbound firewall rule 'prov-pxe-17519' (TCP 17519)"
     New-NetFirewallRule -DisplayName prov-pxe-17519 -Enabled True -Direction inbound -Protocol tcp -LocalPort 17519 -Action Allow -RemoteAddress any
+    Write-Log "Adding inbound firewall rule 'prov-pxe-17530' (TCP 17530)"
     New-NetFirewallRule -DisplayName prov-pxe-17530 -Enabled True -Direction inbound -Protocol tcp -LocalPort 17530 -Action Allow -RemoteAddress any
 
+} else {
+    Write-Log 'ConfigPXE is false. Skipping PXE firewall configuration.'
 }

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -1,0 +1,25 @@
+Describe '0112_Enable-PXE' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0112_Enable-PXE.ps1'
+        $loggerPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\Logger.ps1'
+        . $loggerPath
+    }
+
+    It 'logs firewall rules when ConfigPXE is true' {
+        $Config = [pscustomobject]@{ ConfigPXE = $true }
+        $logPath = Join-Path $env:TEMP ('pxe-log-' + [System.Guid]::NewGuid().ToString() + '.txt')
+        $Global:LogFilePath = $logPath
+        try {
+            & $scriptPath -Config $Config | Out-Null
+            $log = Get-Content -Raw $logPath
+            $log | Should -Match 'prov-pxe-67'
+            $log | Should -Match 'prov-pxe-69'
+            $log | Should -Match 'prov-pxe-17519'
+            $log | Should -Match 'prov-pxe-17530'
+        } finally {
+            Remove-Item $logPath -ErrorAction SilentlyContinue
+            Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add logging for PXE rule creation and skip message when disabled
- test that log entries are written when ConfigPXE is true

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464f261ad48331b04e6e770846d920