### PR TITLE
Fix config variable names and add Pester tests

### DIFF
--- a/runner_scripts/0113_Config-DNS.ps1
+++ b/runner_scripts/0113_Config-DNS.ps1
@@ -7,6 +7,6 @@ Param(
 if ($Config.SetDNSServers -eq $true) {
     
     $interfaceIndex = (Get-NetIPAddress -AddressFamily IPv4 | Select-Object -First 1 -ExpandProperty InterfaceIndex)
-    Set-DnsClientServerAddress -InterfaceIndex $interfaceIndex -ServerAddresses $config.$DNSServers
+    Set-DnsClientServerAddress -InterfaceIndex $interfaceIndex -ServerAddresses $Config.DNSServers
        
 }

--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -6,7 +6,7 @@ Param(
 
 if ($Config.SetTrustedHosts -eq $true) {
     
-    start-process cmd.exe -ArgumentList "/d /c winrm set winrm/config/client @{TrustedHosts=`"$Config.$TrustedHosts`"}"
+    start-process cmd.exe -ArgumentList "/d /c winrm set winrm/config/client @{TrustedHosts=`"$Config.TrustedHosts`"}"
        
 }
 

--- a/tests/Config-DNS.Tests.ps1
+++ b/tests/Config-DNS.Tests.ps1
@@ -1,0 +1,19 @@
+Describe '0113_Config-DNS' {
+    It 'calls Set-DnsClientServerAddress with value from config' {
+        $script = Join-Path $PSScriptRoot '..\runner_scripts\0113_Config-DNS.ps1'
+        $config = [pscustomobject]@{
+            SetDNSServers = $true
+            DNSServers    = '1.2.3.4'
+        }
+
+        Mock Get-NetIPAddress { [pscustomobject]@{ InterfaceIndex = 99 } }
+        Mock Set-DnsClientServerAddress {}
+
+        & $script -Config $config
+
+        Assert-MockCalled Set-DnsClientServerAddress -ParameterFilter {
+            $InterfaceIndex -eq 99 -and $ServerAddresses -eq '1.2.3.4'
+        } -Times 1
+    }
+}
+

--- a/tests/Config-TrustedHosts.Tests.ps1
+++ b/tests/Config-TrustedHosts.Tests.ps1
@@ -1,0 +1,18 @@
+Describe '0114_Config-TrustedHosts' {
+    It 'calls Start-Process with winrm arguments using config value' {
+        $script = Join-Path $PSScriptRoot '..\runner_scripts\0114_Config-TrustedHosts.ps1'
+        $config = [pscustomobject]@{
+            SetTrustedHosts = $true
+            TrustedHosts    = 'host1'
+        }
+
+        Mock Start-Process {}
+
+        & $script -Config $config
+
+        Assert-MockCalled Start-Process -ParameterFilter {
+            $FilePath -eq 'cmd.exe' -and $ArgumentList -match 'TrustedHosts=\"host1\"'
+        } -Times 1
+    }
+}
+


### PR DESCRIPTION
## Summary
- fix property names in Config-DNS and Config-TrustedHosts scripts
- add tests for these scripts

## Testing
- `pwsh -NoLogo -Command Invoke-Pester -CI` *(fails: command not found)*
- `powershell -Command Invoke-Pester -CI` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464f091b148331b8f308aba6a8534b