### PR TITLE
Use NpmPath from config

### DIFF
--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -9,7 +9,7 @@
 
 .CONFIG FORMAT
 {
-  "Dependencies": {
+  "Node_Dependencies": {
     "InstallNpm": true,
     "NpmPath": "C:\\Projects\\vde-mvp\\frontend"
   }
@@ -31,27 +31,27 @@ param(
 $ErrorActionPreference = "Stop"
 Write-Log "==== [0203] Installing Frontend npm Dependencies ===="
 
-# Determine frontend path
-$frontendPath = if ($Config.Dependencies.FrontendPath) {
-    $Config.Dependencies.FrontendPath
+# Determine npm project path
+$npmPath = if ($Config.Node_Dependencies.NpmPath) {
+    $Config.Node_Dependencies.NpmPath
 } else {
     Join-Path $PSScriptRoot "..\frontend"
 }
 
-if (-not (Test-Path $frontendPath)) {
-    Write-Error "ERROR: Frontend folder not found at: $frontendPath"
+if (-not (Test-Path $npmPath)) {
+    Write-Error "ERROR: Frontend folder not found at: $npmPath"
     exit 1
 }
 
-if (-not (Test-Path (Join-Path $frontendPath "package.json"))) {
+if (-not (Test-Path (Join-Path $npmPath "package.json"))) {
     Write-Error "ERROR: No package.json found in frontend folder. Cannot run npm install."
     exit 1
 }
 
-Push-Location $frontendPath
+Push-Location $npmPath
 
 try {
-    Write-Log "Running npm install in $frontendPath ..."
+    Write-Log "Running npm install in $npmPath ..."
     npm install
     Write-Log "✅ npm install completed."
 } catch {

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -1,0 +1,26 @@
+Describe '0203_Install-npm' {
+    It 'runs npm install in configured NpmPath' {
+        $script = Join-Path $PSScriptRoot '..\runner_scripts\0203_Install-npm.ps1'
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $tempDir
+        try {
+            Copy-Item $script -Destination $tempDir
+            $npmDir = Join-Path $tempDir 'frontend'
+            $null = New-Item -ItemType Directory -Path $npmDir
+            '{}' | Set-Content -Path (Join-Path $npmDir 'package.json')
+            $config = @{ Node_Dependencies = @{ NpmPath = $npmDir } }
+
+            $calledPath = $null
+            Mock npm { $calledPath = (Get-Location).ProviderPath }
+
+            Push-Location $tempDir
+            & "$tempDir/0203_Install-npm.ps1" -Config $config
+            Pop-Location
+
+            Assert-MockCalled npm -Times 1 -Exactly
+            $calledPath | Should -Be (Get-Item $npmDir).FullName
+        } finally {
+            Remove-Item -Recurse -Force $tempDir
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use `$Config.Node_Dependencies.NpmPath` instead of `$Config.Dependencies.FrontendPath`
- add Pester test verifying npm install runs inside configured directory

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464f2803208331ac3d8119ae172d5a