### PR TITLE
Ensure provider build restores working directory

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -221,6 +221,9 @@ $taliesinsDir = Join-Path -Path $env:GOPATH -ChildPath "src\\github.com\\taliesi
 if (!(Test-Path $taliesinsDir)) {
     New-Item -ItemType Directory -Force -Path $taliesinsDir | Out-Null
 }
+# Capture current location so we can restore it later
+$originalLocation = Get-Location
+Push-Location
 Set-Location $taliesinsDir
 
 # Define the provider directory/exe
@@ -248,6 +251,9 @@ $destinationBinary = Join-Path $hypervProviderDir "terraform-provider-hyperv.exe
 Copy-Item -Path $providerExePath -Destination $destinationBinary -Force -Verbose
 
 Write-Log "Hyper-V provider installed at: $destinationBinary"
+
+# Restore the original directory
+Pop-Location
 
 # ------------------------------
 # 5) Update Provider Config File (providers.tf)

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -1,0 +1,38 @@
+Describe 'Prepare-HyperVProvider path restoration' {
+    It 'restores location after execution' {
+        $scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0010_Prepare-HyperVProvider.ps1'
+        $config = [pscustomobject]@{
+            PrepareHyperVHost = $true
+            InfraRepoPath = 'C:\\Infra'
+            CertificateAuthority = @{ CommonName = 'TestCA' }
+            HostName = 'hvhost'
+        }
+
+        $location = 'C:\\Start'
+        $stack = @()
+
+        Mock Get-Location { $location }
+        Mock Push-Location { $stack += $location }
+        Mock Set-Location { param($Path) $location = $Path }
+        Mock Pop-Location { $location = $stack[-1]; $stack = $stack[0..($stack.Count-2)] }
+
+        Mock Write-Log {}
+        Mock Get-WindowsOptionalFeature { @{State='Enabled'} }
+        Mock Enable-WindowsOptionalFeature {}
+        Mock Test-WSMan {}
+        Mock Enable-PSRemoting {}
+        Mock Get-WSManInstance { @{MaxMemoryPerShellMB=1024; MaxTimeoutms=1800000; TrustedHosts='*'; Negotiate=$true} }
+        Mock Set-WSManInstance {}
+        Mock New-Item {}
+        Mock Test-Path { $false }
+        Mock git {}
+        Mock go {}
+        Mock Copy-Item {}
+        Mock Read-Host { '' }
+        Mock Resolve-Path { param([string]$Path) @{ Path = $Path } }
+
+        & $scriptPath -Config $config
+
+        $location | Should -Be 'C:\\Start'
+    }
+}


### PR DESCRIPTION
## Summary
- capture original directory in `Prepare-HyperVProvider`
- restore it after provider build
- add Pester test to verify path restoration

## Testing
- `Invoke-Pester tests -Output Detailed` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_68464f22683c8331a325275d8bd1a4ba