### PR TITLE
Switch Node scripts to Node_Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,29 @@ And:
 
 Will probably change repo name to just 'lab-automation'.
 
+## Node dependency configuration
+
+Node-related installs are controlled under the `Node_Dependencies` section of
+`default-config.json`:
+
+```json
+"Node_Dependencies": {
+  "InstallNode": true,
+  "InstallYarn": true,
+  "InstallVite": true,
+  "InstallNodemon": true,
+  "InstallNpm": true,
+  "NpmPath": "C:\\Projects\\vde-mvp\\frontend",
+  "Node": {
+    "InstallerUrl": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
+  }
+}
+```
+
+The scripts `0201_Install-NodeCore.ps1`, `0202_Install-NodeGlobalPackages.ps1`
+and `0203_Install-npm.ps1` read these keys when installing Node, global npm
+packages, or project dependencies.
+
 ## Utility scripts
 
 `lab_utils/Get-Platform.ps1` detects the current platform.

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
     Downloads Node.js installer and installs silently.
-    Uses config.Dependencies.Node.InstallerUrl if specified.
+    Uses config.Node_Dependencies.Node.InstallerUrl if specified.
 
 .PARAMETER Config
     Hashed config object passed from runner.ps1
@@ -23,8 +23,8 @@ $ErrorActionPreference = "Stop"
 
 Write-Log "==== [0201] Installing Node.js Core ===="
 
-$url = if ($Config.Dependencies.Node.InstallerUrl) {
-    $Config.Dependencies.Node.InstallerUrl
+$url = if ($Config.Node_Dependencies.Node.InstallerUrl) {
+    $Config.Node_Dependencies.Node.InstallerUrl
 } else {
     "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
 }

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -4,12 +4,12 @@
 
 .DESCRIPTION
     - Assumes Node.js is already installed
-    - Installs any npm packages flagged as true in the Dependencies section
+    - Installs any npm packages flagged as true in the Node_Dependencies section
     - Must be used in combination with 0201-InstallNodeCore.ps1
 
 .CONFIG FORMAT
 {
-  "Dependencies": {
+  "Node_Dependencies": {
     "InstallYarn": true,
     "InstallVite": true,
     "InstallNodemon": true
@@ -43,15 +43,15 @@ function Install-GlobalPackage($package) {
 Write-Log "==== [0202] Installing Global npm Packages ===="
 
 # --- npm Packages ---
-if ($Config.Dependencies.InstallYarn) {
+if ($Config.Node_Dependencies.InstallYarn) {
     Install-GlobalPackage "yarn"
 }
 
-if ($Config.Dependencies.InstallVite) {
+if ($Config.Node_Dependencies.InstallVite) {
     Install-GlobalPackage "vite"
 }
 
-if ($Config.Dependencies.InstallNodemon) {
+if ($Config.Node_Dependencies.InstallNodemon) {
     Install-GlobalPackage "nodemon"
 }
 

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -9,7 +9,7 @@
 
 .CONFIG FORMAT
 {
-  "Dependencies": {
+  "Node_Dependencies": {
     "InstallNpm": true,
     "NpmPath": "C:\\Projects\\vde-mvp\\frontend"
   }
@@ -32,8 +32,8 @@ $ErrorActionPreference = "Stop"
 Write-Log "==== [0203] Installing Frontend npm Dependencies ===="
 
 # Determine frontend path
-$frontendPath = if ($Config.Dependencies.FrontendPath) {
-    $Config.Dependencies.FrontendPath
+$frontendPath = if ($Config.Node_Dependencies.NpmPath) {
+    $Config.Node_Dependencies.NpmPath
 } else {
     Join-Path $PSScriptRoot "..\frontend"
 }

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -1,0 +1,46 @@
+Describe 'Node installation scripts' {
+    $scriptRoot = Join-Path $PSScriptRoot '..' 'runner_scripts'
+    $core = Join-Path $scriptRoot '0201_Install-NodeCore.ps1'
+    $global = Join-Path $scriptRoot '0202_Install-NodeGlobalPackages.ps1'
+    $npm = Join-Path $scriptRoot '0203_Install-npm.ps1'
+
+    BeforeAll {
+        $env:TEMP = Join-Path ([System.IO.Path]::GetTempPath()) 'pester-temp'
+        New-Item -ItemType Directory -Path $env:TEMP -Force | Out-Null
+    }
+
+    It 'uses Node_Dependencies.Node.InstallerUrl when installing Node' {
+        $config = @{ Node_Dependencies = @{ Node = @{ InstallerUrl = 'http://example.com/node.msi' } } }
+        Mock Invoke-WebRequest {}
+        Mock Start-Process {}
+        Mock Remove-Item {}
+        Mock Get-Command { @{Name='node'} } -ParameterFilter { $Name -eq 'node' }
+        & (Resolve-Path $core) -Config $config
+        Assert-MockCalled Invoke-WebRequest -ParameterFilter { $Uri -eq 'http://example.com/node.msi' } -Times 1
+    }
+
+    It 'installs packages based on Node_Dependencies flags' {
+        $config = @{ Node_Dependencies = @{ InstallYarn=$true; InstallVite=$false; InstallNodemon=$true } }
+        Mock Get-Command { @{Name='npm'} } -ParameterFilter { $Name -eq 'npm' }
+        Mock npm {}
+        & (Resolve-Path $global) -Config $config
+        Assert-MockCalled npm -ParameterFilter { $Args -eq @('install','-g','yarn') } -Times 1
+        Assert-MockCalled npm -ParameterFilter { $Args -eq @('install','-g','nodemon') } -Times 1
+        Assert-MockNotCalled npm -ParameterFilter { $Args -eq @('install','-g','vite') }
+    }
+
+    It 'uses NpmPath from Node_Dependencies when installing project deps' {
+        $temp = Join-Path $env:TEMP ([System.Guid]::NewGuid())
+        New-Item -ItemType Directory -Path $temp | Out-Null
+        New-Item -ItemType File -Path (Join-Path $temp 'package.json') | Out-Null
+        $config = @{ Node_Dependencies = @{ NpmPath = $temp } }
+        Mock npm {}
+        & (Resolve-Path $npm) -Config $config
+        Assert-MockCalled npm -ParameterFilter { $Args[0] -eq 'install' } -Times 1
+        Remove-Item -Recurse -Force $temp
+    }
+
+    AfterAll {
+        Remove-Item -Recurse -Force $env:TEMP -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary
- pull Node configuration from `Node_Dependencies` in the Node scripts
- update global package installer script
- adjust npm install script
- document Node config in README
- add Pester tests covering Node scripts

## Testing
- `Invoke-Pester -CI` *(fails: The expression after '&' in a pipeline element produced an object that was not valid...)*

------
https://chatgpt.com/codex/tasks/task_e_68464f0686b08331ad79ace59d2ab9cc