### PR TITLE
Fix npm path variable

### DIFF
--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -39,20 +39,20 @@ $frontendPath = if ($Config.Node_Dependencies.NpmPath) {
     Join-Path $PSScriptRoot "..\frontend"
 }
 
-if (-not (Test-Path $npmPath)) {
-    Write-Error "ERROR: Frontend folder not found at: $npmPath"
+if (-not (Test-Path $frontendPath)) {
+    Write-Error "ERROR: Frontend folder not found at: $frontendPath"
     exit 1
 }
 
-if (-not (Test-Path (Join-Path $npmPath "package.json"))) {
+if (-not (Test-Path (Join-Path $frontendPath "package.json"))) {
     Write-Error "ERROR: No package.json found in frontend folder. Cannot run npm install."
     exit 1
 }
 
-Push-Location $npmPath
+Push-Location $frontendPath
 
 try {
-    Write-Log "Running npm install in $npmPath ..."
+    Write-Log "Running npm install in $frontendPath ..."
     npm install
     Write-Log "✅ npm install completed."
 } catch {

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -1,26 +1,35 @@
 Describe '0203_Install-npm' {
     It 'runs npm install in configured NpmPath' {
         $script = Join-Path $PSScriptRoot '..\runner_scripts\0203_Install-npm.ps1'
-        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
-        $null = New-Item -ItemType Directory -Path $tempDir
-        try {
-            Copy-Item $script -Destination $tempDir
-            $npmDir = Join-Path $tempDir 'frontend'
-            $null = New-Item -ItemType Directory -Path $npmDir
-            '{}' | Set-Content -Path (Join-Path $npmDir 'package.json')
-            $config = @{ Node_Dependencies = @{ NpmPath = $npmDir } }
+        $npmDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $npmDir
+        '{}' | Set-Content -Path (Join-Path $npmDir 'package.json')
+        $config = @{ Node_Dependencies = @{ NpmPath = $npmDir } }
 
-            $calledPath = $null
-            Mock npm { $calledPath = (Get-Location).ProviderPath }
+        $global:calledPath = $null
+        function npm { param([string[]]$Args) $global:calledPath = (Get-Location).ProviderPath }
 
-            Push-Location $tempDir
-            & "$tempDir/0203_Install-npm.ps1" -Config $config
-            Pop-Location
+        & $script -Config $config
 
-            Assert-MockCalled npm -Times 1 -Exactly
-            $calledPath | Should -Be (Get-Item $npmDir).FullName
-        } finally {
-            Remove-Item -Recurse -Force $tempDir
-        }
+        $calledPath | Should -Be (Get-Item $npmDir).FullName
+
+        Remove-Item -Recurse -Force $npmDir
+    }
+
+    It 'succeeds when NpmPath exists' {
+        $script = Join-Path $PSScriptRoot '..\runner_scripts\0203_Install-npm.ps1'
+        $npmDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $npmDir
+        '{}' | Set-Content -Path (Join-Path $npmDir 'package.json')
+        $config = @{ Node_Dependencies = @{ NpmPath = $npmDir } }
+
+        function npm { param([string[]]$Args) }
+
+        & $script -Config $config
+        $success = $?
+
+        $success | Should -BeTrue
+
+        Remove-Item -Recurse -Force $npmDir
     }
 }


### PR DESCRIPTION
## Summary
- reference the user-configured NpmPath via `$frontendPath`
- add a Pester test covering successful run when path exists

## Testing
- `pwsh -NoProfile -File run_pester.ps1` *(fails: 8 passed, 9 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6847163469b48331b7918fecc9fc89a1