### PR TITLE
Add gh clone detection and tests

### DIFF
--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -17,7 +17,16 @@ if (-not (Test-Path $InfraPath)) {
 # Check if the directory is a git repository
 if (-not (Test-Path (Join-Path $InfraPath ".git"))) {
     Write-Log "Directory is not a git repository. Cloning repository..."
-    git clone $config.InfraRepoUrl $InfraPath
+    $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
+    if ($ghCmd) {
+        gh repo clone $config.InfraRepoUrl $InfraPath
+    } else {
+        git clone $config.InfraRepoUrl $InfraPath
+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to clone $($config.InfraRepoUrl)"
+        exit 1
+    }
 } else {
     Write-Log "Git repository found. Updating repository..."
     Push-Location $InfraPath

--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -65,7 +65,13 @@ if (-not [string]::IsNullOrWhiteSpace($infraRepoUrl)) {
         # Remove-Item -Path (Join-Path $infraRepoPath "*") -Recurse -Force -ErrorAction SilentlyContinue
 
         Write-Log "Cloning $infraRepoUrl to $infraRepoPath..."
-        git clone $infraRepoUrl $infraRepoPath
+        $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
+        if ($ghCmd) {
+            gh repo clone $infraRepoUrl $infraRepoPath
+        }
+        else {
+            git clone $infraRepoUrl $infraRepoPath
+        }
         if ($LASTEXITCODE -ne 0) {
             Write-Error "ERROR: Failed to clone $infraRepoUrl"
             exit 1

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -1,0 +1,29 @@
+Describe '0001_Reset-Git cloning logic' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0001_Reset-Git.ps1'
+    }
+
+    It 'uses gh repo clone when gh CLI is available' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $config = [pscustomobject]@{ InfraRepoUrl='https://example.com/repo.git'; InfraRepoPath=$tempDir }
+        Mock Get-Command { @{Name='gh'} } -ParameterFilter { $Name -eq 'gh' }
+        Mock gh { $global:LASTEXITCODE = 0 }
+        Mock git {}
+        & $scriptPath -Config $config
+        Assert-MockCalled gh -ParameterFilter { $Args[0] -eq 'repo' -and $Args[1] -eq 'clone' } -Times 1
+        Assert-MockNotCalled git
+        Remove-Item -Recurse -Force $tempDir
+    }
+
+    It 'falls back to git clone when gh CLI is missing' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $config = [pscustomobject]@{ InfraRepoUrl='https://example.com/repo.git'; InfraRepoPath=$tempDir }
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'gh' }
+        Mock git { $global:LASTEXITCODE = 0 }
+        Mock gh {}
+        & $scriptPath -Config $config
+        Assert-MockCalled git -ParameterFilter { $Args[0] -eq 'clone' } -Times 1
+        Assert-MockNotCalled gh
+        Remove-Item -Recurse -Force $tempDir
+    }
+}


### PR DESCRIPTION
## Summary
- use `gh repo clone` when available in reset-git
- use `gh repo clone` when available in initialize-opentofu
- cover clone logic with Pester tests

## Testing
- `pwsh -Command 'Invoke-Pester tests/Reset-Git.Tests.ps1 -CI'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471eb1382c833196d38a8978896930