### PR TITLE
Improve OpenTofu installer error handling

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -225,7 +225,11 @@ function logError() {
     try
     {
         [Console]::Error.WriteLine("${red}${message}${normal}")
-    } catch {}
+    } catch {
+        $msg = $_.ToString()
+        Write-Error $msg
+        throw
+    }
 }
 
 function tempdir() {
@@ -304,7 +308,11 @@ function installStandalone() {
             if(Get-Command $cosignPath){
                 $cosignAvailable = $true
             }
-        } catch {}
+        } catch {
+            $msg = $_.ToString()
+            logError $msg
+            throw
+        }
         $ErrorActionPreference = 'continue'
 
         $gpgAvailable = $false
@@ -313,7 +321,11 @@ function installStandalone() {
             if(Get-Command $gpgPath){
                 $gpgAvailable = $true
             }
-        } catch {}
+        } catch {
+            $msg = $_.ToString()
+            logError $msg
+            throw
+        }
         $ErrorActionPreference = 'continue'
 
         if ($cosignAvailable) {
@@ -558,7 +570,11 @@ function installStandalone() {
             try
             {
                 Remove-Item -force -recurse $target
-            } catch {}
+            } catch {
+                $msg = $_.ToString()
+                logError $msg
+                throw
+            }
         }
     }
 }

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,0 +1,15 @@
+Describe 'OpenTofuInstaller error handling' {
+    It 'returns install failed exit code when cosign is missing' {
+        $scriptPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\OpenTofuInstaller.ps1'
+        $arguments = @(
+            '-NoLogo',
+            '-NoProfile',
+            '-File', $scriptPath,
+            '-installMethod', 'standalone',
+            '-cosignPath', 'nonexistent.exe',
+            '-gpgPath', 'nonexistent.exe'
+        )
+        $proc = Start-Process pwsh -ArgumentList $arguments -Wait -PassThru
+        $proc.ExitCode | Should -Be 2
+    }
+}


### PR DESCRIPTION
## Summary
- log and rethrow on errors in `OpenTofuInstaller.ps1`
- test installer exit code on missing cosign

## Testing
- `pwsh -NoProfile -Command Invoke-Pester -Path tests/OpenTofuInstaller.Tests.ps1`
- `pwsh -NoProfile -Command Invoke-Pester -Path tests` *(fails: Could not find Command Get-NetIPAddress, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68471f2ffe2c8331b9c4dd738cd630d9