### PR TITLE
Ensure test scope visibility for RunnerScripts

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -1,9 +1,7 @@
-Describe 'Runner scripts parameter and command checks' {
-    BeforeAll {
-        $scriptDir = Join-Path $PSScriptRoot '..' 'runner_scripts'
-        $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
-    }
+$scriptDir = Join-Path $PSScriptRoot '..' 'runner_scripts'
+$scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 
+Describe 'Runner scripts parameter and command checks' {
     foreach ($script in $scripts) {
         Context $script.Name {
             It 'declares a Config parameter' {


### PR DESCRIPTION
## Summary
- scope script discovery outside of `BeforeAll` so it works across blocks

## Testing
- `Invoke-Pester -CI` *(fails: Cleanup-Files can't find `$Global:LogFilePath` et al.)*

------
https://chatgpt.com/codex/tasks/task_e_68471f9837d8833181b15e1055830c23