### PR TITLE
Fix leftover Write-Log call

### DIFF
--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -34,10 +34,8 @@ if (-not (Test-Path (Join-Path $InfraPath '.git'))) {
         throw
     }
 
-    Write-Log "Clone completed successfully."
+    Write-CustomLog "Clone completed successfully."
 }
-        exit 1
-    }
 
 } else {
     Write-CustomLog "Git repository found. Updating repository..."

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -83,4 +83,25 @@ Describe '0001_Reset-Git' {
             }
         }
     }
+
+    Context 'Logging' {
+        It 'logs a success message when clone succeeds' {
+            $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid())
+
+            $config = [pscustomobject]@{
+                InfraRepoUrl  = 'https://example.com/repo.git'
+                InfraRepoPath = $tempDir
+            }
+
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'gh' }
+            Mock git { $global:LASTEXITCODE = 0 }
+            Mock Write-CustomLog {}
+
+            & $ScriptPath -Config $config
+
+            Assert-MockCalled Write-CustomLog -ParameterFilter { $Message -eq 'Clone completed successfully.' } -Times 1
+
+            Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- replace stray `Write-Log` with `Write-CustomLog`
- add test verifying clone success logging

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: Expected a value, but got $null or empty.)*

------
https://chatgpt.com/codex/tasks/task_e_68472b0cbc2c83318203c4176bf1c9bf