### PR TITLE
CI: run tests on Windows, Ubuntu, and macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,53 @@ on:
 
 jobs:
   lint:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install PowerShell
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          if ! command -v pwsh >/dev/null 2>&1; then
+            if [[ "$RUNNER_OS" == "Linux" ]]; then
+              sudo apt-get update
+              sudo apt-get install -y powershell
+            elif [[ "$RUNNER_OS" == "macOS" ]]; then
+              brew install --cask powershell
+            fi
+          fi
       - uses: ./.github/actions/lint
   tests:
     needs: lint
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
   pester:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
     needs: lint
     steps:
       - uses: actions/checkout@v4
+      - name: Install PowerShell
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          if ! command -v pwsh >/dev/null 2>&1; then
+            if [[ "$RUNNER_OS" == "Linux" ]]; then
+              sudo apt-get update
+              sudo apt-get install -y powershell
+            elif [[ "$RUNNER_OS" == "macOS" ]]; then
+              brew install --cask powershell
+            fi
+          fi
 
       - name: Install Pester
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,12 @@ jobs:
         run: |
           if ! command -v pwsh >/dev/null 2>&1; then
             if [[ "$RUNNER_OS" == "Linux" ]]; then
-              sudo apt-get update
-              sudo apt-get install -y powershell
+              sudo snap install powershell --classic
             elif [[ "$RUNNER_OS" == "macOS" ]]; then
               brew install --cask powershell
             fi
           fi
       - uses: ./.github/actions/lint
-  tests:
-    needs: lint
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
   pester:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -48,8 +39,7 @@ jobs:
         run: |
           if ! command -v pwsh >/dev/null 2>&1; then
             if [[ "$RUNNER_OS" == "Linux" ]]; then
-              sudo apt-get update
-              sudo apt-get install -y powershell
+              sudo snap install powershell --classic
             elif [[ "$RUNNER_OS" == "macOS" ]]; then
               brew install --cask powershell
             fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 This project uses [Pester](https://github.com/pester/Pester) for PowerShell testing.
 
+## Continuous Integration
+
+The GitHub Actions workflow runs linting and Pester tests on Windows, Ubuntu and
+macOS runners. Linux and macOS jobs install PowerShell before executing the lint
+action and tests.
+
 ## Running tests
 
 1. Install PowerShell and the Pester module if they are not already available.
@@ -11,4 +17,6 @@ This project uses [Pester](https://github.com/pester/Pester) for PowerShell test
 Invoke-Pester -Path tests
 ```
 
-This runs the test suite found under the `tests/` directory.
+This runs the test suite found under the `tests/` directory. When adding
+Windows‑specific tests, guard them with `-Skip:($IsLinux -or $IsMacOS)` so the
+suite succeeds across all platforms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,9 @@ This project uses [Pester](https://github.com/pester/Pester) for PowerShell test
 ## Continuous Integration
 
 The GitHub Actions workflow runs linting and Pester tests on Windows, Ubuntu and
-macOS runners. Linux and macOS jobs install PowerShell before executing the lint
-action and tests.
+macOS runners. Linux and macOS runners generally include `pwsh` already; the
+workflow installs PowerShell only if the command is missing so the steps run
+consistently across images.
 
 ## Running tests
 

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -118,7 +118,7 @@ try {
     $config = Get-LabConfig -Path $ConfigFile
     Write-CustomLog "Config file loaded from $ConfigFile."
 } catch {
-    Write-Error "ERROR: $($_.Exception.Message)"
+    Write-Error "ERROR: Failed to load configuration file - $($_.Exception.Message)"
     exit 1
 }
 

--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -582,7 +582,11 @@ function installStandalone() {
             }
         }
         if ($logDir) {
-            try { Remove-Item -Force -Recurse $logDir } catch {}
+            try { Remove-Item -Force -Recurse $logDir }
+            catch {
+                $msg = $_.ToString()
+                Write-Warning "Could not remove log directory ${logDir}: ${msg}"
+            }
         }
     }
 }

--- a/tests/Config-DNS.Tests.ps1
+++ b/tests/Config-DNS.Tests.ps1
@@ -1,5 +1,5 @@
 Describe '0113_Config-DNS' {
-    It 'calls Set-DnsClientServerAddress with value from config' -Skip:$IsLinux {
+    It 'calls Set-DnsClientServerAddress with value from config' -Skip:($IsLinux -or $IsMacOS) {
         $script = Join-Path $PSScriptRoot '..\runner_scripts\0113_Config-DNS.ps1'
         $config = [pscustomobject]@{
             SetDNSServers = $true

--- a/tests/Config-TrustedHosts.Tests.ps1
+++ b/tests/Config-TrustedHosts.Tests.ps1
@@ -1,5 +1,5 @@
 Describe '0114_Config-TrustedHosts' {
-    It 'calls Start-Process with winrm arguments using config value' -Skip:$IsLinux {
+    It 'calls Start-Process with winrm arguments using config value' -Skip:($IsLinux -or $IsMacOS) {
         $script = Join-Path $PSScriptRoot '..\runner_scripts\0114_Config-TrustedHosts.ps1'
         $config = [pscustomobject]@{
             SetTrustedHosts = $true

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -5,7 +5,7 @@ Describe '0112_Enable-PXE' {
         . $loggerPath
     }
 
-    It 'logs firewall rules when ConfigPXE is true' -Skip:$IsLinux {
+    It 'logs firewall rules when ConfigPXE is true' -Skip:($IsLinux -or $IsMacOS) {
         $Config = [pscustomobject]@{ ConfigPXE = $true }
         $logPath = Join-Path $env:TEMP ('pxe-log-' + [System.Guid]::NewGuid().ToString() + '.txt')
         $Global:LogFilePath = $logPath

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,5 +1,5 @@
 Describe 'OpenTofuInstaller logging' {
-    It 'creates log files and removes them for elevated unpack' -Skip:$IsLinux {
+    It 'creates log files and removes them for elevated unpack' -Skip:($IsLinux -or $IsMacOS) {
         $scriptPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\OpenTofuInstaller.ps1'
         $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         New-Item -ItemType Directory -Path $temp | Out-Null

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -38,7 +38,7 @@ exit 0' | Set-Content -Path $dummy
         }
     }
 
-    It 'prompts for script selection when no -Scripts argument is supplied' -Skip:$IsLinux {
+    It 'prompts for script selection when no -Scripts argument is supplied' -Skip:($IsLinux -or $IsMacOS) {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $tempDir
         try {
@@ -91,7 +91,7 @@ Describe 'Customize-Config' {
     }
     }
 
-    It 'updates selections and saves to JSON' -Skip:$IsLinux {
+    It 'updates selections and saves to JSON' -Skip:($IsLinux -or $IsMacOS) {
         $config = @{
             InstallGit = $false
             InstallGo  = $false


### PR DESCRIPTION
## Summary
- add OS matrix to GitHub Actions
- install PowerShell on Linux and macOS runners
- skip Windows-only tests on non-Windows
- document cross-platform CI in CONTRIBUTING

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68472ce4092883318483dd6cddc243f3