### PR TITLE
Fix logger global variable

### DIFF
--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -4,8 +4,14 @@ function Write-CustomLog {
         [Parameter(Mandatory=$true, Position=0)]
         [string]$Message,
         [Parameter(Position=1)]
-        [string]$LogFile = $Global:LogFilePath
+        [string]$LogFile = $null
     )
+
+    if (-not $PSBoundParameters.ContainsKey('LogFile')) {
+        if (Test-Path 'variable:global:LogFilePath') {
+            $LogFile = $Global:LogFilePath
+        }
+    }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     $formatted = "[$timestamp] $Message"
     Write-Host $formatted

--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -46,5 +46,21 @@ Describe 'Cleanup-Files script' {
         Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
     }
+
+    It 'runs without a global log file' {
+        $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $temp
+        $infraPath = Join-Path $temp 'infra'
+        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        $config = [PSCustomObject]@{
+            LocalPath     = $temp
+            RepoUrl       = 'https://github.com/wizzense/test.git'
+            InfraRepoPath = $infraPath
+        }
+
+        { . $scriptPath -Config $config } | Should -Not -Throw
+
+        Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
+    }
 }
 

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,0 +1,15 @@
+Describe 'Write-CustomLog' {
+    It 'works when LogFilePath variable is not defined' {
+        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        { Write-CustomLog 'test message' } | Should -Not -Throw
+    }
+
+    It 'writes to specified log file when provided' {
+        $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid()).ToString() + '.log'
+        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        Write-CustomLog 'hello world' -LogFile $tempFile
+        $content = Get-Content $tempFile -Raw
+        $content | Should -Match 'hello world'
+        Remove-Item $tempFile -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary
- avoid unbound variable errors in `Logger.ps1`
- add tests for logger behavior
- ensure cleanup script works without a global log file

## Testing
- `Invoke-Pester -CI` *(fails: Expected the actual value to be greater than 0, but got 0)*

------
https://chatgpt.com/codex/tasks/task_e_68472f4b557c8331b831573c17f6e96a