### PR TITLE
Fix Write-CustomLog global variable check

### DIFF
--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -8,8 +8,9 @@ function Write-CustomLog {
     )
 
     if (-not $PSBoundParameters.ContainsKey('LogFile')) {
-        if (Test-Path 'variable:global:LogFilePath') {
-            $LogFile = $Global:LogFilePath
+        $var = Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        if ($null -ne $var) {
+            $LogFile = $var.Value
         }
     }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -4,6 +4,13 @@ Describe 'Write-CustomLog' {
         { Write-CustomLog 'test message' } | Should -Not -Throw
     }
 
+    It 'works under strict mode without global variable' {
+        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        Set-StrictMode -Version Latest
+        { Write-CustomLog 'another test' } | Should -Not -Throw
+        Set-StrictMode -Off
+    }
+
     It 'writes to specified log file when provided' {
         $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid()).ToString() + '.log'
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- prevent uninitialized variable errors when `LogFilePath` isn't set
- test logger behaviour under `Set-StrictMode`

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847311eadd8833196ddc4aa359fa337