### PR TITLE
Fix Write-CustomLog global variable check

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -166,7 +166,7 @@ if ($ScriptsToRun) {
             }
         }
         catch {
-            Write-CustomLog "ERROR: Exception in $($Script.Name). $_"
+            Write-CustomLog ("ERROR: Exception in $($Script.Name). {0}`n{1}" -f $PSItem.Exception.Message, $PSItem.ScriptStackTrace)
             exit 1
         }
     }

--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -43,7 +43,7 @@ try {
     Write-CustomLog 'Cleanup completed successfully.'
 }
 catch {
-    Write-Error "Cleanup failed: $_"
+    Write-Error -Message "Cleanup failed: $($PSItem.Exception.Message)`n$($PSItem.ScriptStackTrace)"
     exit 1
 }
 

--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -8,8 +8,9 @@ function Write-CustomLog {
     )
 
     if (-not $PSBoundParameters.ContainsKey('LogFile')) {
-        if (Test-Path 'variable:global:LogFilePath') {
-            $LogFile = $Global:LogFilePath
+        $var = Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        if ($null -ne $var) {
+            $LogFile = $var.Value
         }
     }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -4,6 +4,13 @@ Describe 'Write-CustomLog' {
         { Write-CustomLog 'test message' } | Should -Not -Throw
     }
 
+    It 'works under strict mode without global variable' {
+        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        Set-StrictMode -Version Latest
+        { Write-CustomLog 'another test' } | Should -Not -Throw
+        Set-StrictMode -Off
+    }
+
     It 'writes to specified log file when provided' {
         $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid()).ToString() + '.log'
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- prevent uninitialized variable errors when `LogFilePath` isn't set
- test logger behaviour under `Set-StrictMode`
- show stack trace on script errors

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847311eadd8833196ddc4aa359fa337