### PR TITLE
Fix empty catch blocks in kicker script

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -44,7 +44,12 @@ if (-not (Test-Path $loggerPath)) {
     $loggerUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/runner_utility_scripts/Logger.ps1'
     Invoke-WebRequest -Uri $loggerUrl -OutFile $loggerPath
 }
-try { . $loggerPath } catch {}
+try {
+    . $loggerPath
+} catch {
+    Write-Error "Failed to load logger script: $_"
+    exit 1
+}
 
 # Fallback inline logger in case dot-sourcing failed
 if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
@@ -57,7 +62,11 @@ if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
         $fmt = "[$ts] $Message"
         Write-Host $fmt
         if ($LogFile) {
-            try { $fmt | Out-File -FilePath $LogFile -Encoding utf8 -Append } catch {}
+            try {
+                $fmt | Out-File -FilePath $LogFile -Encoding utf8 -Append
+            } catch {
+                Write-Error "Failed to write log to file: $_"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add error handling when loading the logger script
- report failures when writing logs to file

## Testing
- `pwsh -Command "Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning"`
- `ruff .`
- `pwsh -Command "Invoke-Pester -CI -ErrorAction Stop"` *(fails: RunnerScripts.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_68473403d0508331b577cb2ecc1d4edc