### PR TITLE
Handle missing LogFilePath in Logger

### DIFF
--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -8,9 +8,10 @@ function Write-CustomLog {
     )
 
     if (-not $PSBoundParameters.ContainsKey('LogFile')) {
-        $var = Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
-        if ($null -ne $var) {
-            $LogFile = $var.Value
+        try {
+            $LogFile = Get-Variable -Name LogFilePath -Scope Global -ValueOnly -ErrorAction Stop
+        } catch {
+            $LogFile = $null
         }
     }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'

--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -62,5 +62,28 @@ Describe 'Cleanup-Files script' {
 
         Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
     }
+
+    It 'completes when LogFilePath is undefined' {
+        $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $temp
+        $repoName = 'opentofu-lab-automation'
+        $repoPath = Join-Path $temp $repoName
+        $infraPath = Join-Path $temp 'infra'
+        $null = New-Item -ItemType Directory -Path $repoPath
+        $null = New-Item -ItemType Directory -Path $infraPath
+        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        $config = [PSCustomObject]@{
+            LocalPath     = $temp
+            RepoUrl       = "https://github.com/wizzense/$repoName.git"
+            InfraRepoPath = $infraPath
+        }
+
+        { . $scriptPath -Config $config } | Should -Not -Throw
+
+        (Test-Path $repoPath) | Should -BeFalse
+        (Test-Path $infraPath) | Should -BeFalse
+
+        Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
+    }
 }
 


### PR DESCRIPTION
## Summary
- make Write-CustomLog safer when `LogFilePath` isn't defined
- add regression test for invoking Cleanup-Files with no `LogFilePath`

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684735459278833197f7b48537d929ef