### PR TITLE
Clarify PowerShell requirement for Invoke-Pester

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ gh repo clone <owner/repo>
 
 Using `gh` avoids the COM initialization issues seen with some Git installations.
 
+Running the test suite via `Invoke-Pester` requires **PowerShell 7 or later**.
+If you see errors about missing commands when invoking Pester, ensure `pwsh`
+is installed and use that executable instead of Windows PowerShell 5.1.
+
 ## Utility scripts
 
 `lab_utils/Get-Platform.ps1` detects the current platform.


### PR DESCRIPTION
## Summary
- update README troubleshooting with PowerShell 7+ note for Pester

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: RunnerScripts.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_6847354610f08331a1d18035dceb3504