### PR TITLE
Add manual workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [ main ]


### PR DESCRIPTION
## Summary
- enable `workflow_dispatch` trigger for CI

## Testing
- `Invoke-Pester -Path tests -CI` *(fails: missing closing '}' in OpenTofuInstaller.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_684736bcdd908331a8c2c6e8a80f76ef