### PR TITLE
Fix logger to handle undefined global variable

### DIFF
--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -8,11 +8,8 @@ function Write-CustomLog {
     )
 
     if (-not $PSBoundParameters.ContainsKey('LogFile')) {
-        try {
-            $LogFile = Get-Variable -Name LogFilePath -Scope Global -ValueOnly -ErrorAction Stop
-        } catch {
-            $LogFile = $null
-        }
+        $LogFile = Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue |
+                   Select-Object -ExpandProperty Value
     }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     $formatted = "[$timestamp] $Message"


### PR DESCRIPTION
## Summary
- refine Write-CustomLog so it checks `$Global:LogFilePath` safely without a try/catch

## Testing
- `Invoke-Pester -Output Detailed` *(fails: tests expect env setup)*

------
https://chatgpt.com/codex/tasks/task_e_684736d621c08331910c60e80bee5703