### PR TITLE
Fix cleanup script not deleting repo path in use

### DIFF
--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -15,6 +15,9 @@ Param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Ensure we are not executing from inside the directory we want to delete
+Push-Location -Path ([System.IO.Path]::GetTempPath())
+
 try {
     $localBase = if ($Config.LocalPath) {
         $Config.LocalPath
@@ -45,5 +48,8 @@ try {
 catch {
     Write-Error -Message "Cleanup failed: $($PSItem.Exception.Message)`n$($PSItem.ScriptStackTrace)"
     exit 1
+}
+finally {
+    Pop-Location
 }
 


### PR DESCRIPTION
## Summary
- avoid deleting repo we are executing from by pushing to temp directory
- restore original location after cleanup

## Testing
- `pwsh -Command "Invoke-Pester -Script tests/Cleanup-Files.Tests.ps1 -Quiet"`

------
https://chatgpt.com/codex/tasks/task_e_68473d9f5e9c8331976ce8e40e59789b