### PR TITLE
Fix lint action ruff version

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -18,9 +18,9 @@ runs:
         if-no-files-found: ignore
         restore-keys: |
           ${{ runner.os }}-lint-psmodules-
-    - name: Install Python dependencies
+    - name: Install ruff
       shell: bash
-      run: pip install -r "${{ github.action_path }}/requirements.txt"
+      run: pip install "ruff>=0.1"
     - name: Install PSScriptAnalyzer
       shell: pwsh
       run: Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser


### PR DESCRIPTION
## Summary
- update ruff install in composite lint action

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI -ErrorAction Stop"` *(fails: `bash: pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68474b7257648331b0265099ac4bc028