### PR TITLE
Fix GitHub Actions lint caching and PSScriptAnalyzer install

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -15,15 +15,16 @@ runs:
           ~/.local/share/powershell/Modules
           ~/Documents/PowerShell/Modules
         key: ${{ runner.os }}-lint-psmodules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
-        if-no-files-found: ignore
         restore-keys: |
           ${{ runner.os }}-lint-psmodules-
     - name: Install ruff
       shell: bash
       run: pip install "ruff>=0.1"
-    - name: Install PSScriptAnalyzer
+    - name: Resolve Locked PSScriptAnalyzer Module
       shell: pwsh
-      run: Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+      run: |
+        Remove-Module -Name PSScriptAnalyzer -Force -ErrorAction SilentlyContinue
+        Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
     - name: Run Script Analyzer
       shell: pwsh
       run: |


### PR DESCRIPTION
## Summary
- remove the unsupported `if-no-files-found` option
- reinstall PSScriptAnalyzer after removing any locked instance

## Testing
- `ruff check .`
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68474f50973c8331bdf9b1b6fdc38cd8