### PR TITLE
Fix bracket typo in reset-git

### DIFF
--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -43,7 +43,7 @@ if (-not (Test-Path (Join-Path $InfraPath '.git'))) {
     Write-CustomLog "Clone completed successfully."
 }
 
-} else {
+else {
     Write-CustomLog "Git repository found. Updating repository..."
     Push-Location $InfraPath
     try {


### PR DESCRIPTION
## Summary
- fix a misplaced curly brace in `0001_Reset-Git.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68475198986c8331b93f6c42a6e600ca