### PR TITLE
Fix PSScriptAnalyzer lock in CI

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -20,11 +20,6 @@ runs:
     - name: Install ruff
       shell: bash
       run: pip install "ruff>=0.1"
-    - name: Resolve Locked PSScriptAnalyzer Module
-      shell: pwsh
-      run: |
-        Remove-Module -Name PSScriptAnalyzer -Force -ErrorAction SilentlyContinue
-        Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
     - name: Run Script Analyzer
       shell: pwsh
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,16 @@ jobs:
           path: ~/.local/share/powershell/Modules
           key: ${{ runner.os }}-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pwsh-modules-
+      - name: Uninstall PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          if (Get-Module -ListAvailable -Name PSScriptAnalyzer) {
+            Uninstall-Module -Name PSScriptAnalyzer -AllVersions -Force
+          }
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.24.0 -Force -Scope CurrentUser
       - uses: ./.github/actions/lint
   pester:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- ensure `PSScriptAnalyzer` is removed before install
- install a specific version of `PSScriptAnalyzer` in CI

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847540bbf248331a6dfafebd95db009