### PR TITLE
Fix PSScriptAnalyzer uninstall on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
           key: ${{ runner.os }}-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pwsh-modules-
       - uses: ./.github/actions/lint
+      - name: Uninstall PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          if (Get-Module -ListAvailable -Name PSScriptAnalyzer) {
+            Remove-Module -Name PSScriptAnalyzer -Force -ErrorAction SilentlyContinue
+            Uninstall-Module -Name PSScriptAnalyzer -AllVersions -Force
+          }
   pester:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## Summary
- update lint workflow to unload PSScriptAnalyzer before uninstalling

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847550f3a748331aa5060507e9f391a