### PR TITLE
fix: guard PSScriptAnalyzer uninstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,19 @@ jobs:
           path: ~/.local/share/powershell/Modules
           key: ${{ runner.os }}-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pwsh-modules-
+      - name: Uninstall PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          if (Get-Module -ListAvailable -Name PSScriptAnalyzer) {
+            Write-Host "PSScriptAnalyzer module found. Uninstalling..."
+            Uninstall-Module -Name PSScriptAnalyzer -AllVersions -Force
+          } else {
+            Write-Host "PSScriptAnalyzer module not found. Skipping uninstallation."
+          }
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.24.0 -Force -Scope CurrentUser
       - uses: ./.github/actions/lint
   pester:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- handle missing PSScriptAnalyzer module in CI

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: RunnerScripts.Tests.ps1, OpenTofuInstaller.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_6847552c28a883319359bc3a401fab57