### PR TITLE
Improve cleanup script for missing repo dir

### DIFF
--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -16,6 +16,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 # Ensure we are not executing from inside the directory we want to delete
+$originalLocation = Get-Location
 Push-Location -Path ([System.IO.Path]::GetTempPath())
 
 try {
@@ -50,6 +51,12 @@ catch {
     exit 1
 }
 finally {
-    Pop-Location
+    if (Test-Path $originalLocation.Path) {
+        Pop-Location
+    }
+    else {
+        Pop-Location -ErrorAction SilentlyContinue
+        Set-Location $env:TEMP
+    }
 }
 

--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -85,5 +85,31 @@ Describe 'Cleanup-Files script' {
 
         Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
     }
+
+    It 'completes when the repo directory is removed' {
+        $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $repoName = 'opentofu-lab-automation'
+        $repoPath = Join-Path $temp $repoName
+        $infraPath = Join-Path $temp 'infra'
+        $null = New-Item -ItemType Directory -Path $repoPath
+        $null = New-Item -ItemType Directory -Path $infraPath
+
+        $config = [PSCustomObject]@{
+            LocalPath     = $temp
+            RepoUrl       = "https://github.com/wizzense/$repoName.git"
+            InfraRepoPath = $infraPath
+        }
+
+        $orig = Get-Location
+        Set-Location $repoPath
+
+        { . $scriptPath -Config $config } | Should -Not -Throw
+
+        (Test-Path $repoPath) | Should -BeFalse
+        (Get-Location).Path | Should -Not -Be $repoPath
+
+        Set-Location $orig
+        Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
+    }
 }
 


### PR DESCRIPTION
## Summary
- protect Cleanup-Files from popping a non-existent location
- test removal of repo directory during script run

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: RunnerScripts.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_684755b8bcc4833186cd85ed51333bf7