### PR TITLE
Remove redundant PSScriptAnalyzer uninstall step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,24 +40,11 @@ jobs:
           path: ~/.local/share/powershell/Modules
           key: ${{ runner.os }}-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pwsh-modules-
-      - name: Uninstall PSScriptAnalyzer
-        shell: pwsh
-        run: |
-          if (Get-Module -ListAvailable -Name PSScriptAnalyzer) {
-            Uninstall-Module -Name PSScriptAnalyzer -AllVersions -Force
-          }
       - name: Install PSScriptAnalyzer
         shell: pwsh
         run: |
           Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.24.0 -Force -Scope CurrentUser
       - uses: ./.github/actions/lint
-      - name: Uninstall PSScriptAnalyzer
-        shell: pwsh
-        run: |
-          if (Get-Module -ListAvailable -Name PSScriptAnalyzer) {
-            Remove-Module -Name PSScriptAnalyzer -Force -ErrorAction SilentlyContinue
-            Uninstall-Module -Name PSScriptAnalyzer -AllVersions -Force
-          }
   pester:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## Summary
- keep PSScriptAnalyzer installed for lint job
- remove uninstall steps from CI workflow

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475747d3808331b79146143fdee135