### PR TITLE
Gate Node installer by config

### DIFF
--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -23,23 +23,27 @@ $ErrorActionPreference = "Stop"
 
 Write-CustomLog "==== [0201] Installing Node.js Core ===="
 
-$url = if ($Config.Node_Dependencies.Node.InstallerUrl) {
-    $Config.Node_Dependencies.Node.InstallerUrl
+if ($Config.Node_Dependencies.InstallNode) {
+    $url = if ($Config.Node_Dependencies.Node.InstallerUrl) {
+        $Config.Node_Dependencies.Node.InstallerUrl
+    } else {
+        "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
+    }
+
+    $installerPath = Join-Path $env:TEMP "node-installer.msi"
+    Write-CustomLog "Downloading Node.js from: $url"
+    Invoke-WebRequest -Uri $url -OutFile $installerPath -UseBasicParsing
+
+    Start-Process msiexec.exe -ArgumentList "/i `"$installerPath`" /quiet /norestart" -Wait -NoNewWindow
+    Remove-Item $installerPath -Force
+
+    if (Get-Command node -ErrorAction SilentlyContinue) {
+        Write-CustomLog "✅Node.js installed successfully."
+        node -v
+    } else {
+        Write-Error "Node.js installation failed."
+        exit 1
+    }
 } else {
-    "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
-}
-
-$installerPath = Join-Path $env:TEMP "node-installer.msi"
-Write-CustomLog "Downloading Node.js from: $url"
-Invoke-WebRequest -Uri $url -OutFile $installerPath -UseBasicParsing
-
-Start-Process msiexec.exe -ArgumentList "/i `"$installerPath`" /quiet /norestart" -Wait -NoNewWindow
-Remove-Item $installerPath -Force
-
-if (Get-Command node -ErrorAction SilentlyContinue) {
-    Write-CustomLog "✅Node.js installed successfully."
-    node -v
-} else {
-    Write-Error "Node.js installation failed."
-    exit 1
+    Write-CustomLog "InstallNode flag is disabled. Skipping Node.js installation."
 }

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -10,13 +10,25 @@ Describe 'Node installation scripts' {
     }
 
     It 'uses Node_Dependencies.Node.InstallerUrl when installing Node' {
-        $config = @{ Node_Dependencies = @{ Node = @{ InstallerUrl = 'http://example.com/node.msi' } } }
+        $config = @{ Node_Dependencies = @{ InstallNode=$true; Node = @{ InstallerUrl = 'http://example.com/node.msi' } } }
         Mock Invoke-WebRequest {}
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command { @{Name='node'} } -ParameterFilter { $Name -eq 'node' }
         & (Resolve-Path $core) -Config $config
         Assert-MockCalled Invoke-WebRequest -ParameterFilter { $Uri -eq 'http://example.com/node.msi' } -Times 1
+    }
+
+    It 'does nothing when InstallNode is $false' {
+        $config = @{ Node_Dependencies = @{ InstallNode = $false } }
+        Mock Invoke-WebRequest {}
+        Mock Start-Process {}
+        Mock Remove-Item {}
+        Mock Get-Command {}
+        & (Resolve-Path $core) -Config $config
+        Assert-MockNotCalled Invoke-WebRequest
+        Assert-MockNotCalled Start-Process
+        Assert-MockNotCalled Remove-Item
     }
 
     It 'installs packages based on Node_Dependencies flags' {


### PR DESCRIPTION
## Summary
- skip Node.js install when `InstallNode` flag is false
- add test covering the skip condition

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module Pester; Invoke-Pester"` *(fails: ParameterBindingValidationException)*

------
https://chatgpt.com/codex/tasks/task_e_684755ca7ca48331b86700943ab86d52