### PR TITLE
Fix PSSA warnings in Runner.Tests.ps1

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -133,7 +133,12 @@ exit 0' | Set-Content -Path $dummy
             $responses = @('0001')
             $script:index = 0
             $called = 0
-            function global:Read-Host { param([string]$Prompt) $called++; $responses[$script:index++] }
+            function global:Read-Host {
+                param([string]$Prompt)
+                $null = $Prompt
+                $called++
+                $responses[$script:index++]
+            }
             Push-Location $tempDir
             & "$tempDir/runner.ps1" -Auto | Out-Null
             Pop-Location
@@ -181,7 +186,11 @@ Describe 'Customize-Config' {
 
         $answers = @('Y','N','Y','C:\\Repo','C:\\Node')
         $script:idx = 0
-        function global:Read-Host { param([string]$Prompt) $answers[$script:idx++] }
+        function global:Read-Host {
+            param([string]$Prompt)
+            $null = $Prompt
+            $answers[$script:idx++]
+        }
 
         $updated = Customize-Config -ConfigObject $config
 


### PR DESCRIPTION
## Summary
- reference the Read-Host prompt so ScriptAnalyzer does not report it unused

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684758a6d8b483319693d4424e511839