### PR TITLE
Replace Write-Host usage with logging functions

### DIFF
--- a/iso_tools/bootstrap.ps1
+++ b/iso_tools/bootstrap.ps1
@@ -8,7 +8,7 @@ $bootstrapUrl = "https://raw.githubusercontent.com/wizzense/opentofu-lab-automat
 Invoke-WebRequest -Uri $bootstrapUrl -OutFile '.\kicker-bootstrap.ps1'
 
 if (Test-Path '.\kicker-bootstrap.ps1') {
-  Write-Host "Downloaded kicker-bootstrap.ps1 to $(Resolve-Path '.\kicker-bootstrap.ps1')"
+  Write-Output "Downloaded kicker-bootstrap.ps1 to $(Resolve-Path '.\kicker-bootstrap.ps1')"
   & .\kicker-bootstrap.ps1
 } else {
   Write-Error 'kicker-bootstrap.ps1 was not found after download.'

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -24,7 +24,7 @@ $prompt = "`n<press any key to continue>`n"
 
 
 function Write-Continue($prompt) {
-  Write-Host "$prompt  " -NoNewline
+  [Console]::Write($prompt + '  ')
   Microsoft.PowerShell.Utility\Read-Host }
 
 $ErrorActionPreference = 'Stop'  # So any error throws an exception
@@ -60,7 +60,7 @@ if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
         )
         $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
         $fmt = "[$ts] $Message"
-        Write-Host $fmt
+        Write-Output $fmt
         if ($LogFile) {
             try {
                 $fmt | Out-File -FilePath $LogFile -Encoding utf8 -Append

--- a/lab_utils/Expand-All.ps1
+++ b/lab_utils/Expand-All.ps1
@@ -9,35 +9,35 @@ function Expand-All {
     if ($ZipFile) {
         # Expand a specific zip file if provided
         if (-not (Test-Path $ZipFile)) {
-            Write-Host "File '$ZipFile' does not exist."
+            Write-CustomLog "File '$ZipFile' does not exist."
             return
         }
-        Write-Host "Specified ZIP file: $ZipFile"
+        Write-CustomLog "Specified ZIP file: $ZipFile"
         $confirmation = Read-Host "Do you want to expand this archive? (y/n)"
         if ($confirmation -ne 'y') {
-            Write-Host "Operation canceled."
+            Write-CustomLog "Operation canceled."
             return
         }
         $destination = Join-Path -Path (Split-Path $ZipFile -Parent) -ChildPath (Split-Path $ZipFile -LeafBase)
-        Write-Host "Expanding archive: $ZipFile to $destination"
+        Write-CustomLog "Expanding archive: $ZipFile to $destination"
         Expand-Archive -Path $ZipFile -DestinationPath $destination -Force
-        Write-Host "Archive expanded."
+        Write-CustomLog "Archive expanded."
     }
     else {
         # Expand all zip files recursively in the current directory
         $currentDir = Get-Location
-        Write-Host "Current Directory: $currentDir"
+        Write-CustomLog "Current Directory: $currentDir"
         $confirmation = Read-Host "Do you want to expand all archives in this directory and its subdirectories? (y/n)"
         if ($confirmation -ne 'y') {
-            Write-Host "Operation canceled."
+            Write-CustomLog "Operation canceled."
             return
         }
         Get-ChildItem -Path $currentDir -Recurse -Filter *.zip | ForEach-Object {
             $destination = Join-Path -Path $_.DirectoryName -ChildPath $_.BaseName
-            Write-Host "Expanding archive: $($_.FullName) to $destination"
+            Write-CustomLog "Expanding archive: $($_.FullName) to $destination"
             Expand-Archive -Path $_.FullName -DestinationPath $destination -Force
         }
-        Write-Host "All archives expanded."
+        Write-CustomLog "All archives expanded."
     }
 }
 

--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -176,7 +176,7 @@ Pop-Location
 
 Write-CustomLog "OpenTofu initialized successfully."
 
-Write-Host @"
+Write-CustomLog @"
 NEXT STEPS:
 1. Check or edit the .tf files in '$infraRepoPath'.
 2. You may need to modify variables.tf to match your Hyper-V configuration.

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -315,7 +315,7 @@ if (Test-Path $tfFile) {
 } else {
     Write-CustomLog "providers.tf not found in $infraRepoPath; skipping provider config update."
 }
-    Write-Host @"
+    Write-CustomLog @"
 Done preparing Hyper-V host and installing the provider.
 You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
 "@

--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -13,12 +13,12 @@ function Write-CustomLog {
     }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     $formatted = "[$timestamp] $Message"
-    Write-Host $formatted
+    Write-Output $formatted
     if ($LogFile) {
         try {
             $formatted | Out-File -FilePath $LogFile -Encoding utf8 -Append
         } catch {
-            Write-Host "[ERROR] Failed to write to log file ${LogFile}: $_"
+            Write-Output "[ERROR] Failed to write to log file ${LogFile}: $_"
         }
     }
 }

--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -660,11 +660,11 @@ ${bold}${blue}Exit codes:${normal}
   ${bold}${exitCodeInvalidArgument}${normal}                             Invalid configuration options.
 
 "@
-    Write-Host $usageText
+    Write-Output $usageText
 }
 
-Write-Host "${blue}${bold}OpenTofu Installer${normal}"
-Write-Host ""
+Write-Output "${blue}${bold}OpenTofu Installer${normal}"
+Write-Output ""
 if ($help) {
     usage
     exit $exitCodeOK


### PR DESCRIPTION
## Summary
- swap remaining `Write-Host` calls for `Write-CustomLog` or `Write-Output`
- adjust helper function in kicker to avoid `Write-Host`
- update OpenTofu installer and other scripts to use modern logging

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI"` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475955c3a883318246d195b449cbd0