### PR TITLE
Rename Customize-Config function

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -38,7 +38,7 @@ function ConvertTo-Hashtable {
     }
 }
 
-function Customize-Config {
+function Set-LabConfig {
     param(
         [hashtable]$ConfigObject
     )
@@ -85,7 +85,7 @@ Write-CustomLog $formattedConfig
 if (-not $Auto) {
     $customize = Read-Host "Would you like to customize your configuration? (Y/N)"
     if ($customize -match '^(?i)y') {
-        $Config = Customize-Config -ConfigObject $Config
+        $Config = Set-LabConfig -ConfigObject $Config
         # Save the updated configuration
         $Config | ConvertTo-Json -Depth 5 | Out-File -FilePath $ConfigFile -Encoding utf8
         Write-CustomLog "Configuration updated and saved to $ConfigFile"

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -144,9 +144,9 @@ exit 0' | Set-Content -Path $dummy
     }
 }
 
-Describe 'Customize-Config' {
+Describe 'Set-LabConfig' {
     BeforeAll {
-        function Customize-Config {
+        function Set-LabConfig {
             param([hashtable]$ConfigObject)
 
         $installPrompts = @{ 
@@ -183,7 +183,7 @@ Describe 'Customize-Config' {
         $script:idx = 0
         function global:Read-Host { param([string]$Prompt) $answers[$script:idx++] }
 
-        $updated = Customize-Config -ConfigObject $config
+        $updated = Set-LabConfig -ConfigObject $config
 
         $temp = Join-Path ([System.IO.Path]::GetTempPath()) 'config-test.json'
         $updated | ConvertTo-Json -Depth 5 | Out-File -FilePath $temp -Encoding utf8


### PR DESCRIPTION
## Summary
- rename `Customize-Config` to `Set-LabConfig`
- update references in Runner tests

## Testing
- `Invoke-Pester -Configuration @{Run=@{Path='tests/Runner.Tests.ps1'}}`

------
https://chatgpt.com/codex/tasks/task_e_6847595967948331850fa0276322827b