### PR TITLE
Add process block to escapePathArgument

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -591,17 +591,20 @@ function installStandalone() {
     }
 }
 
-function escapePathArgument() {
+function escapePathArgument {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        [string] $path
+        [string] $Path
     )
 
-    if ($path -contains '"') {
-        throw [InvalidArgumentException]::new("Invalid path: ${path}")
-    }
+    process {
+        if ($Path -contains '"') {
+            throw [InvalidArgumentException]::new("Invalid path: ${Path}")
+        }
 
-    return "`"${path}`""
+        "`"${Path}`""
+    }
 }
 
 function usage() {

--- a/tests/EscapePathArgument.Tests.ps1
+++ b/tests/EscapePathArgument.Tests.ps1
@@ -1,0 +1,17 @@
+Describe 'escapePathArgument' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$null, [ref]$null)
+        $funcAst = $ast.Find({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'escapePathArgument' }, $false)
+        Invoke-Expression $funcAst.Extent.Text
+    }
+
+    It 'wraps path in quotes' {
+        escapePathArgument -Path 'C:\Test Path' | Should -Be '"C:\Test Path"'
+    }
+
+    It 'accepts pipeline input' {
+        'C:\Temp' | escapePathArgument | Should -Be '"C:\Temp"'
+    }
+
+}


### PR DESCRIPTION
## Summary
- convert `escapePathArgument` to advanced function using `process{}`
- add Pester coverage for pipeline input

## Testing
- `Invoke-Pester` *(fails: Tests Passed: 19, Failed: 55)*

------
https://chatgpt.com/codex/tasks/task_e_6847595d5648833186e2db9cc29e05b1