### PR TITLE
Remove unused debug mention from installer help

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -619,7 +619,6 @@ ${bold}${blue}OPTIONS for all installation methods:${normal}
   ${bold}-skipChangePath${normal}               Skip changing the user/system path to include the OpenTofu path.
   ${bold}-skipVerify${normal}                   Skip cosign integrity verification.
                                 (${bold}${red}not recommended${normal}).
-  ${bold}-debug${normal}                        Enable debug logging.
 
 ${bold}${blue}OPTIONS for the standalone installation:${normal}
 


### PR DESCRIPTION
## Summary
- clean up help text for `OpenTofuInstaller.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847596e63d08331aff52cbd6b140c58