### PR TITLE
Remove unused location variable

### DIFF
--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -15,8 +15,6 @@ Param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# Ensure we are not executing from inside the directory we want to delete
-$originalLocation = Get-Location
 Push-Location -Path ([System.IO.Path]::GetTempPath())
 
 try {
@@ -51,11 +49,9 @@ catch {
     exit 1
 }
 finally {
-    if (Test-Path $originalLocation.Path) {
-        Pop-Location
-    }
-    else {
-        Pop-Location -ErrorAction SilentlyContinue
+    try {
+        Pop-Location -ErrorAction Stop
+    } catch {
         Set-Location $env:TEMP
     }
 }

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -255,8 +255,6 @@ $taliesinsDir = Join-Path -Path $env:GOPATH -ChildPath "src\\github.com\\taliesi
 if (!(Test-Path $taliesinsDir)) {
     New-Item -ItemType Directory -Force -Path $taliesinsDir | Out-Null
 }
-# Capture current location so we can restore it later
-$originalLocation = Get-Location
 Push-Location
 Set-Location $taliesinsDir
 


### PR DESCRIPTION
## Summary
- cleanup: rely on Push/Pop-Location in cleanup script
- cleanup: remove `$originalLocation` from Hyper-V prep

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847597c57348331bfbfafbfa42828f1