### PR TITLE
Remove unused Config parameter from WinRM script

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -176,7 +176,14 @@ if ($ScriptsToRun) {
     foreach ($Script in $ScriptsToRun) {
         Write-CustomLog "`n--- Running: $($Script.Name) ---"
         try {
-            & "$PSScriptRoot\runner_scripts\$($Script.Name)" -Config $Config
+            $scriptPath = "$PSScriptRoot\runner_scripts\$($Script.Name)"
+            $cmdInfo = Get-Command -Name $scriptPath -ErrorAction SilentlyContinue
+            if ($cmdInfo -and $cmdInfo.Parameters.ContainsKey('Config')) {
+                & $scriptPath -Config $Config
+            }
+            else {
+                & $scriptPath
+            }
             if ($LASTEXITCODE -ne 0) {
                 Write-CustomLog "ERROR: $($Script.Name) exited with code $LASTEXITCODE."
                 $failed += $Script.Name

--- a/runner_scripts/0100_Enable-WinRM.ps1
+++ b/runner_scripts/0100_Enable-WinRM.ps1
@@ -1,7 +1,3 @@
-Param(
-    [Parameter(Mandatory=$true)]
-    [PSCustomObject]$Config
-)
 . "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
 
 # Check if WinRM is already configured

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -4,10 +4,14 @@ $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 Describe 'Runner scripts parameter and command checks' {
     foreach ($script in $scripts) {
         Context $script.Name {
-            It 'declares a Config parameter' {
+            It 'declares a Config parameter when required' {
                 $ast = [System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$null)
                 $configParam = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'Config' }
-                $configParam | Should -Not -BeNullOrEmpty
+                if ($script.Name -eq '0100_Enable-WinRM.ps1') {
+                    $configParam | Should -BeNullOrEmpty
+                } else {
+                    $configParam | Should -Not -BeNullOrEmpty
+                }
             }
 
             It 'contains at least one command invocation' {


### PR DESCRIPTION
## Summary
- eliminate the `Config` parameter in `0100_Enable-WinRM.ps1`
- call runner scripts with `Config` only when the parameter exists
- adjust RunnerScripts tests for the new behavior

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847598756388331a7d4723a44954328