### PR TITLE
Replace global variables in tests

### DIFF
--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -8,8 +8,12 @@ function Write-CustomLog {
     )
 
     if (-not $PSBoundParameters.ContainsKey('LogFile')) {
-        $LogFile = Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue |
-                   Select-Object -ExpandProperty Value
+        if (Get-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue) {
+            $LogFile = (Get-Variable -Name LogFilePath -Scope Script -ValueOnly)
+        } else {
+            $LogFile = Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue |
+                       Select-Object -ExpandProperty Value
+        }
     }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     $formatted = "[$timestamp] $Message"

--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'Cleanup-Files script' {
         $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $temp
 
-        $Global:LogFilePath = Join-Path $temp 'cleanup.log'
+        $script:LogFilePath = Join-Path $temp 'cleanup.log'
 
         $repoName = 'opentofu-lab-automation'
         $repoPath = Join-Path $temp $repoName
@@ -27,14 +27,14 @@ Describe 'Cleanup-Files script' {
         (Test-Path $infraPath) | Should -BeFalse
 
         Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
-        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
     }
 
     It 'handles missing directories gracefully' {
         $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $temp
         $infraPath = Join-Path $temp 'infra'
-        $Global:LogFilePath = Join-Path $temp 'cleanup.log'
+        $script:LogFilePath = Join-Path $temp 'cleanup.log'
         $config = [PSCustomObject]@{
             LocalPath     = $temp
             RepoUrl       = 'https://github.com/wizzense/test.git'
@@ -44,14 +44,14 @@ Describe 'Cleanup-Files script' {
         { . $scriptPath -Config $config } | Should -Not -Throw
 
         Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
-        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
     }
 
     It 'runs without a global log file' {
         $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $temp
         $infraPath = Join-Path $temp 'infra'
-        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         $config = [PSCustomObject]@{
             LocalPath     = $temp
             RepoUrl       = 'https://github.com/wizzense/test.git'
@@ -71,7 +71,7 @@ Describe 'Cleanup-Files script' {
         $infraPath = Join-Path $temp 'infra'
         $null = New-Item -ItemType Directory -Path $repoPath
         $null = New-Item -ItemType Directory -Path $infraPath
-        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         $config = [PSCustomObject]@{
             LocalPath     = $temp
             RepoUrl       = "https://github.com/wizzense/$repoName.git"

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -8,7 +8,7 @@ Describe '0112_Enable-PXE' {
     It 'logs firewall rules when ConfigPXE is true' -Skip:($IsLinux -or $IsMacOS) {
         $Config = [pscustomobject]@{ ConfigPXE = $true }
         $logPath = Join-Path $env:TEMP ('pxe-log-' + [System.Guid]::NewGuid().ToString() + '.txt')
-        $Global:LogFilePath = $logPath
+        $script:LogFilePath = $logPath
         try {
             & $scriptPath -Config $Config | Out-Null
             $log = Get-Content -Raw $logPath
@@ -18,7 +18,7 @@ Describe '0112_Enable-PXE' {
             $log | Should -Match 'prov-pxe-17530'
         } finally {
             Remove-Item $logPath -ErrorAction SilentlyContinue
-            Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         }
     }
 }

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -6,12 +6,12 @@ Describe '0203_Install-npm' {
         '{}' | Set-Content -Path (Join-Path $npmDir 'package.json')
         $config = @{ Node_Dependencies = @{ NpmPath = $npmDir } }
 
-        $global:calledPath = $null
-        function npm { param([string[]]$Args) $global:calledPath = (Get-Location).ProviderPath }
+        $script:calledPath = $null
+        function npm { param([string[]]$Args) $script:calledPath = (Get-Location).ProviderPath }
 
         & $script -Config $config
 
-        $calledPath | Should -Be (Get-Item $npmDir).FullName
+        $script:calledPath | Should -Be (Get-Item $npmDir).FullName
 
         Remove-Item -Recurse -Force $npmDir
     }

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,10 +1,12 @@
 Describe 'Write-CustomLog' {
     It 'works when LogFilePath variable is not defined' {
+        Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
         { Write-CustomLog 'test message' } | Should -Not -Throw
     }
 
     It 'works under strict mode without global variable' {
+        Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
         Set-StrictMode -Version Latest
         { Write-CustomLog 'another test' } | Should -Not -Throw
@@ -13,6 +15,7 @@ Describe 'Write-CustomLog' {
 
     It 'writes to specified log file when provided' {
         $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid()).ToString() + '.log'
+        Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
         Write-CustomLog 'hello world' -LogFile $tempFile
         $content = Get-Content $tempFile -Raw


### PR DESCRIPTION
## Summary
- support script-scoped `LogFilePath` in `Write-CustomLog`
- scope test variables locally instead of global

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475998f2f08331a2d67ee9e31dbba9