### PR TITLE
Replace Args variable in Pester tests

### DIFF
--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -7,7 +7,7 @@ Describe '0203_Install-npm' {
         $config = @{ Node_Dependencies = @{ NpmPath = $npmDir } }
 
         $global:calledPath = $null
-        function npm { param([string[]]$Args) $global:calledPath = (Get-Location).ProviderPath }
+        function npm { param([string[]]$testArgs) $global:calledPath = (Get-Location).ProviderPath }
 
         & $script -Config $config
 
@@ -23,7 +23,7 @@ Describe '0203_Install-npm' {
         '{}' | Set-Content -Path (Join-Path $npmDir 'package.json')
         $config = @{ Node_Dependencies = @{ NpmPath = $npmDir } }
 
-        function npm { param([string[]]$Args) }
+        function npm { param([string[]]$testArgs) }
 
         & $script -Config $config
         $success = $?

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -22,11 +22,12 @@ Describe 'Node installation scripts' {
     It 'installs packages based on Node_Dependencies flags' {
         $config = @{ Node_Dependencies = @{ InstallYarn=$true; InstallVite=$false; InstallNodemon=$true } }
         Mock Get-Command { @{Name='npm'} } -ParameterFilter { $Name -eq 'npm' }
+        function npm { param([string[]]$testArgs) }
         Mock npm {}
         & (Resolve-Path $global) -Config $config
-        Assert-MockCalled npm -ParameterFilter { $Args -eq @('install','-g','yarn') } -Times 1
-        Assert-MockCalled npm -ParameterFilter { $Args -eq @('install','-g','nodemon') } -Times 1
-        Assert-MockNotCalled npm -ParameterFilter { $Args -eq @('install','-g','vite') }
+        Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
+        Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','nodemon') } -Times 1
+        Assert-MockNotCalled npm -ParameterFilter { $testArgs -eq @('install','-g','vite') }
     }
 
     It 'uses NpmPath from Node_Dependencies when installing project deps' {
@@ -34,9 +35,10 @@ Describe 'Node installation scripts' {
         New-Item -ItemType Directory -Path $temp | Out-Null
         New-Item -ItemType File -Path (Join-Path $temp 'package.json') | Out-Null
         $config = @{ Node_Dependencies = @{ NpmPath = $temp } }
+        function npm { param([string[]]$testArgs) }
         Mock npm {}
         & (Resolve-Path $npm) -Config $config
-        Assert-MockCalled npm -ParameterFilter { $Args[0] -eq 'install' } -Times 1
+        Assert-MockCalled npm -ParameterFilter { $testArgs[0] -eq 'install' } -Times 1
         Remove-Item -Recurse -Force $temp
     }
 


### PR DESCRIPTION
## Summary
- rename `$Args` usage to `$testArgs` in Node-related tests
- update mocks to capture parameters using the new variable

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684759a446608331abfe646252581582