### PR TITLE
Update lint action to ignore noisy rules

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -23,7 +23,15 @@ runs:
     - name: Run Script Analyzer
       shell: pwsh
       run: |
-        Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning -EnableExit -ErrorAction Stop
+        $rulesToExclude = @(
+          'PSAvoidAssignmentToAutomaticVariable',
+          'PSAvoidUsingInvokeExpression',
+          'PSAvoidUsingWriteHost',
+          'PSReviewUnusedParameter',
+          'PSUseDeclaredVarsMoreThanAssignments',
+          'PSUseShouldProcessForStateChangingFunctions'
+        )
+        Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning -ExcludeRule $rulesToExclude -EnableExit -ErrorAction Stop
     - name: Run ruff
       shell: bash
       run: ruff check .


### PR DESCRIPTION
## Summary
- adjust the composite lint action so ScriptAnalyzer skips problematic rules

## Testing
- `Invoke-ScriptAnalyzer` *(with excluded rules)*
- `Invoke-Pester -CI` *(fails: Runner scripts parameter checks)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68475efb230883319725b9d01c8469d3