### PR TITLE
Add configurable logging defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ To run ALL scripts, type 'all'.
 To run one or more specific scripts, provide comma separated 4-digit prefixes (e.g. 0001,0003).
 Or type 'exit' to quit this script.
 
+## Logging
+
+All scripts output to the console using `Write-CustomLog`. If no log file is
+specified, a file named `lab.log` is created in `C:\temp` on Windows (or the
+system temporary directory on other platforms). Set the `LAB_LOG_DIR`
+environment variable or `$global:LogFilePath` to override the location.
+
 Make sure to modify the 'main.tf' so it uses your admin credentials and hostname/IP of the host machine if you don't have a customized config.json or choose not to customize.
 
 provider "hyperv" {

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -51,6 +51,16 @@ try {
     exit 1
 }
 
+# Set default log file path if none is defined
+if (-not (Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue)) {
+    $logDir = $env:LAB_LOG_DIR
+    if (-not $logDir) {
+        if ($IsWindows) { $logDir = 'C:\\temp' } else { $logDir = [System.IO.Path]::GetTempPath() }
+    }
+    if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+    $global:LogFilePath = Join-Path $logDir 'lab.log'
+}
+
 # Fallback inline logger in case dot-sourcing failed
 if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
     function Write-CustomLog {

--- a/runner.ps1
+++ b/runner.ps1
@@ -8,6 +8,16 @@ param(
 . "$PSScriptRoot\runner_utility_scripts\Logger.ps1"
 . "$PSScriptRoot\lab_utils\Get-LabConfig.ps1"
 
+# Set default log file path if none is defined
+if (-not (Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue)) {
+    $logDir = $env:LAB_LOG_DIR
+    if (-not $logDir) {
+        if ($IsWindows) { $logDir = 'C:\\temp' } else { $logDir = [System.IO.Path]::GetTempPath() }
+    }
+    if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+    $global:LogFilePath = Join-Path $logDir 'lab.log'
+}
+
 function ConvertTo-Hashtable {
     param(
         $obj

--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -13,6 +13,13 @@ function Write-CustomLog {
         } else {
             $LogFile = Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue |
                        Select-Object -ExpandProperty Value
+            if (-not $LogFile) {
+                $logDir = $env:LAB_LOG_DIR
+                if (-not $logDir) {
+                    if ($IsWindows) { $logDir = 'C:\\temp' } else { $logDir = [System.IO.Path]::GetTempPath() }
+                }
+                $LogFile = Join-Path $logDir 'lab.log'
+            }
         }
     }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'


### PR DESCRIPTION
## Summary
- set default log directory to `C:\temp` (or system temp on non‑Windows)
- create the log file path in `kicker-bootstrap.ps1` and `runner.ps1`
- fall back to this path in `Write-CustomLog`
- document logging behaviour in README

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68475ff116d08331bb5324dbf6533a21