### PR TITLE
Refine script validation tests

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -5,8 +5,12 @@ Describe 'Runner scripts parameter and command checks' {
     foreach ($script in $scripts) {
         Context $script.Name {
             It 'declares a Config parameter when required' {
-                $ast = [System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$null)
-                $configParam = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'Config' }
+                $ast         = [System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$null)
+                $configParam = $null
+                if ($ast -and $ast.ParamBlock) {
+                    $configParam = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'Config' }
+                }
+
                 if ($script.Name -eq '0100_Enable-WinRM.ps1') {
                     $configParam | Should -BeNullOrEmpty
                 } else {
@@ -16,7 +20,7 @@ Describe 'Runner scripts parameter and command checks' {
 
             It 'contains at least one command invocation' {
                 $ast = [System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$null)
-                $commands = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true)
+                $commands = if ($ast) { $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) } else { @() }
                 $commands.Count | Should -BeGreaterThan 0
             }
         }


### PR DESCRIPTION
## Summary
- handle missing Param blocks gracefully
- guard AST search in `RunnerScripts.Tests.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684761dd80a88331b9c3f8772ce639ce