### PR TITLE
Sync InstallCA flag name

### DIFF
--- a/config_files/default-config.json
+++ b/config_files/default-config.json
@@ -18,7 +18,7 @@
   "InstallOpenTofu": false,
   "InitializeOpenTofu": false,
   "PrepareHyperVHost": false,
-  "Install-CA": false,
+  "InstallCA": false,
   "InstallCosign": false,
   "CosignURL": "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-windows-amd64.exe",
   "CosignPath": "C:\\temp\\cosign",

--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -1,0 +1,34 @@
+Describe '0104_Install-CA script' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0104_Install-CA.ps1'
+    }
+
+    It 'invokes CA installation when InstallCA is true' {
+        $config = [pscustomobject]@{
+            InstallCA = $true
+            CertificateAuthority = @{ CommonName = 'TestCA'; ValidityYears = 1 }
+        }
+        Mock Write-CustomLog {}
+        Mock Get-WindowsFeature { @{ Installed = $false } } -ParameterFilter { $Name -eq 'Adcs-Cert-Authority' }
+        Mock Install-WindowsFeature {}
+        Mock Get-Item { $null }
+        Mock Install-AdcsCertificationAuthority {}
+
+        . $scriptPath -Config $config
+
+        Assert-MockCalled Install-AdcsCertificationAuthority -Times 1
+    }
+
+    It 'skips CA installation when InstallCA is false' {
+        $config = [pscustomobject]@{
+            InstallCA = $false
+            CertificateAuthority = @{ CommonName = 'TestCA'; ValidityYears = 1 }
+        }
+        Mock Write-CustomLog {}
+        Mock Install-AdcsCertificationAuthority {}
+
+        . $scriptPath -Config $config
+
+        Assert-MockNotCalled Install-AdcsCertificationAuthority
+    }
+}


### PR DESCRIPTION
## Summary
- fix mismatched CA flag in default config
- cover the CA install script with new Pester tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847657b35008331938114296aa87579