### PR TITLE
Fix ScriptAnalyzer findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Or type 'exit' to quit this script.
 All scripts output to the console using `Write-CustomLog`. If no log file is
 specified, a file named `lab.log` is created in `C:\temp` on Windows (or the
 system temporary directory on other platforms). Set the `LAB_LOG_DIR`
-environment variable or `$global:LogFilePath` to override the location.
+environment variable or `$script:LogFilePath` to override the location.
 
 Make sure to modify the 'main.tf' so it uses your admin credentials and hostname/IP of the host machine if you don't have a customized config.json or choose not to customize.
 

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -52,13 +52,14 @@ try {
 }
 
 # Set default log file path if none is defined
-if (-not (Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue)) {
+if (-not (Get-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue) -and
+    -not (Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue)) {
     $logDir = $env:LAB_LOG_DIR
     if (-not $logDir) {
         if ($IsWindows) { $logDir = 'C:\\temp' } else { $logDir = [System.IO.Path]::GetTempPath() }
     }
     if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
-    $global:LogFilePath = Join-Path $logDir 'lab.log'
+    $script:LogFilePath = Join-Path $logDir 'lab.log'
 }
 
 # Fallback inline logger in case dot-sourcing failed

--- a/runner.ps1
+++ b/runner.ps1
@@ -9,13 +9,14 @@ param(
 . "$PSScriptRoot\lab_utils\Get-LabConfig.ps1"
 
 # Set default log file path if none is defined
-if (-not (Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue)) {
+if (-not (Get-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue) -and
+    -not (Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue)) {
     $logDir = $env:LAB_LOG_DIR
     if (-not $logDir) {
         if ($IsWindows) { $logDir = 'C:\\temp' } else { $logDir = [System.IO.Path]::GetTempPath() }
     }
     if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
-    $global:LogFilePath = Join-Path $logDir 'lab.log'
+    $script:LogFilePath = Join-Path $logDir 'lab.log'
 }
 
 function ConvertTo-Hashtable {

--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Cleanup-Files script' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0000_Cleanup-Files.ps1'
+        $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0000_Cleanup-Files.ps1'
     }
 
     It 'removes repo and infra directories when they exist' {
@@ -21,7 +21,7 @@ Describe 'Cleanup-Files script' {
             InfraRepoPath = $infraPath
         }
 
-        . $scriptPath -Config $config
+        . $script:scriptPath -Config $config
 
         (Test-Path $repoPath) | Should -BeFalse
         (Test-Path $infraPath) | Should -BeFalse
@@ -41,7 +41,7 @@ Describe 'Cleanup-Files script' {
             InfraRepoPath = $infraPath
         }
 
-        { . $scriptPath -Config $config } | Should -Not -Throw
+        { . $script:scriptPath -Config $config } | Should -Not -Throw
 
         Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
@@ -58,7 +58,7 @@ Describe 'Cleanup-Files script' {
             InfraRepoPath = $infraPath
         }
 
-        { . $scriptPath -Config $config } | Should -Not -Throw
+        { . $script:scriptPath -Config $config } | Should -Not -Throw
 
         Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
     }
@@ -78,7 +78,7 @@ Describe 'Cleanup-Files script' {
             InfraRepoPath = $infraPath
         }
 
-        { . $scriptPath -Config $config } | Should -Not -Throw
+        { . $script:scriptPath -Config $config } | Should -Not -Throw
 
         (Test-Path $repoPath) | Should -BeFalse
         (Test-Path $infraPath) | Should -BeFalse
@@ -103,7 +103,7 @@ Describe 'Cleanup-Files script' {
         $orig = Get-Location
         Set-Location $repoPath
 
-        { . $scriptPath -Config $config } | Should -Not -Throw
+        { . $script:scriptPath -Config $config } | Should -Not -Throw
 
         (Test-Path $repoPath) | Should -BeFalse
         (Get-Location).Path | Should -Not -Be $repoPath

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -1,6 +1,6 @@
 Describe '0112_Enable-PXE' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0112_Enable-PXE.ps1'
+        $script:scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0112_Enable-PXE.ps1'
         $loggerPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\Logger.ps1'
         . $loggerPath
     }
@@ -10,7 +10,7 @@ Describe '0112_Enable-PXE' {
         $logPath = Join-Path $env:TEMP ('pxe-log-' + [System.Guid]::NewGuid().ToString() + '.txt')
         $script:LogFilePath = $logPath
         try {
-            & $scriptPath -Config $Config | Out-Null
+            & $script:scriptPath -Config $Config | Out-Null
             $log = Get-Content -Raw $logPath
             $log | Should -Match 'prov-pxe-67'
             $log | Should -Match 'prov-pxe-69'

--- a/tests/EscapePathArgument.Tests.ps1
+++ b/tests/EscapePathArgument.Tests.ps1
@@ -1,7 +1,7 @@
 Describe 'escapePathArgument' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
-        $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$null, [ref]$null)
+        $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:scriptPath, [ref]$null, [ref]$null)
         $funcAst = $ast.Find({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq 'escapePathArgument' }, $false)
         Invoke-Expression $funcAst.Extent.Text
     }

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -7,7 +7,11 @@ Describe '0203_Install-npm' {
         $config = @{ Node_Dependencies = @{ NpmPath = $npmDir } }
 
         $script:calledPath = $null
-        function npm { param([string[]]$Args) $script:calledPath = (Get-Location).ProviderPath }
+        function npm {
+            param([string[]]$NpmArgs)
+            $script:calledPath = (Get-Location).ProviderPath
+            $null = $NpmArgs
+        }
 
 
         & $script -Config $config
@@ -24,7 +28,10 @@ Describe '0203_Install-npm' {
         '{}' | Set-Content -Path (Join-Path $npmDir 'package.json')
         $config = @{ Node_Dependencies = @{ NpmPath = $npmDir } }
 
-        function npm { param([string[]]$testArgs) }
+        function npm {
+            param([string[]]$testArgs)
+            $null = $testArgs
+        }
 
         & $script -Config $config
         $success = $?

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -1,7 +1,7 @@
 Describe 'kicker-bootstrap utilities' {
     It 'defines Write-CustomLog fallback' {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
-        $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$null, [ref]$null)
+        $script:scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:scriptPath, [ref]$null, [ref]$null)
         $funcs = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
         ($funcs.Name -contains 'Write-CustomLog') | Should -BeTrue
     }

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -34,7 +34,10 @@ Describe 'Node installation scripts' {
     It 'installs packages based on Node_Dependencies flags' {
         $config = @{ Node_Dependencies = @{ InstallYarn=$true; InstallVite=$false; InstallNodemon=$true } }
         Mock Get-Command { @{Name='npm'} } -ParameterFilter { $Name -eq 'npm' }
-        function npm { param([string[]]$testArgs) }
+        function npm {
+            param([string[]]$testArgs)
+            $null = $testArgs
+        }
         Mock npm {}
         & (Resolve-Path $global) -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
@@ -47,7 +50,10 @@ Describe 'Node installation scripts' {
         New-Item -ItemType Directory -Path $temp | Out-Null
         New-Item -ItemType File -Path (Join-Path $temp 'package.json') | Out-Null
         $config = @{ Node_Dependencies = @{ NpmPath = $temp } }
-        function npm { param([string[]]$testArgs) }
+        function npm {
+            param([string[]]$testArgs)
+            $null = $testArgs
+        }
         Mock npm {}
         & (Resolve-Path $npm) -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs[0] -eq 'install' } -Times 1

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'OpenTofuInstaller logging' {
     It 'creates log files and removes them for elevated unpack' -Skip:($IsLinux -or $IsMacOS) {
-        $scriptPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\OpenTofuInstaller.ps1'
+        $script:scriptPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\OpenTofuInstaller.ps1'
         $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         New-Item -ItemType Directory -Path $temp | Out-Null
         $zipPath = Join-Path $temp 'tofu_0.0.0_windows_amd64.zip'
@@ -13,28 +13,30 @@ Describe 'OpenTofuInstaller logging' {
             } else { New-Item -ItemType File -Path $OutFile -Force | Out-Null }
         }
         Mock Expand-Archive {}
-        $logFile = $null
+        $script:logFile = $null
         Mock Start-Process {
             param($FilePath, $ArgumentList, $RedirectStandardOutput, $RedirectStandardError)
-            $logFile = $RedirectStandardOutput
+            $null = $FilePath
+            $null = $ArgumentList
+            $script:logFile = $RedirectStandardOutput
             New-Item -ItemType File -Path $RedirectStandardOutput -Force | Out-Null
             New-Item -ItemType File -Path $RedirectStandardError -Force | Out-Null
             $proc = New-Object psobject -Property @{ ExitCode = 0 }
             $proc | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { }
             return $proc
         }
-        & $scriptPath -installMethod standalone -opentofuVersion '0.0.0' -installPath $temp -allUsers -skipVerify -skipChangePath | Out-Null
+        & $script:scriptPath -installMethod standalone -opentofuVersion '0.0.0' -installPath $temp -allUsers -skipVerify -skipChangePath | Out-Null
         Assert-MockCalled Start-Process -Times 1
-        (Test-Path $logFile) | Should -BeFalse
+        (Test-Path $script:logFile) | Should -BeFalse
         Remove-Item -Recurse -Force $temp
 
 Describe 'OpenTofuInstaller error handling' {
     It 'returns install failed exit code when cosign is missing' {
-        $scriptPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\OpenTofuInstaller.ps1'
+        $script:scriptPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\OpenTofuInstaller.ps1'
         $arguments = @(
             '-NoLogo',
             '-NoProfile',
-            '-File', $scriptPath,
+            '-File', $script:scriptPath,
             '-installMethod', 'standalone',
             '-cosignPath', 'nonexistent.exe',
             '-gpgPath', 'nonexistent.exe'

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Prepare-HyperVProvider path restoration' {
     It 'restores location after execution' {
-        $scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0010_Prepare-HyperVProvider.ps1'
+        $script:scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0010_Prepare-HyperVProvider.ps1'
         $config = [pscustomobject]@{
             PrepareHyperVHost = $true
             InfraRepoPath = 'C:\\Infra'
@@ -8,13 +8,13 @@ Describe 'Prepare-HyperVProvider path restoration' {
             HostName = 'hvhost'
         }
 
-        $location = 'C:\\Start'
-        $stack = @()
+        $script:location = 'C:\\Start'
+        $script:stack = @()
 
-        Mock Get-Location { $location }
-        Mock Push-Location { $stack += $location }
-        Mock Set-Location { param($Path) $location = $Path }
-        Mock Pop-Location { $location = $stack[-1]; $stack = $stack[0..($stack.Count-2)] }
+        Mock Get-Location { $script:location }
+        Mock Push-Location { $script:stack += $script:location }
+        Mock Set-Location { param($Path) $script:location = $Path }
+        Mock Pop-Location { $script:location = $script:stack[-1]; $script:stack = $script:stack[0..($script:stack.Count-2)] }
 
         Mock Write-CustomLog {}
         Mock Get-WindowsOptionalFeature { @{State='Enabled'} }
@@ -31,7 +31,7 @@ Describe 'Prepare-HyperVProvider path restoration' {
         Mock Read-Host { '' }
         Mock Resolve-Path { param([string]$Path) @{ Path = $Path } }
 
-        & $scriptPath -Config $config
+        & $script:scriptPath -Config $config
 
         $location | Should -Be 'C:\\Start'
     }
@@ -39,7 +39,7 @@ Describe 'Prepare-HyperVProvider path restoration' {
 
 Describe 'Prepare-HyperVProvider certificate handling' {
     It 'creates PEM files and updates providers.tf' {
-        $scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0010_Prepare-HyperVProvider.ps1'
+        $script:scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0010_Prepare-HyperVProvider.ps1'
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $tempDir
         $config = [pscustomobject]@{
@@ -74,7 +74,7 @@ Describe 'Prepare-HyperVProvider certificate handling' {
           '}'
         ) | Set-Content -Path $providerFile
 
-        & $scriptPath -Config $config
+        & $script:scriptPath -Config $config
 
         Test-Path (Join-Path $tempDir 'TestCA.pem') | Should -BeTrue
         Test-Path (Join-Path $tempDir ("$(hostname).pem")) | Should -BeTrue

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -10,7 +10,7 @@
 Describe '0001_Reset-Git' {
 
     BeforeAll {
-        $ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0001_Reset-Git.ps1'
+        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0001_Reset-Git.ps1'
     }
 
     Context 'Clone command selection' {
@@ -27,7 +27,7 @@ Describe '0001_Reset-Git' {
             Mock gh { $global:LASTEXITCODE = 0 }
             Mock git {}
 
-            & $ScriptPath -Config $config
+            & $script:ScriptPath -Config $config
 
             Assert-MockCalled gh  -ParameterFilter { $args[0] -eq 'repo' -and $args[1] -eq 'clone' } -Times 1
             Assert-MockNotCalled git
@@ -47,7 +47,7 @@ Describe '0001_Reset-Git' {
             Mock git { $global:LASTEXITCODE = 0 }
             Mock gh  {}
 
-            & $ScriptPath -Config $config
+            & $script:ScriptPath -Config $config
 
             Assert-MockCalled git -ParameterFilter { $args[0] -eq 'clone' } -Times 1
             Assert-MockNotCalled gh
@@ -71,7 +71,7 @@ Describe '0001_Reset-Git' {
             Mock git { $global:LASTEXITCODE = 1 }
 
             try {
-                & $ScriptPath -Config $config
+                & $script:ScriptPath -Config $config
                 # If the script uses `throw`, this assertion is skipped because the Try is exited.
                 $LASTEXITCODE | Should -Be 1
             }
@@ -98,7 +98,7 @@ Describe '0001_Reset-Git' {
             }
             Mock git {}
 
-            & $ScriptPath -Config $config
+            & $script:ScriptPath -Config $config
 
             Assert-MockCalled gh -ParameterFilter { $args[0] -eq 'auth' -and $args[1] -eq 'status' } -Times 1
             Assert-MockNotCalled gh -ParameterFilter { $args[0] -eq 'repo' -and $args[1] -eq 'clone' }
@@ -121,7 +121,7 @@ Describe '0001_Reset-Git' {
             Mock git { $global:LASTEXITCODE = 0 }
             Mock Write-CustomLog {}
 
-            & $ScriptPath -Config $config
+            & $script:ScriptPath -Config $config
 
             Assert-MockCalled Write-CustomLog -ParameterFilter { $Message -eq 'Clone completed successfully.' } -Times 1
 


### PR DESCRIPTION
## Summary
- avoid global log variable and use script-scoped variable
- update docs for new `LogFilePath` usage
- fix unused parameter warnings in test scripts

## Testing
- `Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning`
- `Invoke-ScriptAnalyzer` with repo rules
- `Invoke-Pester -Path tests` *(fails: Expected a value, but got $null or empty)*

------
https://chatgpt.com/codex/tasks/task_e_684765b53a008331bc8abda3e2e3ad5f