### PR TITLE
Improve runner script menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Completely optional scripts I use for other tasks:
 
 To run ALL scripts, type 'all'.
 To run one or more specific scripts, provide comma separated 4-digit prefixes (e.g. 0001,0003).
+Append '!' to a prefix to force that script and enable its configuration flag.
 Or type 'exit' to quit this script.
 
 ## Logging

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -117,6 +117,72 @@ exit 0
         }
     }
 
+    It 'forces script execution when flag disabled using -Force' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $tempDir
+        try {
+            Copy-Item $script:runnerPath -Destination $tempDir
+            Copy-Item (Join-Path $PSScriptRoot '..\runner_utility_scripts') -Destination $tempDir -Recurse
+            Copy-Item (Join-Path $PSScriptRoot '..\lab_utils') -Destination $tempDir -Recurse
+            $configDir = Join-Path $tempDir 'config_files'
+            $null = New-Item -ItemType Directory -Path $configDir
+            $configFile = Join-Path $configDir 'config.json'
+            '{ "RunFoo": false }' | Set-Content -Path $configFile
+            $scriptsDir = Join-Path $tempDir 'runner_scripts'
+            $null = New-Item -ItemType Directory -Path $scriptsDir
+            $out = Join-Path $tempDir 'out.txt'
+            $scriptFile = Join-Path $scriptsDir '0001_Test.ps1'
+            @"`nparam([PSCustomObject]`$Config)
+if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath '$out' } else { Write-Output 'skip' }"@ | Set-Content -Path $scriptFile
+
+            Push-Location $tempDir
+            Mock Read-Host { throw 'Read-Host should not be called' }
+            & "$tempDir/runner.ps1" -Scripts '0001' -Auto -ConfigFile $configFile -Force | Out-Null
+            $updated = Get-Content -Raw $configFile | ConvertFrom-Json
+            Pop-Location
+
+            Test-Path $out | Should -BeTrue
+            $updated.RunFoo | Should -BeTrue
+        }
+        finally { Remove-Item -Recurse -Force $tempDir }
+    }
+
+    It 'forces script via selection using !' -Skip:($IsLinux -or $IsMacOS) {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $tempDir
+        try {
+            Copy-Item $script:runnerPath -Destination $tempDir
+            Copy-Item (Join-Path $PSScriptRoot '..\runner_utility_scripts') -Destination $tempDir -Recurse
+            Copy-Item (Join-Path $PSScriptRoot '..\lab_utils') -Destination $tempDir -Recurse
+            $configDir = Join-Path $tempDir 'config_files'
+            $null = New-Item -ItemType Directory -Path $configDir
+            $configFile = Join-Path $configDir 'config.json'
+            '{ "RunFoo": false }' | Set-Content -Path $configFile
+            $scriptsDir = Join-Path $tempDir 'runner_scripts'
+            $null = New-Item -ItemType Directory -Path $scriptsDir
+            $out = Join-Path $tempDir 'out.txt'
+            $scriptFile = Join-Path $scriptsDir '0001_Test.ps1'
+            @"`nparam([PSCustomObject]`$Config)
+if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath '$out' } else { Write-Output 'skip' }"@ | Set-Content -Path $scriptFile
+
+            $responses = @('0001!','exit')
+            $script:idx = 0
+            function global:Read-Host {
+                param([string]$Prompt)
+                $null = $Prompt
+                $responses[$script:idx++]
+            }
+            Push-Location $tempDir
+            & "$tempDir/runner.ps1" -Auto -ConfigFile $configFile | Out-Null
+            $updated = Get-Content -Raw $configFile | ConvertFrom-Json
+            Pop-Location
+
+            Test-Path $out | Should -BeTrue
+            $updated.RunFoo | Should -BeTrue
+        }
+        finally { Remove-Item -Recurse -Force $tempDir }
+    }
+
     It 'prompts for script selection when no -Scripts argument is supplied' -Skip:($IsLinux -or $IsMacOS) {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $tempDir


### PR DESCRIPTION
## Summary
- support `!` suffix to force scripts
- keep results when returning to the menu
- update docs and tests for forced selection

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684766f686108331bd75093130b15f38