### PR TITLE
Centralize runner script execution with wrapper

### DIFF
--- a/lab_utils/Invoke-LabScript.ps1
+++ b/lab_utils/Invoke-LabScript.ps1
@@ -1,0 +1,24 @@
+function Invoke-LabScript {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]$Config,
+        [Parameter(Mandatory=$true)]
+        [scriptblock]$ScriptBlock
+    )
+
+    if (-not $Config) {
+        throw 'Config object cannot be null'
+    }
+    if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
+        . "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+    }
+
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    try {
+        Invoke-Command -ScriptBlock $ScriptBlock -NoNewScope
+    } finally {
+        $ErrorActionPreference = $prev
+    }
+}

--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 <#
 .SYNOPSIS
@@ -54,5 +56,7 @@ finally {
     } catch {
         Set-Location $env:TEMP
     }
+}
+
 }
 

--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 # Determine InfraPath
 $InfraPath = if ($Config.InfraRepoPath) { $Config.InfraRepoPath } else { "C:\Temp\base-infra" }
@@ -56,3 +58,5 @@ else {
         Pop-Location
     }
 }
+}
+

--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 function Install-Cosign {
     # Check if cosign is available in the current PATH
@@ -62,3 +64,5 @@ elseif ($Config.InstallGpg -eq $true) {
 if (-not $Config.InstallCosign -and -not $Config.InstallGpg) {
     Write-CustomLog "No installation option specified. Use -InstallCosign and/or -InstallGpg when running this script."
 }
+}
+

--- a/runner_scripts/0007_Install-Go.ps1
+++ b/runner_scripts/0007_Install-Go.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 if ($Config.InstallGo -eq $true) {
     $GoConfig = $Config.Go
     if ($null -eq $GoConfig) {
@@ -47,5 +49,7 @@ if ($Config.InstallGo -eq $true) {
     Write-CustomLog "Go installation complete."
 } else {
     Write-CustomLog "InstallGo flag is disabled. Skipping Go installation."
+}
+
 }
 

--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -3,7 +3,9 @@ param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($Config.InstallOpenTofu -eq $true) {
     
@@ -13,3 +15,5 @@ if ($Config.InstallOpenTofu -eq $true) {
 } else {
     Write-CustomLog "InstallOpenTofu flag is disabled. Skipping OpenTofu installation."
 }
+}
+

--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -14,7 +14,9 @@ Param(
     [Parameter(Mandatory = $true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($Config.InitializeOpenTofu -eq $true) {
 
@@ -192,3 +194,5 @@ exit 0
 } else {
     Write-CustomLog "InitializeOpenTofu flag is disabled. Skipping initialization."
 }
+}
+

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 function Convert-CerToPem {
     param(
@@ -319,5 +321,7 @@ You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
 "@
 } else {
     Write-CustomLog "PrepareHyperVHost flag is disabled. Skipping Hyper-V host preparation."
+}
+
 }
 

--- a/runner_scripts/0100_Enable-WinRM.ps1
+++ b/runner_scripts/0100_Enable-WinRM.ps1
@@ -1,4 +1,11 @@
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+Param(
+    [Parameter(Mandatory=$true)]
+    [PSCustomObject]$Config
+)
+
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 # Check if WinRM is already configured
 $winrmStatus = Get-Service -Name WinRM -ErrorAction SilentlyContinue
@@ -15,5 +22,7 @@ if ($winrmStatus -and $winrmStatus.Status -eq 'Running') {
     # e.g.: Set-Item -Path WSMan:\localhost\Service\Auth\Basic -Value $true
     
     Write-CustomLog "WinRM has been enabled."
+}
+
 }
 

--- a/runner_scripts/0101_Enable-RemoteDesktop.ps1
+++ b/runner_scripts/0101_Enable-RemoteDesktop.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 # Check current Remote Desktop status
 $currentStatus = Get-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name "fDenyTSConnections"
@@ -21,3 +23,5 @@ if ($Config.AllowRemoteDesktop -eq $true) {
 else {
     Write-CustomLog "Remote Desktop is NOT enabled by config."
 }
+}
+

--- a/runner_scripts/0102_Configure-Firewall.ps1
+++ b/runner_scripts/0102_Configure-Firewall.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 Write-CustomLog "Configuring Firewall rules..."
 
@@ -19,3 +21,5 @@ if ($null -ne $Config.FirewallPorts) {
 } else {
     Write-CustomLog "No firewall ports specified."
 }
+}
+

--- a/runner_scripts/0103_Change-ComputerName.ps1
+++ b/runner_scripts/0103_Change-ComputerName.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($config.SetComputerName -eq $true) {
 
@@ -33,3 +35,5 @@ if ($config.SetComputerName -eq $true) {
 } else {
     Write-CustomLog "SetComputerName flag is disabled. Skipping computer name change."
 }
+}
+

--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($Config.InstallCA -eq $true) {
 Write-CustomLog "Checking for existing Certificate Authority (Standalone Root CA)..."
@@ -56,3 +58,5 @@ Write-CustomLog "Standalone Root CA '$CAName' installation complete."
 } else {
     Write-CustomLog "InstallCA flag is disabled. Skipping CA installation."
 }
+}
+

--- a/runner_scripts/0105_Install-HyperV.ps1
+++ b/runner_scripts/0105_Install-HyperV.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($Config.InstallHyperV -eq $true) {
     Write-CustomLog "Checking if Hyper-V is already installed..."
@@ -37,3 +39,5 @@ if ($Config.InstallHyperV -eq $true) {
 } else {
     Write-CustomLog "InstallHyperV flag is disabled. Skipping Hyper-V installation."
 }
+}
+

--- a/runner_scripts/0106_Install-WAC.ps1
+++ b/runner_scripts/0106_Install-WAC.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($Config.InstallWAC -eq $true) {
     # Retrieve configuration for WAC from the config object
@@ -66,3 +68,5 @@ if ($Config.InstallWAC -eq $true) {
 } else {
     Write-CustomLog "InstallWAC flag is disabled. Skipping Windows Admin Center installation."
 }
+}
+

--- a/runner_scripts/0111_Disable-TCPIP6.ps1
+++ b/runner_scripts/0111_Disable-TCPIP6.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($Config.DisableTCPIP6 -eq $true) {
     
@@ -12,4 +14,6 @@ if ($Config.DisableTCPIP6 -eq $true) {
     Write-CustomLog "DisableTCPIP6 flag is disabled. Skipping IPv6 configuration."
 }
 
+
+}
 

--- a/runner_scripts/0112_Enable-PXE.ps1
+++ b/runner_scripts/0112_Enable-PXE.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($Config.ConfigPXE -eq $true) {
 
@@ -17,4 +19,5 @@ if ($Config.ConfigPXE -eq $true) {
 
 } else {
     Write-CustomLog 'ConfigPXE is false. Skipping PXE firewall configuration.'
-}
+}}
+

--- a/runner_scripts/0113_Config-DNS.ps1
+++ b/runner_scripts/0113_Config-DNS.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($Config.SetDNSServers -eq $true) {
     
@@ -12,3 +14,5 @@ if ($Config.SetDNSServers -eq $true) {
 } else {
     Write-CustomLog "SetDNSServers flag is disabled. Skipping DNS configuration."
 }
+}
+

--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -2,7 +2,9 @@ Param(
     [Parameter(Mandatory=$true)]
     [PSCustomObject]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 if ($Config.SetTrustedHosts -eq $true) {
     
@@ -13,4 +15,6 @@ if ($Config.SetTrustedHosts -eq $true) {
 }
 
 
+
+}
 

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -17,7 +17,9 @@ param(
     [Parameter(Mandatory)]
     [hashtable]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 $ErrorActionPreference = "Stop"
 
@@ -47,3 +49,5 @@ if ($Config.Node_Dependencies.InstallNode) {
 } else {
     Write-CustomLog "InstallNode flag is disabled. Skipping Node.js installation."
 }
+}
+

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -27,7 +27,9 @@ param(
     [Parameter(Mandatory)]
     [hashtable]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 $ErrorActionPreference = "Stop"
 
@@ -62,4 +64,6 @@ if ($Config.Node_Dependencies.InstallNodemon) {
 }
 
 Write-CustomLog "==== Global npm package installation complete ===="
+
+}
 

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -26,7 +26,9 @@ param(
     [Parameter(Mandatory)]
     [hashtable]$Config
 )
-. "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
+. "$PSScriptRoot\..\lab_utils\Invoke-LabScript.ps1"
+
+Invoke-LabScript -Config $Config -ScriptBlock {
 
 $ErrorActionPreference = "Stop"
 Write-CustomLog "==== [0203] Installing Frontend npm Dependencies ===="
@@ -66,5 +68,7 @@ Pop-Location
 Write-CustomLog "==== Frontend dependency installation complete ===="
 } else {
     Write-CustomLog "InstallNpm flag is disabled. Skipping project dependency installation."
+}
+
 }
 

--- a/tests/Invoke-LabScript.Tests.ps1
+++ b/tests/Invoke-LabScript.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'Invoke-LabScript' {
+    BeforeAll {
+        $modulePath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Invoke-LabScript.ps1'
+        . $modulePath
+    }
+
+    It 'throws when Config is null' {
+        { Invoke-LabScript -Config $null -ScriptBlock { } } | Should -Throw
+    }
+
+    It 'executes the provided script block' {
+        $ran = $false
+        Invoke-LabScript -Config @{} -ScriptBlock { $script:ran = $true }
+        $ran | Should -BeTrue
+    }
+}

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -27,6 +27,8 @@ Describe 'OpenTofuInstaller logging' {
         Assert-MockCalled Start-Process -Times 1
         (Test-Path $logFile) | Should -BeFalse
         Remove-Item -Recurse -Force $temp
+    }
+}
 
 Describe 'OpenTofuInstaller error handling' {
     It 'returns install failed exit code when cosign is missing' {

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -1,6 +1,8 @@
 Describe 'Prepare-HyperVProvider path restoration' {
     It 'restores location after execution' {
         $scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0010_Prepare-HyperVProvider.ps1'
+        . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Invoke-LabScript.ps1')
+        . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Invoke-LabScript.ps1')
         $config = [pscustomobject]@{
             PrepareHyperVHost = $true
             InfraRepoPath = 'C:\\Infra'
@@ -31,7 +33,7 @@ Describe 'Prepare-HyperVProvider path restoration' {
         Mock Read-Host { '' }
         Mock Resolve-Path { param([string]$Path) @{ Path = $Path } }
 
-        & $scriptPath -Config $config
+        . $scriptPath -Config $config
 
         $location | Should -Be 'C:\\Start'
     }
@@ -74,7 +76,7 @@ Describe 'Prepare-HyperVProvider certificate handling' {
           '}'
         ) | Set-Content -Path $providerFile
 
-        & $scriptPath -Config $config
+        . $scriptPath -Config $config
 
         Test-Path (Join-Path $tempDir 'TestCA.pem') | Should -BeTrue
         Test-Path (Join-Path $tempDir ("$(hostname).pem")) | Should -BeTrue

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -11,6 +11,7 @@ Describe '0001_Reset-Git' {
 
     BeforeAll {
         $ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0001_Reset-Git.ps1'
+        . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Invoke-LabScript.ps1')
     }
 
     Context 'Clone command selection' {
@@ -27,7 +28,7 @@ Describe '0001_Reset-Git' {
             Mock gh { $global:LASTEXITCODE = 0 }
             Mock git {}
 
-            & $ScriptPath -Config $config
+            . $ScriptPath -Config $config
 
             Assert-MockCalled gh  -ParameterFilter { $args[0] -eq 'repo' -and $args[1] -eq 'clone' } -Times 1
             Assert-MockNotCalled git
@@ -47,7 +48,7 @@ Describe '0001_Reset-Git' {
             Mock git { $global:LASTEXITCODE = 0 }
             Mock gh  {}
 
-            & $ScriptPath -Config $config
+            . $ScriptPath -Config $config
 
             Assert-MockCalled git -ParameterFilter { $args[0] -eq 'clone' } -Times 1
             Assert-MockNotCalled gh
@@ -71,7 +72,7 @@ Describe '0001_Reset-Git' {
             Mock git { $global:LASTEXITCODE = 1 }
 
             try {
-                & $ScriptPath -Config $config
+                . $ScriptPath -Config $config
                 # If the script uses `throw`, this assertion is skipped because the Try is exited.
                 $LASTEXITCODE | Should -Be 1
             }
@@ -98,7 +99,7 @@ Describe '0001_Reset-Git' {
             }
             Mock git {}
 
-            & $ScriptPath -Config $config
+            . $ScriptPath -Config $config
 
             Assert-MockCalled gh -ParameterFilter { $args[0] -eq 'auth' -and $args[1] -eq 'status' } -Times 1
             Assert-MockNotCalled gh -ParameterFilter { $args[0] -eq 'repo' -and $args[1] -eq 'clone' }
@@ -121,7 +122,7 @@ Describe '0001_Reset-Git' {
             Mock git { $global:LASTEXITCODE = 0 }
             Mock Write-CustomLog {}
 
-            & $ScriptPath -Config $config
+            . $ScriptPath -Config $config
 
             Assert-MockCalled Write-CustomLog -ParameterFilter { $Message -eq 'Clone completed successfully.' } -Times 1
 

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -1,28 +1,33 @@
 $scriptDir = Join-Path $PSScriptRoot '..' 'runner_scripts'
-$scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
+$cases = Get-ChildItem $scriptDir -Filter '*.ps1' | ForEach-Object {
+    @{ Name = $_.Name; Path = $_.FullName }
+}
 
 Describe 'Runner scripts parameter and command checks' {
-    foreach ($script in $scripts) {
-        Context $script.Name {
-            It 'declares a Config parameter when required' {
-                $ast         = [System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$null)
-                $configParam = $null
-                if ($ast -and $ast.ParamBlock) {
-                    $configParam = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'Config' }
-                }
-
-                if ($script.Name -eq '0100_Enable-WinRM.ps1') {
-                    $configParam | Should -BeNullOrEmpty
-                } else {
-                    $configParam | Should -Not -BeNullOrEmpty
-                }
-            }
-
-            It 'contains at least one command invocation' {
-                $ast = [System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$null)
-                $commands = if ($ast) { $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) } else { @() }
-                $commands.Count | Should -BeGreaterThan 0
-            }
+    It 'declares a Config parameter when required' -TestCases $cases {
+        param($Name, $Path)
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$null)
+        $configParam = $null
+        if ($ast -and $ast.ParamBlock) {
+            $configParam = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'Config' }
         }
+        if ($Name -eq '0100_Enable-WinRM.ps1') {
+            $configParam | Should -BeNullOrEmpty
+        } else {
+            $configParam | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'contains at least one command invocation' -TestCases $cases {
+        param($Name, $Path)
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$null)
+        $commands = if ($ast) { $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) } else { @() }
+        $commands.Count | Should -BeGreaterThan 0
+    }
+
+    It 'uses Invoke-LabScript wrapper' -TestCases $cases {
+        param($Name, $Path)
+        $content = Get-Content -Path $Path -Raw
+        $content | Should -Match 'Invoke-LabScript'
     }
 }


### PR DESCRIPTION
## Summary
- add `Invoke-LabScript` to wrap script execution with logging and error handling
- refactor all runner scripts to use the new wrapper
- create new tests for the wrapper and update existing ones

## Testing
- `Invoke-Pester` *(fails: Could not find Command Write-CustomLog, gh)*

------
https://chatgpt.com/codex/tasks/task_e_684764c95c98833191b0f221c2de5a0f