### PR TITLE
Enforce Config parameter across runner scripts

### DIFF
--- a/runner_scripts/0100_Enable-WinRM.ps1
+++ b/runner_scripts/0100_Enable-WinRM.ps1
@@ -1,3 +1,9 @@
+
+Param(
+    [Parameter(Mandatory=$true)]
+    [PSCustomObject]$Config
+)
+
 . "$PSScriptRoot\..\runner_utility_scripts\Logger.ps1"
 
 # Check if WinRM is already configured

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -11,11 +11,7 @@ Describe 'Runner scripts parameter and command checks' {
                     $configParam = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'Config' }
                 }
 
-                if ($script.Name -eq '0100_Enable-WinRM.ps1') {
-                    $configParam | Should -BeNullOrEmpty
-                } else {
-                    $configParam | Should -Not -BeNullOrEmpty
-                }
+                $configParam | Should -Not -BeNullOrEmpty
             }
 
             It 'contains at least one command invocation' {


### PR DESCRIPTION
## Summary
- require that every runner script exposes a `Config` parameter
- add the missing parameter to `0100_Enable-WinRM.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476e484bf483319ba0fbe8158b737a