### PR TITLE
Add issue-on-fail workflow

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -1,0 +1,38 @@
+name: Issue on CI failure
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  create-issue:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runId = context.payload.workflow_run.id;
+            const run = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            const { data } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            const failed = data.jobs.filter(job => job.conclusion === 'failure');
+            let body = `CI workflow run [${run.data.head_branch}](${run.data.html_url}) failed.\n`;
+            body += failed.map(j => `- Job **${j.name}** [logs](${j.html_url})`).join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `CI failed on ${run.data.head_branch}`,
+              body,
+            });
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,7 @@ Invoke-Pester -Path tests
 This runs the test suite found under the `tests/` directory. When adding
 Windows‑specific tests, guard them with `-Skip:($IsLinux -or $IsMacOS)` so the
 suite succeeds across all platforms.
+
+## CI failure issues
+
+If the `CI` workflow fails, the `issue-on-fail.yml` workflow automatically opens a GitHub issue summarizing which jobs failed. This helps track flaky tests without manual intervention.


### PR DESCRIPTION
## Summary
- open an issue whenever the CI workflow fails
- document the automated issue in CONTRIBUTING

## Testing
- `Invoke-Pester -CI -ErrorAction Stop` *(fails: Missing closing '}' and CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_68476e9e16c08331ba79ec1507ad9505