### PR TITLE
Fix Node installer log and add BOM to npm script

### DIFF
--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -36,7 +36,7 @@ if ($Config.Node_Dependencies.InstallNode) {
     Remove-Item $installerPath -Force
 
     if (Get-Command node -ErrorAction SilentlyContinue) {
-        Write-CustomLog "✅Node.js installed successfully."
+        Write-CustomLog "Node.js installed successfully."
         node -v
     } else {
         Write-Error "Node.js installation failed."

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+﻿Param([pscustomobject]$Config)
 . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 Invoke-LabStep -Config $Config -Body {
 <#


### PR DESCRIPTION
## Summary
- drop emoji from Node install logging
- re-save Install-npm script with UTF-8 BOM

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684773d32af08331aa7161c4cb62436f