### PR TITLE
Fix secure string generation in test

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -110,7 +110,8 @@ Describe 'Convert certificate helpers honour -WhatIf' {
         $stub | Add-Member -MemberType ScriptMethod -Name GetRSAPrivateKey -Value { $rsa }
         Mock Set-Content {}
         Mock New-Object { $stub }
-        Convert-PfxToPem -PfxPath $pfx -Password (ConvertTo-SecureString 'pw' -AsPlainText -Force) -CertPath $cert -KeyPath $key -WhatIf
+        $securePw = [System.Net.NetworkCredential]::new('', 'pw').SecurePassword
+        Convert-PfxToPem -PfxPath $pfx -Password $securePw -CertPath $cert -KeyPath $key -WhatIf
         Assert-MockNotCalled Set-Content
         Remove-Item $pfx -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
## Summary
- replace `ConvertTo-SecureString -AsPlainText` usage in `PrepareHyperVProvider.Tests.ps1`
- generate a secure string using `NetworkCredential` instead

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684773e05b1483319b65c781f626e500