### PR TITLE
Remove ShouldProcess exclusion from linter

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -28,8 +28,7 @@ runs:
           'PSAvoidUsingInvokeExpression',
           'PSAvoidUsingWriteHost',
           'PSReviewUnusedParameter',
-          'PSUseDeclaredVarsMoreThanAssignments',
-          'PSUseShouldProcessForStateChangingFunctions'
+          'PSUseDeclaredVarsMoreThanAssignments'
         )
         Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning -ExcludeRule $rulesToExclude -EnableExit -ErrorAction Stop
     - name: Run ruff

--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -4,6 +4,7 @@ Invoke-LabStep -Config $Config -Body {
 
 function Install-Cosign {
     [CmdletBinding(SupportsShouldProcess)]
+    param()
     # Check if cosign is available in the current PATH
     if (-not (Test-Path (Join-Path $Config.CosignPath "cosign-windows-amd64.exe") -ErrorAction SilentlyContinue)) {
         Write-CustomLog "Cosign is not found. Installing cosign..."

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -29,8 +29,11 @@ Invoke-LabStep -Config $Config -Body {
 Write-Output "Config parameter is: $Config"
 
 
-function Install-GlobalPackage($package) {
+function Install-GlobalPackage {
     [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [string]$package
+    )
     if (Get-Command npm -ErrorAction SilentlyContinue) {
         Write-CustomLog "Installing npm package: $package..."
         if ($PSCmdlet.ShouldProcess($package, 'Install npm package')) {


### PR DESCRIPTION
## Summary
- activate `PSUseShouldProcessForStateChangingFunctions`
- update validation and node global package install scripts

## Testing
- `Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning -ExcludeRule PSAvoidAssignmentToAutomaticVariable,PSAvoidUsingInvokeExpression,PSAvoidUsingWriteHost,PSReviewUnusedParameter,PSUseDeclaredVarsMoreThanAssignments`
- `Invoke-Pester` *(fails: Tests Passed: 14, Failed: 67)*

------
https://chatgpt.com/codex/tasks/task_e_684773e423d883318ace4ee7654dfd36