### PR TITLE
Wrap install scripts in advanced functions

### DIFF
--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -1,6 +1,9 @@
-Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
-Invoke-LabStep -Config $Config -Body {
+function Install-NodeCore {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param([pscustomobject]$Config)
+
+    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+    Invoke-LabStep -Config $Config -Body {
 <#
 .SYNOPSIS
     Installs Node.js via MSI, using the existing config framework.
@@ -46,3 +49,5 @@ if ($Config.Node_Dependencies.InstallNode) {
     Write-CustomLog "InstallNode flag is disabled. Skipping Node.js installation."
 }
 }
+}
+if ($MyInvocation.InvocationName -ne '.') { Install-NodeCore @PSBoundParameters }

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -1,6 +1,9 @@
-Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
-Invoke-LabStep -Config $Config -Body {
+function Install-NodeGlobalPackages {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param([pscustomobject]$Config)
+
+    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+    Invoke-LabStep -Config $Config -Body {
 <#
 .SYNOPSIS
     Installs global npm packages like yarn, vite, and nodemon using config-based logic.
@@ -29,8 +32,9 @@ Invoke-LabStep -Config $Config -Body {
 Write-Output "Config parameter is: $Config"
 
 
-function Install-GlobalPackage($package) {
+function Install-GlobalPackage {
     [CmdletBinding(SupportsShouldProcess)]
+    param([string]$package)
     if (Get-Command npm -ErrorAction SilentlyContinue) {
         Write-CustomLog "Installing npm package: $package..."
         if ($PSCmdlet.ShouldProcess($package, 'Install npm package')) {
@@ -64,3 +68,5 @@ if ($Config.Node_Dependencies.InstallNodemon) {
 
 Write-CustomLog "==== Global npm package installation complete ===="
 }
+}
+if ($MyInvocation.InvocationName -ne '.') { Install-NodeGlobalPackages @PSBoundParameters }

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -1,6 +1,9 @@
-Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
-Invoke-LabStep -Config $Config -Body {
+function Install-NpmDependencies {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param([pscustomobject]$Config)
+
+    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+    Invoke-LabStep -Config $Config -Body {
 <#
 .SYNOPSIS
     Install frontend project dependencies using npm.
@@ -42,7 +45,9 @@ $frontendPath = if ($Config.Node_Dependencies.NpmPath) {
 if (-not (Test-Path $frontendPath)) {
     if ($Config.Node_Dependencies.CreateNpmPath) {
         Write-CustomLog "Creating missing frontend folder at: $frontendPath"
-        New-Item -ItemType Directory -Path $frontendPath -Force | Out-Null
+        if ($PSCmdlet.ShouldProcess($frontendPath, 'Create NpmPath')) {
+            New-Item -ItemType Directory -Path $frontendPath -Force | Out-Null
+        }
     } else {
         Write-CustomLog "Frontend folder not found at: $frontendPath. Skipping npm install."
         return
@@ -58,7 +63,9 @@ Push-Location $frontendPath
 
 try {
     Write-CustomLog "Running npm install in $frontendPath ..."
-    npm install
+    if ($PSCmdlet.ShouldProcess($frontendPath, 'Run npm install')) {
+        npm install
+    }
     Write-CustomLog "✅ npm install completed."
 } catch {
     Write-Error "ERROR: npm install failed: $_"
@@ -71,3 +78,5 @@ Write-CustomLog "==== Frontend dependency installation complete ===="
     Write-CustomLog "InstallNpm flag is disabled. Skipping project dependency installation."
 }
 }
+}
+if ($MyInvocation.InvocationName -ne '.') { Install-NpmDependencies @PSBoundParameters }

--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -14,7 +14,8 @@ Describe '0104_Install-CA script' {
         Mock Get-Item { $null }
         Mock Install-AdcsCertificationAuthority {}
 
-        . $scriptPath -Config $config
+        . $scriptPath
+        Install-CA -Config $config
 
         Assert-MockCalled Install-AdcsCertificationAuthority -Times 1
     }
@@ -27,7 +28,8 @@ Describe '0104_Install-CA script' {
         Mock Write-CustomLog {}
         Mock Install-AdcsCertificationAuthority {}
 
-        . $scriptPath -Config $config
+        . $scriptPath
+        Install-CA -Config $config
 
         Assert-MockNotCalled Install-AdcsCertificationAuthority
     }

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -14,7 +14,8 @@ Describe '0203_Install-npm' {
         }
 
 
-        & $script -Config $config
+        . $script
+        Install-NpmDependencies -Config $config
 
         $script:calledPath | Should -Be (Get-Item $npmDir).FullName
 
@@ -33,7 +34,8 @@ Describe '0203_Install-npm' {
             $null = $testArgs
         }
 
-        & $script -Config $config
+        . $script
+        Install-NpmDependencies -Config $config
         $success = $?
 
         $success | Should -BeTrue
@@ -49,7 +51,8 @@ Describe '0203_Install-npm' {
         $script:called = $false
         function npm { $script:called = $true }
 
-        & $script -Config $config
+        . $script
+        Install-NpmDependencies -Config $config
         $success = $?
 
         $success | Should -BeTrue
@@ -64,7 +67,8 @@ Describe '0203_Install-npm' {
         $script:calledPath = $null
         function npm { param([string[]]$Args) $script:calledPath = (Get-Location).ProviderPath }
 
-        & $script -Config $config
+        . $script
+        Install-NpmDependencies -Config $config
 
         $script:calledPath | Should -Be (Get-Item $npmDir).FullName
         Test-Path $npmDir | Should -BeTrue

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -15,7 +15,8 @@ Describe 'Node installation scripts' {
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command { @{Name='node'} } -ParameterFilter { $Name -eq 'node' }
-        & (Resolve-Path $core) -Config $config
+        . (Resolve-Path $core)
+        Install-NodeCore -Config $config
         Assert-MockCalled Invoke-WebRequest -ParameterFilter { $Uri -eq 'http://example.com/node.msi' } -Times 1
     }
 
@@ -25,7 +26,8 @@ Describe 'Node installation scripts' {
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command {}
-        & (Resolve-Path $core) -Config $config
+        . (Resolve-Path $core)
+        Install-NodeCore -Config $config
         Assert-MockNotCalled Invoke-WebRequest
         Assert-MockNotCalled Start-Process
         Assert-MockNotCalled Remove-Item
@@ -39,14 +41,16 @@ Describe 'Node installation scripts' {
             $null = $testArgs
         }
         Mock npm {}
-        & (Resolve-Path $global) -Config $config
+        . (Resolve-Path $global)
+        Install-NodeGlobalPackages -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','nodemon') } -Times 1
         Assert-MockNotCalled npm -ParameterFilter { $testArgs -eq @('install','-g','vite') }
     }
 
     It 'honours -WhatIf for Install-GlobalPackage' {
-        . (Resolve-Path $global) -Config @{ Node_Dependencies = @{ InstallYarn=$false; InstallVite=$false; InstallNodemon=$false } }
+        . (Resolve-Path $global)
+        Install-NodeGlobalPackages -Config @{ Node_Dependencies = @{ InstallYarn=$false; InstallVite=$false; InstallNodemon=$false } }
         function npm { param([string[]]$testArgs) }
         Mock npm {}
         Install-GlobalPackage 'yarn' -WhatIf
@@ -63,7 +67,8 @@ Describe 'Node installation scripts' {
             $null = $testArgs
         }
         Mock npm {}
-        & (Resolve-Path $npm) -Config $config
+        . (Resolve-Path $npm)
+        Install-NpmDependencies -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs[0] -eq 'install' } -Times 1
         Remove-Item -Recurse -Force $temp
     }

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -5,13 +5,11 @@ Describe 'Runner scripts parameter and command checks' {
     foreach ($script in $scripts) {
         Context $script.Name {
             It 'declares a Config parameter when required' {
-                $ast         = [System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$null)
-                $configParam = $null
-                if ($ast -and $ast.ParamBlock) {
-                    $configParam = $ast.ParamBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq 'Config' }
-                }
-
-                $configParam | Should -Not -BeNullOrEmpty
+                $ast = [System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$null)
+                $configParam = if ($ast) {
+                    $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.ParameterAst] -and $n.Name.VariablePath.UserPath -eq 'Config' }, $true)
+                } else { @() }
+                $configParam.Count | Should -BeGreaterThan 0
             }
 
             It 'contains at least one command invocation' {


### PR DESCRIPTION
## Summary
- create `Install-NodeCore`, `Install-NodeGlobalPackages`, `Install-NpmDependencies` and `Install-CA` cmdlets
- check `ShouldProcess` before downloads, installs or service changes
- call the new functions in unit tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI"` *(fails: Expected the actual value to be greater than 0, but got 0)*

------
https://chatgpt.com/codex/tasks/task_e_684773e14e308331b4b09b1c83b9d490