### PR TITLE
Add GitHub Model helpers and generator scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,21 @@ Use this output to branch your automation logic according to the host
 operating system. Check the other `lab_utils` scripts for additional
 cross-platform helpers.
 
+
+## GitHub Models
+
+Some scripts rely on GitHub Models for text generation. Create a token with the **ai-inference** scope from your account settings and set it as `GITHUB_MODEL_TOKEN`:
+
+```powershell
+$env:GITHUB_MODEL_TOKEN = 'ghu_your_token'
+```
+
+Example usage:
+
+```powershell
+# Generate configuration from a prompt
+./runner_scripts/0015_Generate-ConfigFromPrompt.ps1 -Prompt "produce a minimal hyper-v config" -Model 'llama3-8b'
+
+# Append a summary section to README
+./runner_scripts/0016_Generate-Docs.ps1 -Prompt "summarize the infra modules"
+```

--- a/lab_utils/Invoke-GHModel.ps1
+++ b/lab_utils/Invoke-GHModel.ps1
@@ -1,0 +1,30 @@
+function Invoke-GHModel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Model,
+
+        [Parameter(Mandatory)]
+        [string]$Prompt,
+
+        [hashtable]$Parameters
+    )
+
+    $token = $env:GITHUB_MODEL_TOKEN
+    if (-not $token) { throw 'GITHUB_MODEL_TOKEN is not set' }
+
+    $headers = @{
+        Authorization       = "Bearer $token"
+        Accept              = 'application/json'
+        'X-GitHub-Api-Version' = '2022-11-28'
+    }
+
+    $body = @{ prompt = $Prompt }
+    if ($Parameters) { $body.parameters = $Parameters }
+
+    $uri = "https://api.github.com/ai/model-inference/$Model"
+    $json = $body | ConvertTo-Json -Depth 5
+    $response = Invoke-RestMethod -Uri $uri -Method Post -Headers $headers -Body $json
+
+    return $response.choices[0].message.content
+}

--- a/py/gh_models.py
+++ b/py/gh_models.py
@@ -1,0 +1,19 @@
+import os
+from azure.ai.inference import ChatCompletionsClient
+from azure.core.credentials import AzureKeyCredential
+
+
+def invoke_model(model: str, prompt: str, parameters: dict | None = None) -> str:
+    """Call GitHub Models using the Azure AI Inference SDK."""
+    token = os.getenv("GITHUB_MODEL_TOKEN")
+    if not token:
+        raise RuntimeError("GITHUB_MODEL_TOKEN not set")
+
+    client = ChatCompletionsClient(
+        endpoint="https://api.github.com/ai",
+        credential=AzureKeyCredential(token),
+    )
+
+    params = parameters or {}
+    result = client.complete(messages=[{"role": "user", "content": prompt}], model=model, **params)
+    return result.choices[0].message.content

--- a/runner_scripts/0015_Generate-ConfigFromPrompt.ps1
+++ b/runner_scripts/0015_Generate-ConfigFromPrompt.ps1
@@ -1,0 +1,16 @@
+Param(
+    [pscustomobject]$Config,
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Prompt,
+    [string]$Model = 'llama3-8b'
+)
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+. "$PSScriptRoot/../lab_utils/Invoke-GHModel.ps1"
+Invoke-LabStep -Config $Config -Body {
+    Write-CustomLog "Generating configuration via GitHub model $Model"
+    $text = Invoke-GHModel -Model $Model -Prompt $Prompt
+    $outFile = Join-Path $PSScriptRoot '..' 'config_files' 'generated-config.json'
+    $text | Out-File -FilePath $outFile -Encoding utf8
+    Write-CustomLog "Saved configuration to $outFile"
+}

--- a/runner_scripts/0016_Generate-Docs.ps1
+++ b/runner_scripts/0016_Generate-Docs.ps1
@@ -1,0 +1,20 @@
+Param(
+    [pscustomobject]$Config,
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Prompt,
+    [string]$Model = 'llama3-8b'
+)
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+. "$PSScriptRoot/../lab_utils/Invoke-GHModel.ps1"
+Invoke-LabStep -Config $Config -Body {
+    Write-CustomLog "Generating documentation via GitHub model $Model"
+    $text = Invoke-GHModel -Model $Model -Prompt $Prompt
+    $readme = Join-Path $PSScriptRoot '..' 'README.md'
+    if (Test-Path $readme) {
+        Add-Content -Path $readme -Value "`n$text"
+        Write-CustomLog "Updated README.md with model output"
+    } else {
+        Write-CustomLog "README.md not found at $readme"
+    }
+}

--- a/tests/Generate-ModelScripts.Tests.ps1
+++ b/tests/Generate-ModelScripts.Tests.ps1
@@ -1,0 +1,48 @@
+Describe 'GitHub model runner scripts' {
+    BeforeAll {
+        $runnerDir = Join-Path $PSScriptRoot '..'
+        $script15 = Join-Path $runnerDir 'runner_scripts' '0015_Generate-ConfigFromPrompt.ps1'
+        $script16 = Join-Path $runnerDir 'runner_scripts' '0016_Generate-Docs.ps1'
+        $labUtils  = Join-Path $runnerDir 'lab_utils'
+        $utilDir   = Join-Path $runnerDir 'runner_utility_scripts'
+        $configDir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid())
+        New-Item -ItemType Directory -Path $configDir | Out-Null
+        Copy-Item (Join-Path $runnerDir 'config_files') -Destination $configDir -Recurse
+        $script:temp = $configDir
+        $script:script15 = $script15
+        $script:script16 = $script16
+        $script:labUtils  = $labUtils
+        $script:utilDir   = $utilDir
+    }
+
+    AfterAll {
+        Remove-Item -Recurse -Force $script:temp
+    }
+
+    It 'creates generated config file' {
+        $dest = Join-Path $script:temp 'config_files'
+        Copy-Item $script:script15 -Destination $script:temp
+        Copy-Item $script:labUtils -Destination $script:temp -Recurse
+        Copy-Item $script:utilDir -Destination $script:temp -Recurse
+        Push-Location $script:temp
+        Mock Invoke-GHModel { 'config-json' }
+        & ./0015_Generate-ConfigFromPrompt.ps1 -Config @{} -Prompt 'p'
+        Pop-Location
+        $outFile = Join-Path $dest 'generated-config.json'
+        (Get-Content -Raw $outFile) | Should -Be 'config-json'
+    }
+
+    It 'appends docs to README' {
+        $dest = $script:temp
+        Copy-Item $script:script16 -Destination $dest
+        Copy-Item $script:labUtils -Destination $dest -Recurse
+        Copy-Item $script:utilDir -Destination $dest -Recurse
+        Set-Content -Path (Join-Path $dest 'README.md') -Value 'base'
+        Push-Location $dest
+        Mock Invoke-GHModel { 'added text' }
+        & ./0016_Generate-Docs.ps1 -Config @{} -Prompt 'p'
+        Pop-Location
+        $readme = Get-Content -Raw (Join-Path $dest 'README.md')
+        $readme | Should -Match 'added text'
+    }
+}

--- a/tests/Invoke-GHModel.Tests.ps1
+++ b/tests/Invoke-GHModel.Tests.ps1
@@ -1,0 +1,35 @@
+Describe 'Invoke-GHModel' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Invoke-GHModel.ps1')
+    }
+
+    It 'posts prompt to GitHub endpoint with token' {
+        $headers = $null
+        $body    = $null
+        Mock Invoke-RestMethod {
+            param($Uri,$Method,$Headers,$Body)
+            $headers = $Headers
+            $body    = $Body
+            @{ choices = @(@{ message = @{ content = 'response text' } }) }
+        }
+        $env:GITHUB_MODEL_TOKEN = 'testtoken'
+        $result = Invoke-GHModel -Model 'test-model' -Prompt 'hello'
+
+        $headers.Authorization | Should -Be 'Bearer testtoken'
+        $headers.Accept | Should -Be 'application/json'
+        ($body | ConvertFrom-Json).prompt | Should -Be 'hello'
+        $result | Should -Be 'response text'
+    }
+
+    It 'includes parameters when provided' {
+        $captured = $null
+        Mock Invoke-RestMethod {
+            param($Uri,$Method,$Headers,$Body)
+            $captured = $Body
+            @{ choices = @(@{ message = @{ content = 'x' } }) }
+        }
+        $env:GITHUB_MODEL_TOKEN = 'tok'
+        Invoke-GHModel -Model 'model' -Prompt 'p' -Parameters @{temperature=0.1}
+        (($captured | ConvertFrom-Json).parameters.temperature) | Should -Be 0.1
+    }
+}


### PR DESCRIPTION
## Summary
- add Invoke-GHModel utility for calling GitHub Model Inference API
- add runner scripts to generate config and docs from prompts
- document GitHub Models token usage
- provide Python prototype wrapper
- test GitHub model helper and runner scripts

## Testing
- `Invoke-Pester -EnableExit` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477620847c8331969e68012a253a72