### PR TITLE
Propagate runner exit code

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -382,7 +382,12 @@ if (!(Test-Path $runnerScriptName)) {
 }
 
 Write-CustomLog "Running $runnerScriptName from $repoPath ..."
-. .\$runnerScriptName -ConfigFile $ConfigFile
+& ".\$runnerScriptName" -ConfigFile $ConfigFile
+
+if ($LASTEXITCODE -ne 0) {
+    Write-CustomLog "Runner script failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
 
 Write-CustomLog "`n=== Kicker script finished successfully! ==="
 exit 0

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -5,4 +5,11 @@ Describe 'kicker-bootstrap utilities' {
         $funcs = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
         ($funcs.Name -contains 'Write-CustomLog') | Should -BeTrue
     }
+
+    It 'invokes runner with call operator and propagates exit code' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
+        $content = Get-Content $scriptPath -Raw
+        $content | Should -Match '& \\.\\\$runnerScriptName'
+        $content | Should -Match 'exit \$LASTEXITCODE'
+    }
 }


### PR DESCRIPTION
## Summary
- invoke `runner.ps1` via call operator in kicker script
- exit with `$LASTEXITCODE` on failure
- add regression test for runner invocation

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Missing closing '}' in OpenTofuInstaller.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_6847778eb3188331bedb03ef7ecbbca4