### PR TITLE
Fix secure string test and remove node emojis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ When PowerShell is available via `pwsh`, run tests locally:
 pwsh -NoLogo -NoProfile -Command "Invoke-Pester"
 ```
 
+### CI failure issues
+
+`.github/workflows/issue-on-fail.yml` opens an issue whenever the `CI` workflow ends in `failure`. It uses `actions-ecosystem/action-create-issue@v1` with the repository `GITHUB_TOKEN` and requests `issues: write` permissions. Check these issues when debugging failing runs and mention them when submitting fixes.
+
 ---
 
 ## Phase 1  Cross-Platform Foundations (3 days)

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -36,7 +36,7 @@ if ($Config.Node_Dependencies.InstallNode) {
     Remove-Item $installerPath -Force
 
     if (Get-Command node -ErrorAction SilentlyContinue) {
-        Write-CustomLog "✅Node.js installed successfully."
+        Write-CustomLog "Node.js installed successfully."
         node -v
     } else {
         Write-Error "Node.js installation failed."

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+﻿Param([pscustomobject]$Config)
 . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 Invoke-LabStep -Config $Config -Body {
 <#
@@ -59,7 +59,7 @@ Push-Location $frontendPath
 try {
     Write-CustomLog "Running npm install in $frontendPath ..."
     npm install
-    Write-CustomLog "✅ npm install completed."
+    Write-CustomLog "npm install completed."
 } catch {
     Write-Error "ERROR: npm install failed: $_"
     exit 1

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -110,7 +110,8 @@ Describe 'Convert certificate helpers honour -WhatIf' {
         $stub | Add-Member -MemberType ScriptMethod -Name GetRSAPrivateKey -Value { $rsa }
         Mock Set-Content {}
         Mock New-Object { $stub }
-        Convert-PfxToPem -PfxPath $pfx -Password (ConvertTo-SecureString 'pw' -AsPlainText -Force) -CertPath $cert -KeyPath $key -WhatIf
+        $securePass = (New-Object System.Net.NetworkCredential('', 'pw')).SecurePassword
+        Convert-PfxToPem -PfxPath $pfx -Password $securePass -CertPath $cert -KeyPath $key -WhatIf
         Assert-MockNotCalled Set-Content
         Remove-Item $pfx -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
## Summary
- avoid ConvertTo-SecureString -AsPlainText in PrepareHyperVProvider.Tests.ps1
- drop emoji logging from Install-NodeCore and Install-npm
- ensure Install-npm script is encoded with UTF-8 BOM
- document CI failure issue workflow in `AGENTS.md`

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_684771cdc25883318b0430dcab8f94f7