### PR TITLE
Do not fail CI on ScriptAnalyzer warnings

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -30,7 +30,12 @@ runs:
           'PSReviewUnusedParameter',
           'PSUseDeclaredVarsMoreThanAssignments'
         )
-        Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning -ExcludeRule $rulesToExclude -EnableExit -ErrorAction Stop
+        $results = Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning -ExcludeRule $rulesToExclude
+        $results | Format-Table
+        if ($results | Where-Object Severity -eq 'Error') {
+          Write-Error 'ScriptAnalyzer errors detected'
+          exit 1
+        }
     - name: Run ruff
       shell: bash
       run: ruff check .


### PR DESCRIPTION
## Summary
- modify the lint action so ScriptAnalyzer errors fail the step but warnings do not

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `bash: pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68477a3078d48331a983c24f63c2ab73