### PR TITLE
Fix Start-Process casing in trusted hosts script

### DIFF
--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -4,7 +4,7 @@ Invoke-LabStep -Config $Config -Body {
 
 if ($Config.SetTrustedHosts -eq $true) {
     
-    start-process cmd.exe -ArgumentList "/d /c winrm set winrm/config/client @{TrustedHosts=`"$Config.TrustedHosts`"}"
+    Start-Process cmd.exe -ArgumentList "/d /c winrm set winrm/config/client @{TrustedHosts=`"$Config.TrustedHosts`"}"
 
 } else {
     Write-CustomLog "SetTrustedHosts flag is disabled. Skipping TrustedHosts configuration."


### PR DESCRIPTION
## Summary
- fix the casing of `Start-Process` in Config-TrustedHosts script

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847864cd2408331aba2246ef7bb61ba