### PR TITLE
Fix OpenTofuInstaller test braces

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -29,6 +29,8 @@ Describe 'OpenTofuInstaller logging' {
         Assert-MockCalled Start-Process -Times 1
         (Test-Path $script:logFile) | Should -BeFalse
         Remove-Item -Recurse -Force $temp
+    }
+}
 
 Describe 'OpenTofuInstaller error handling' {
     It 'returns install failed exit code when cosign is missing' {


### PR DESCRIPTION
## Summary
- close the initial `It` block in `tests/OpenTofuInstaller.Tests.ps1`
- close the surrounding `Describe` block

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847864860b48331babf559911dbcdc3