### PR TITLE
Fix menu log output

### DIFF
--- a/lab_utils/Menu.ps1
+++ b/lab_utils/Menu.ps1
@@ -15,7 +15,7 @@ function Get-MenuSelection {
         }
         $map["$num"] = $item
         if ($prefix) { $map[$prefix] = $item }
-        Write-CustomLog ("{0}) {1}" -f $num, $item)
+        Write-CustomLog ("{0}) {1}" -f $num, $item) | Write-Host
     }
     while ($true) {
         $prompt = if ($AllowAll) { "Enter numbers/prefixes (comma separated), 'all', or 'exit'" } else { "Enter numbers/prefixes or 'exit'" }
@@ -25,6 +25,6 @@ function Get-MenuSelection {
         $tokens = $input -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
         $selected = foreach ($t in $tokens) { if ($map.ContainsKey($t)) { $map[$t] } }
         if ($selected) { return $selected }
-        Write-CustomLog 'Invalid selection. Try again.'
+        Write-CustomLog 'Invalid selection. Try again.' | Write-Host
     }
 }


### PR DESCRIPTION
## Summary
- prevent menu logging from polluting return values

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847864bd1708331a90f47dd6a5102d0