### PR TITLE
Add config param to Node scripts

### DIFF
--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -1,3 +1,5 @@
+Param([pscustomobject]$Config)
+
 function Install-NodeCore {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -1,3 +1,5 @@
+Param([pscustomobject]$Config)
+
 function Install-NodeGlobalPackages {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -1,3 +1,4 @@
+Param([pscustomobject]$Config)
 
 function Install-NpmDependencies {
     [CmdletBinding(SupportsShouldProcess = $true)]

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -14,7 +14,7 @@ Describe '0203_Install-npm' {
         }
 
 
-        . $script
+        . $script -Config @{}
         Install-NpmDependencies -Config $config
 
         $script:calledPath | Should -Be (Get-Item $npmDir).FullName
@@ -34,7 +34,7 @@ Describe '0203_Install-npm' {
             $null = $testArgs
         }
 
-        . $script
+        . $script -Config @{}
         Install-NpmDependencies -Config $config
         $success = $?
 
@@ -51,7 +51,7 @@ Describe '0203_Install-npm' {
         $script:called = $false
         function npm { $script:called = $true }
 
-        . $script
+        . $script -Config @{}
         Install-NpmDependencies -Config $config
         $success = $?
 
@@ -67,7 +67,7 @@ Describe '0203_Install-npm' {
         $script:calledPath = $null
         function npm { param([string[]]$Args) $script:calledPath = (Get-Location).ProviderPath }
 
-        . $script
+        . $script -Config @{}
         Install-NpmDependencies -Config $config
 
         $script:calledPath | Should -Be (Get-Item $npmDir).FullName

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Node installation scripts' {
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command { @{Name='node'} } -ParameterFilter { $Name -eq 'node' }
-        . (Resolve-Path $core)
+        . (Resolve-Path $core) -Config @{}
         Install-NodeCore -Config $config
         Assert-MockCalled Invoke-WebRequest -ParameterFilter { $Uri -eq 'http://example.com/node.msi' } -Times 1
     }
@@ -26,7 +26,7 @@ Describe 'Node installation scripts' {
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command {}
-        . (Resolve-Path $core)
+        . (Resolve-Path $core) -Config @{}
         Install-NodeCore -Config $config
         Assert-MockNotCalled Invoke-WebRequest
         Assert-MockNotCalled Start-Process
@@ -41,7 +41,7 @@ Describe 'Node installation scripts' {
             $null = $testArgs
         }
         Mock npm {}
-        . (Resolve-Path $global)
+        . (Resolve-Path $global) -Config @{}
         Install-NodeGlobalPackages -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','nodemon') } -Times 1
@@ -49,7 +49,7 @@ Describe 'Node installation scripts' {
     }
 
     It 'honours -WhatIf for Install-GlobalPackage' {
-        . (Resolve-Path $global)
+        . (Resolve-Path $global) -Config @{}
         Install-NodeGlobalPackages -Config @{ Node_Dependencies = @{ InstallYarn=$false; InstallVite=$false; InstallNodemon=$false } }
         function npm { param([string[]]$testArgs) }
         Mock npm {}
@@ -67,7 +67,7 @@ Describe 'Node installation scripts' {
             $null = $testArgs
         }
         Mock npm {}
-        . (Resolve-Path $npm)
+        . (Resolve-Path $npm) -Config @{}
         Install-NpmDependencies -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs[0] -eq 'install' } -Times 1
         Remove-Item -Recurse -Force $temp


### PR DESCRIPTION
## Summary
- accept `-Config` parameter at the script level for Node install scripts
- update tests to dot-source scripts with the parameter

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847864eb5248331a967d36843310552