### PR TITLE
Update Logger default path and add tests

### DIFF
--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -8,18 +8,21 @@ function Write-CustomLog {
     )
 
     if (-not $PSBoundParameters.ContainsKey('LogFile')) {
+        $candidate = $null
         if (Get-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue) {
-            $LogFile = (Get-Variable -Name LogFilePath -Scope Script -ValueOnly)
+            $candidate = Get-Variable -Name LogFilePath -Scope Script -ValueOnly
+        } elseif (Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue) {
+            $candidate = Get-Variable -Name LogFilePath -Scope Global -ValueOnly
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+            $LogFile = $candidate
         } else {
-            $LogFile = Get-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue |
-                       Select-Object -ExpandProperty Value
-            if (-not $LogFile) {
-                $logDir = $env:LAB_LOG_DIR
-                if (-not $logDir) {
-                    if ($IsWindows) { $logDir = 'C:\\temp' } else { $logDir = [System.IO.Path]::GetTempPath() }
-                }
-                $LogFile = Join-Path $logDir 'lab.log'
+            $logDir = $env:LAB_LOG_DIR
+            if (-not $logDir) {
+                if ($IsWindows) { $logDir = 'C:\\temp' } else { $logDir = [System.IO.Path]::GetTempPath() }
             }
+            $LogFile = Join-Path $logDir 'lab.log'
         }
     }
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -11,6 +11,7 @@ Describe '0112_Enable-PXE' {
         $script:LogFilePath = $logPath
         try {
             & $script:scriptPath -Config $Config | Out-Null
+            (Test-Path $logPath) | Should -BeTrue
             $log = Get-Content -Raw $logPath
             $log | Should -Match 'prov-pxe-67'
             $log | Should -Match 'prov-pxe-69'

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -22,4 +22,17 @@ Describe 'Write-CustomLog' {
         $content | Should -Match 'hello world'
         Remove-Item $tempFile -ErrorAction SilentlyContinue
     }
+
+    It 'defaults to LogFilePath variable when not provided' {
+        $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid()).ToString() + '.log'
+        $script:LogFilePath = $tempFile
+        try {
+            Write-CustomLog 'variable default works'
+            $content = Get-Content $tempFile -Raw
+            $content | Should -Match 'variable default works'
+        } finally {
+            Remove-Item $tempFile -ErrorAction SilentlyContinue
+            Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- improve `Write-CustomLog` so `$LogFile` falls back to `$LogFilePath` only when it has a value
- verify logger behavior with a new test
- ensure PXE logging test asserts the log file exists

## Testing
- `pwsh -NoLogo -NoProfile -File run_tests.ps1` *(fails: RunnerScripts.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_6847864e6f1c8331956c6f0da09795ac