### PR TITLE
Fix Write-CustomLog mocks

### DIFF
--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -4,6 +4,7 @@ Describe '0104_Install-CA script' {
     }
 
     It 'invokes CA installation when InstallCA is true' {
+        . (Join-Path $PSScriptRoot '..\runner_utility_scripts\Logger.ps1')
         $config = [pscustomobject]@{
             InstallCA = $true
             CertificateAuthority = @{ CommonName = 'TestCA'; ValidityYears = 1 }
@@ -21,6 +22,7 @@ Describe '0104_Install-CA script' {
     }
 
     It 'skips CA installation when InstallCA is false' {
+        . (Join-Path $PSScriptRoot '..\runner_utility_scripts\Logger.ps1')
         $config = [pscustomobject]@{
             InstallCA = $false
             CertificateAuthority = @{ CommonName = 'TestCA'; ValidityYears = 1 }

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -1,5 +1,6 @@
 Describe 'Prepare-HyperVProvider path restoration' {
     It 'restores location after execution' {
+        . (Join-Path $PSScriptRoot '..\runner_utility_scripts\Logger.ps1')
         $script:scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0010_Prepare-HyperVProvider.ps1'
         $config = [pscustomobject]@{
             PrepareHyperVHost = $true
@@ -39,6 +40,7 @@ Describe 'Prepare-HyperVProvider path restoration' {
 
 Describe 'Prepare-HyperVProvider certificate handling' {
     It 'creates PEM files and updates providers.tf' {
+        . (Join-Path $PSScriptRoot '..\runner_utility_scripts\Logger.ps1')
         $script:scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0010_Prepare-HyperVProvider.ps1'
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $tempDir

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -110,6 +110,7 @@ Describe '0001_Reset-Git' {
 
     Context 'Logging' {
         It 'logs a success message when clone succeeds' {
+            . (Join-Path $PSScriptRoot '..\runner_utility_scripts\Logger.ps1')
             $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid())
 
             $config = [pscustomobject]@{


### PR DESCRIPTION
## Summary
- dot-source Logger.ps1 before mocking Write-CustomLog
- verify that Pester runs without command-not-found errors

## Testing
- `pwsh -NoLogo -NoProfile -Command ". ./runner_utility_scripts/Logger.ps1; Invoke-Pester"` *(fails: Convert-CerToPem not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478648fba88331bffe6a854c5b636b