### PR TITLE
Fix NodeScripts path resolution

### DIFF
--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -1,12 +1,18 @@
 Describe 'Node installation scripts' {
     $scriptRoot = Join-Path $PSScriptRoot '..' 'runner_scripts'
-    $core = Join-Path $scriptRoot '0201_Install-NodeCore.ps1'
-    $global = Join-Path $scriptRoot '0202_Install-NodeGlobalPackages.ps1'
-    $npm = Join-Path $scriptRoot '0203_Install-npm.ps1'
+    $core = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0201_Install-NodeCore.ps1')).Path
+    $global = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0202_Install-NodeGlobalPackages.ps1')).Path
+    $npm = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0203_Install-npm.ps1')).Path
 
     BeforeAll {
         $env:TEMP = Join-Path ([System.IO.Path]::GetTempPath()) 'pester-temp'
         New-Item -ItemType Directory -Path $env:TEMP -Force | Out-Null
+    }
+
+    It 'resolves script paths from the tests directory' {
+        Test-Path $core | Should -BeTrue
+        Test-Path $global | Should -BeTrue
+        Test-Path $npm   | Should -BeTrue
     }
 
     It 'uses Node_Dependencies.Node.InstallerUrl when installing Node' {
@@ -15,7 +21,7 @@ Describe 'Node installation scripts' {
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command { @{Name='node'} } -ParameterFilter { $Name -eq 'node' }
-        . (Resolve-Path $core)
+        . (Resolve-Path -ErrorAction Stop $core)
         Install-NodeCore -Config $config
         Assert-MockCalled Invoke-WebRequest -ParameterFilter { $Uri -eq 'http://example.com/node.msi' } -Times 1
     }
@@ -26,7 +32,7 @@ Describe 'Node installation scripts' {
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command {}
-        . (Resolve-Path $core)
+        . (Resolve-Path -ErrorAction Stop $core)
         Install-NodeCore -Config $config
         Assert-MockNotCalled Invoke-WebRequest
         Assert-MockNotCalled Start-Process
@@ -41,7 +47,7 @@ Describe 'Node installation scripts' {
             $null = $testArgs
         }
         Mock npm {}
-        . (Resolve-Path $global)
+        . (Resolve-Path -ErrorAction Stop $global)
         Install-NodeGlobalPackages -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','nodemon') } -Times 1
@@ -49,7 +55,7 @@ Describe 'Node installation scripts' {
     }
 
     It 'honours -WhatIf for Install-GlobalPackage' {
-        . (Resolve-Path $global)
+        . (Resolve-Path -ErrorAction Stop $global)
         Install-NodeGlobalPackages -Config @{ Node_Dependencies = @{ InstallYarn=$false; InstallVite=$false; InstallNodemon=$false } }
         function npm { param([string[]]$testArgs) }
         Mock npm {}
@@ -67,7 +73,7 @@ Describe 'Node installation scripts' {
             $null = $testArgs
         }
         Mock npm {}
-        . (Resolve-Path $npm)
+        . (Resolve-Path -ErrorAction Stop $npm)
         Install-NpmDependencies -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs[0] -eq 'install' } -Times 1
         Remove-Item -Recurse -Force $temp


### PR DESCRIPTION
## Summary
- verify node script paths using `Resolve-Path`
- ensure tests work from `tests/` directory

## Testing
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Path tests'` *(fails: RunnerScripts.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_6847864c3b208331b8dea2c622592ecb