### PR TITLE
Improve CI to include PowerShell 5.1 test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/cache@v4
         with:
-          path: C:\Users\runneradmin\Documents\PowerShell\Modules
+          path: |
+            C:\Users\runneradmin\Documents\WindowsPowerShell\Modules
+            C:\Users\runneradmin\Documents\PowerShell\Modules
           key: windows-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: windows-pwsh-modules-
       - name: Cache PowerShell modules (Posix)
@@ -70,7 +72,9 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/cache@v4
         with:
-          path: C:\Users\runneradmin\Documents\PowerShell\Modules
+          path: |
+            C:\Users\runneradmin\Documents\WindowsPowerShell\Modules
+            C:\Users\runneradmin\Documents\PowerShell\Modules
           key: windows-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: windows-pwsh-modules-
       - name: Cache PowerShell modules (Posix)
@@ -81,11 +85,23 @@ jobs:
           key: ${{ runner.os }}-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pwsh-modules-
       
+      - name: Install Pester (Windows PowerShell)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          Install-Module -Name Pester -Force -Scope CurrentUser
       - name: Install Pester
+        if: runner.os != 'Windows'
         shell: pwsh
         run: |
           Install-Module -Name Pester -Force -Scope CurrentUser
+      - name: Run Pester (Windows PowerShell)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          Invoke-Pester -CI -ErrorAction Stop
       - name: Run Pester
+        if: runner.os != 'Windows'
         shell: pwsh
         run: |
           Invoke-Pester -CI -ErrorAction Stop


### PR DESCRIPTION
## Summary
- cache Windows PowerShell and PowerShell Core modules in CI
- run Pester tests under Windows PowerShell 5.1
- keep cross-platform pwsh run for Linux and macOS

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478650ebec83318e72e5be8bc63931