### PR TITLE
Fix logger test path

### DIFF
--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,4 +1,4 @@
-. ../runner_utility_scripts/Logger.ps1
+. "$PSScriptRoot/../runner_utility_scripts/Logger.ps1"
 
 Describe 'Write-CustomLog' {
     It 'works when LogFilePath variable is not defined' {


### PR DESCRIPTION
## Summary
- use `$PSScriptRoot` when sourcing Logger.ps1 in tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: powershell-yaml module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68478a2f2bd883319b1ff36abc68e7ad