### PR TITLE
Fix NodeScripts test path setup

### DIFF
--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -1,10 +1,10 @@
 Describe 'Node installation scripts' {
-    $scriptRoot = Join-Path $PSScriptRoot '..' 'runner_scripts'
-    $core = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0201_Install-NodeCore.ps1')).Path
-    $global = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0202_Install-NodeGlobalPackages.ps1')).Path
-    $npm = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0203_Install-npm.ps1')).Path
-
     BeforeAll {
+        $scriptRoot = Join-Path $PSScriptRoot '..' 'runner_scripts'
+        $script:core   = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0201_Install-NodeCore.ps1')).Path
+        $script:global = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0202_Install-NodeGlobalPackages.ps1')).Path
+        $script:npm    = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0203_Install-npm.ps1')).Path
+
         $env:TEMP = Join-Path ([System.IO.Path]::GetTempPath()) 'pester-temp'
         New-Item -ItemType Directory -Path $env:TEMP -Force | Out-Null
     }


### PR DESCRIPTION
## Summary
- ensure NodeScripts tests resolve runner script paths inside `BeforeAll`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478a66c4448331a16d3b8e867e4703