### PR TITLE
Fix Logger.Tests path

### DIFF
--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,4 +1,4 @@
-. ../runner_utility_scripts/Logger.ps1
+. (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
 
 Describe 'Write-CustomLog' {
     It 'works when LogFilePath variable is not defined' {


### PR DESCRIPTION
## Summary
- fix import path in Logger.Tests to use `$PSScriptRoot`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Minimal"` *(fails: Could not find Command Get-WindowsFeature)*

------
https://chatgpt.com/codex/tasks/task_e_68478a5cba008331b85e11c4a1b201a7