### PR TITLE
Add top-level Config parameter to Install-CA

### DIFF
--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -1,3 +1,4 @@
+Param([pscustomobject]$Config)
 function Install-CA {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)


### PR DESCRIPTION
## Summary
- add a Config Param statement at the top of `0104_Install-CA.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478addd0148331a820ba87a0802d57