### PR TITLE
Add debug output to runner script tests

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -9,12 +9,18 @@ Describe 'Runner scripts parameter and command checks' {
                 $configParam = if ($ast) {
                     $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.ParameterAst] -and $n.Name.VariablePath.UserPath -eq 'Config' }, $true)
                 } else { @() }
+                if ($configParam.Count -eq 0) {
+                    Write-Host "No Config parameter found in $($script.FullName)"
+                }
                 $configParam.Count | Should -BeGreaterThan 0
             }
 
             It 'contains at least one command invocation' {
                 $ast = [System.Management.Automation.Language.Parser]::ParseFile($script.FullName, [ref]$null, [ref]$null)
                 $commands = if ($ast) { $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) } else { @() }
+                if ($commands.Count -eq 0) {
+                    Write-Host "No commands found in $($script.FullName)"
+                }
                 $commands.Count | Should -BeGreaterThan 0
             }
         }


### PR DESCRIPTION
## Summary
- improve RunnerScripts tests with helpful debug messages

## Testing
- `Invoke-Pester -Path tests/RunnerScripts.Tests.ps1` *(fails: Config parameter or commands not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478ae1b56c833188c69eb060ee3bb2