### PR TITLE
Handle LOCALAPPDATA missing on Linux

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -132,6 +132,10 @@ $normal = "$esc[0m"
 $magenta = "$esc[35m"
 
 $defaultOpenTofuVersion = "latest"
+if (-not $Env:LOCALAPPDATA -and $IsLinux) {
+    # Fallback for Linux where LOCALAPPDATA may not be defined
+    $Env:LOCALAPPDATA = Join-Path $HOME ".local/share"
+}
 if ($allUsers) {
     $defaultInstallPath = Join-Path $Env:Programfiles "OpenTofu"
 } else {

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -1,10 +1,10 @@
 Describe 'Node installation scripts' {
-    $scriptRoot = Join-Path $PSScriptRoot '..' 'runner_scripts'
-    $core = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0201_Install-NodeCore.ps1')).Path
-    $global = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0202_Install-NodeGlobalPackages.ps1')).Path
-    $npm = (Resolve-Path -ErrorAction Stop (Join-Path $scriptRoot '0203_Install-npm.ps1')).Path
-
     BeforeAll {
+        $script:scriptRoot = Join-Path $PSScriptRoot '..' 'runner_scripts'
+        $script:core   = (Resolve-Path -ErrorAction Stop (Join-Path $script:scriptRoot '0201_Install-NodeCore.ps1')).Path
+        $script:global = (Resolve-Path -ErrorAction Stop (Join-Path $script:scriptRoot '0202_Install-NodeGlobalPackages.ps1')).Path
+        $script:npm    = (Resolve-Path -ErrorAction Stop (Join-Path $script:scriptRoot '0203_Install-npm.ps1')).Path
+
         $env:TEMP = Join-Path ([System.IO.Path]::GetTempPath()) 'pester-temp'
         New-Item -ItemType Directory -Path $env:TEMP -Force | Out-Null
     }


### PR DESCRIPTION
## Summary
- fix `OpenTofuInstaller.ps1` to use `$HOME/.local/share` when `LOCALAPPDATA` is missing
- scope test variables correctly in `NodeScripts.Tests.ps1`

## Testing
- `Invoke-Pester` *(fails: `Cannot find an overload for "Add" and the argument count: "1"`)*

------
https://chatgpt.com/codex/tasks/task_e_68478a9fdc4883319296b18fa9e8a81b