### PR TITLE
Fix Logger tests to source Logger.ps1 inside BeforeAll

### DIFF
--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,8 +1,9 @@
 
-. (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
-
 
 Describe 'Write-CustomLog' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+    }
     It 'works when LogFilePath variable is not defined' {
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- ensure Write-CustomLog is loaded for each test run

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478d5232688331aa8eb784d10d0809