### PR TITLE
Fix Write-CustomLog tests

### DIFF
--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,8 +1,8 @@
 
-. (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
-
-
 Describe 'Write-CustomLog' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+    }
     It 'works when LogFilePath variable is not defined' {
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- load Logger.ps1 in a `BeforeAll` block so Write-CustomLog is available for each test

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478d667a788331b72bcb3b21f7d56d