### PR TITLE
Fix NodeScripts Tests path variable typo

### DIFF
--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'Node installation scripts' {
         $global = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0202_Install-NodeGlobalPackages.ps1')).Path
         $npm    = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0203_Install-npm.ps1')).Path
         Test-Path $core | Should -BeTrue
-        Test-Path $globalScript | Should -BeTrue
+        Test-Path $global | Should -BeTrue
         Test-Path $npm   | Should -BeTrue
     }
 


### PR DESCRIPTION
## Summary
- fix `NodeScripts.Tests` to assert on `$global` path instead of undefined `$globalScript`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478d727ac08331b1e5675b66b02751