### PR TITLE
Fix TestDrive contamination in OpenTofuInstaller tests

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,3 +1,10 @@
+BeforeAll {
+    # Ensure no lingering TestDrive from previous test runs
+    if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
+        Remove-PSDrive -Name TestDrive -Force -ErrorAction SilentlyContinue
+    }
+}
+
 Describe 'OpenTofuInstaller logging' {
     It 'creates log files and removes them for elevated unpack' -Skip:($IsLinux -or $IsMacOS) {
         $script:scriptPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\OpenTofuInstaller.ps1'


### PR DESCRIPTION
## Summary
- clear existing `TestDrive` before running OpenTofuInstaller tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: `bash: pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68478d7c0d348331b4481f5a55c4209c