### PR TITLE
Enable Pester on Windows CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,14 +89,7 @@ jobs:
           key: ${{ runner.os }}-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pwsh-modules-
       
-      - name: Install Pester (Windows PowerShell)
-        if: runner.os == 'Windows'
-        shell: powershell
-        run: |
-          Install-Module -Name Pester -Force -Scope CurrentUser
-          
-      - name: Install Pester (pwsh)
-        if: runner.os != 'Windows'
+      - name: Install Pester
         shell: pwsh
         run: |
           Install-Module -Name Pester -Force -Scope CurrentUser
@@ -107,7 +100,6 @@ jobs:
           Install-Module -Name powershell-yaml -Force -Scope CurrentUser
           
       - name: Run Pester
-        if: runner.os != 'Windows'
         shell: pwsh
         run: |
           Invoke-Pester -CI -ErrorAction Stop


### PR DESCRIPTION
## Summary
- install Pester with pwsh across OSes
- run Pester step on Windows as well

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Cannot find an overload for "Add" and the argument count: "1")*

------
https://chatgpt.com/codex/tasks/task_e_68478b0685a083318caefd6cc4f5e9a0