### PR TITLE
Fix temporary log path in tests

### DIFF
--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Write-CustomLog' {
     }
 
     It 'writes to specified log file when provided' {
-        $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid()).ToString() + '.log'
+        $tempFile = (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())) + '.log'
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
         Write-CustomLog 'hello world' -LogFile $tempFile
@@ -27,7 +27,7 @@ Describe 'Write-CustomLog' {
     }
 
     It 'defaults to LogFilePath variable when not provided' {
-        $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid()).ToString() + '.log'
+        $tempFile = (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())) + '.log'
         $script:LogFilePath = $tempFile
         try {
             Write-CustomLog 'variable default works'


### PR DESCRIPTION
## Summary
- fix temporary log file path in `Logger.Tests.ps1`

## Testing
- `Invoke-Pester -Configuration @{ Run = @{ Path = 'tests/Logger.Tests.ps1' } }`

------
https://chatgpt.com/codex/tasks/task_e_68478d4551008331b61f8eb879580896