### PR TITLE
Fix Logger test path and load

### DIFF
--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,8 +1,8 @@
 
-. (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
-
-
 Describe 'Write-CustomLog' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+    }
     It 'works when LogFilePath variable is not defined' {
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
@@ -18,7 +18,7 @@ Describe 'Write-CustomLog' {
     }
 
     It 'writes to specified log file when provided' {
-        $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid()).ToString() + '.log'
+        $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) (([System.Guid]::NewGuid()).ToString() + '.log')
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
         Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
         Write-CustomLog 'hello world' -LogFile $tempFile
@@ -28,7 +28,7 @@ Describe 'Write-CustomLog' {
     }
 
     It 'defaults to LogFilePath variable when not provided' {
-        $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid()).ToString() + '.log'
+        $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) (([System.Guid]::NewGuid()).ToString() + '.log')
         $script:LogFilePath = $tempFile
         try {
             Write-CustomLog 'variable default works'


### PR DESCRIPTION
## Summary
- load Logger utility inside Pester `BeforeAll`
- fix temp file paths in logger tests

## Testing
- `Invoke-Pester tests/Logger.Tests.ps1 -Output Detailed`
- `Invoke-Pester` *(fails: The term 'nonexistent.exe' is not recognized, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68478d58487c833195e3b2b70a9ca112