### PR TITLE
Fix TestDrive conflict in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,4 +102,7 @@ jobs:
       - name: Run Pester
         shell: pwsh
         run: |
+          if (Get-PSDrive TestDrive -ErrorAction SilentlyContinue) {
+            Remove-PSDrive TestDrive -Force -ErrorAction SilentlyContinue
+          }
           Invoke-Pester -CI -ErrorAction Stop


### PR DESCRIPTION
## Summary
- clear lingering TestDrive in the CI workflow before invoking Pester

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI"` *(fails: TestDrive already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68478d3381b08331ad3ee9042d359156