### PR TITLE
Fix NodeScripts test stray line

### DIFF
--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -69,7 +69,6 @@ Describe 'Node installation scripts' {
     
         $global = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0202_Install-NodeGlobalPackages.ps1')).Path
         . $global
-n
 
         Install-NodeGlobalPackages -Config @{ Node_Dependencies = @{ InstallYarn=$false; InstallVite=$false; InstallNodemon=$false } }
         function npm { param([string[]]$testArgs) }


### PR DESCRIPTION
## Summary
- cleanup NodeScripts.Tests

## Testing
- `Invoke-Pester` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684790b08dc8833184a7ae5f42c8432b