### PR TITLE
Fix cosign URL variable

### DIFF
--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -24,12 +24,12 @@ function Install-Cosign {
         try {
             if ($PSCmdlet.ShouldProcess($destination, 'Download cosign')) {
                 # Download the cosign executable
-                Invoke-WebRequest -Uri $config.cosignUrl -OutFile $destination -UseBasicParsing
+                Invoke-WebRequest -Uri $Config.CosignURL -OutFile $destination -UseBasicParsing
                 Write-CustomLog "Cosign downloaded and installed at $destination"
             }
         }
         catch {
-            Write-Error "Failed to download cosign from $cosignUrl. Please check your internet connection and try again."
+            Write-Error "Failed to download cosign from $Config.CosignURL. Please check your internet connection and try again."
             return
         }
 


### PR DESCRIPTION
## Summary
- reference `$Config.CosignURL` consistently when downloading cosign
- update error message to display the config URL

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_684790b4ccdc8331a95a0a311bf44116