### PR TITLE
Fix lingering TestDrive across Pester runs

### DIFF
--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Cleanup-Files script' {
     BeforeAll {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0000_Cleanup-Files.ps1'

--- a/tests/Config-DNS.Tests.ps1
+++ b/tests/Config-DNS.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe '0113_Config-DNS' {
     It 'calls Set-DnsClientServerAddress with value from config' -Skip:($IsLinux -or $IsMacOS) {
         $script = Join-Path $PSScriptRoot '..\runner_scripts\0113_Config-DNS.ps1'

--- a/tests/Config-TrustedHosts.Tests.ps1
+++ b/tests/Config-TrustedHosts.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe '0114_Config-TrustedHosts' {
     It 'calls Start-Process with winrm arguments using config value' -Skip:($IsLinux -or $IsMacOS) {
         $script = Join-Path $PSScriptRoot '..\runner_scripts\0114_Config-TrustedHosts.ps1'

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe '0112_Enable-PXE' {
     BeforeAll {
         $script:scriptPath = Join-Path $PSScriptRoot '..\runner_scripts\0112_Enable-PXE.ps1'

--- a/tests/EscapePathArgument.Tests.ps1
+++ b/tests/EscapePathArgument.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'escapePathArgument' {
     BeforeAll {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Format-Config' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Format-Config.ps1')

--- a/tests/Get-LabConfig.Tests.ps1
+++ b/tests/Get-LabConfig.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Get-LabConfig' {
 
     It 'returns PSCustomObject for valid JSON' {

--- a/tests/Get-Platform.Tests.ps1
+++ b/tests/Get-Platform.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Get-Platform' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')

--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe '0104_Install-CA script' {
     BeforeAll {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0104_Install-CA.ps1'

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe '0203_Install-npm' {
     It 'runs npm install in configured NpmPath' {
         $script = Join-Path $PSScriptRoot '..\runner_scripts\0203_Install-npm.ps1'

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'kicker-bootstrap utilities' {
     It 'defines Write-CustomLog fallback' {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Write-CustomLog' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')

--- a/tests/Menu.Tests.ps1
+++ b/tests/Menu.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Get-MenuSelection' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Menu.ps1')

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Node installation scripts' {
     BeforeAll {
 

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,10 +1,4 @@
-BeforeAll {
-    # Ensure no lingering TestDrive from previous test runs
-    if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
-        Remove-PSDrive -Name TestDrive -Force -ErrorAction SilentlyContinue
-    }
-}
-
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'OpenTofuInstaller logging' {
     It 'creates log files and removes them for elevated unpack' -Skip:($IsLinux -or $IsMacOS) {
         $script:scriptPath = Join-Path $PSScriptRoot '..\runner_utility_scripts\OpenTofuInstaller.ps1'

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Prepare-HyperVProvider path restoration' {
     It 'restores location after execution' {
         . (Join-Path $PSScriptRoot '..\runner_utility_scripts\Logger.ps1')

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 ﻿<#
 .SYNOPSIS
     Tests for runner_scripts\0001_Reset-Git.ps1

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'runner.ps1 configuration' {
     It 'loads default configuration without errors' {
         $modulePath = Join-Path $PSScriptRoot '..\lab_utils\Get-LabConfig.ps1'

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -1,3 +1,4 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 $scriptDir = Join-Path $PSScriptRoot '..' 'runner_scripts'
 $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 

--- a/tests/TestDriveCleanup.ps1
+++ b/tests/TestDriveCleanup.ps1
@@ -1,0 +1,5 @@
+BeforeAll {
+    if (Get-PSDrive TestDrive -ErrorAction SilentlyContinue) {
+        Remove-PSDrive TestDrive -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary
- add common `TestDriveCleanup.ps1`
- call cleanup script from every test
- remove inline cleanup from `OpenTofuInstaller.Tests.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847927c2ed4833186260e3898421ffc