### PR TITLE
Fix hyperv provider step logic

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -259,7 +259,8 @@ if (!(Test-Path $taliesinsDir)) {
     New-Item -ItemType Directory -Force -Path $taliesinsDir | Out-Null
 }
 Push-Location
-Set-Location $taliesinsDir
+try {
+    Set-Location $taliesinsDir
 
 # Define the provider directory/exe
 $providerDir     = Join-Path $taliesinsDir "terraform-provider-hyperv"
@@ -286,9 +287,11 @@ $destinationBinary = Join-Path $hypervProviderDir "terraform-provider-hyperv.exe
 Copy-Item -Path $providerExePath -Destination $destinationBinary -Force -Verbose
 
 Write-CustomLog "Hyper-V provider installed at: $destinationBinary"
-
-# Restore the original directory
-Pop-Location
+}
+finally {
+    # Restore the original directory even if build fails
+    Pop-Location
+}
 
 # ------------------------------
 # 5) Update Provider Config File (providers.tf)


### PR DESCRIPTION
## Summary
- ensure Pop-Location runs via try/finally
- assert certificate helpers are called
- allow tests to use `$TestDrive` for tmp files

## Testing
- `Invoke-Pester -Script tests/PrepareHyperVProvider.Tests.ps1` *(fails: Could not find Command Get-WindowsOptionalFeature)*

------
https://chatgpt.com/codex/tasks/task_e_684792859f608331a175701d6467c341