### PR TITLE
Fix tests to dot-source scripts

### DIFF
--- a/tests/Config-TrustedHosts.Tests.ps1
+++ b/tests/Config-TrustedHosts.Tests.ps1
@@ -8,7 +8,7 @@ Describe '0114_Config-TrustedHosts' {
 
         Mock Start-Process {}
 
-        & $script -Config $config
+        . $script -Config $config
 
         Assert-MockCalled Start-Process -ParameterFilter {
             $FilePath -eq 'cmd.exe' -and $ArgumentList -match 'TrustedHosts=\"host1\"'

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -10,7 +10,7 @@ Describe '0112_Enable-PXE' {
         $logPath = Join-Path $env:TEMP ('pxe-log-' + [System.Guid]::NewGuid().ToString() + '.txt')
         $script:LogFilePath = $logPath
         try {
-            & $script:scriptPath -Config $Config | Out-Null
+            . $script:scriptPath -Config $Config | Out-Null
             (Test-Path $logPath) | Should -BeTrue
             $log = Get-Content -Raw $logPath
             $log | Should -Match 'prov-pxe-67'


### PR DESCRIPTION
## Summary
- dot-source `Config-TrustedHosts` script during tests
- dot-source `Enable-PXE` script during tests

## Testing
- `Invoke-Pester` *(fails: Cannot find an overload for "Add")*

------
https://chatgpt.com/codex/tasks/task_e_6847932a84c08331a265e956ef7adb7f