### PR TITLE
Fix gh path in Reset-Git tests

### DIFF
--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -23,7 +23,7 @@ Describe '0001_Reset-Git' {
                 InfraRepoPath = $tempDir
             }
 
-            Mock Get-Command { @{ Name = 'gh' } } -ParameterFilter { $Name -eq 'gh' }
+            Mock Get-Command { @{ Name = 'gh'; Path = 'gh.exe' } } -ParameterFilter { $Name -eq 'gh' }
             Mock gh { $global:LASTEXITCODE = 0 }
             Mock git {}
 


### PR DESCRIPTION
## Summary
- ensure mocked `Get-Command` for `gh` returns a Path

## Testing
- `Invoke-Pester` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847932deaac8331b089a808869e9afe