### PR TITLE
Fix path expansion in tests

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -54,13 +54,13 @@ exit 0' | Set-Content -Path $dummy
             $fail = Join-Path $scriptsDir '0001_Fail.ps1'
             @"
 Param([PSCustomObject]`$Config)
-'1' | Out-File -FilePath '$out1'
+'1' | Out-File -FilePath "$out1"
 exit 1
 "@ | Set-Content -Path $fail
             $succ = Join-Path $scriptsDir '0002_Success.ps1'
             @"
 Param([PSCustomObject]`$Config)
-'2' | Out-File -FilePath '$out2'
+'2' | Out-File -FilePath "$out2"
 exit 0
 "@ | Set-Content -Path $succ
 
@@ -93,13 +93,13 @@ exit 0
             $clean = Join-Path $scriptsDir '0000_Cleanup.ps1'
             @"
 Param([PSCustomObject]`$Config)
-'c' | Out-File -FilePath '$out1'
+'c' | Out-File -FilePath "$out1"
 exit 0
 "@ | Set-Content -Path $clean
             $other = Join-Path $scriptsDir '0001_Other.ps1'
             @"
 Param([PSCustomObject]`$Config)
-'o' | Out-File -FilePath '$out2'
+'o' | Out-File -FilePath "$out2"
 exit 0
 "@ | Set-Content -Path $other
 
@@ -134,7 +134,7 @@ exit 0
             $scriptFile = Join-Path $scriptsDir '0001_Test.ps1'
             @"
 Param([PSCustomObject]`$Config)
-if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath '$out' } else { Write-Output 'skip' }
+if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath "$out" } else { Write-Output 'skip' }
 "@ | Set-Content -Path $scriptFile
 
             Push-Location $tempDir
@@ -163,7 +163,7 @@ if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath '$out' } else { Wri
             $scriptFile = Join-Path $scriptsDir '0001_NoExit.ps1'
             @"
 Param([PSCustomObject]`$Config)
-'ok' | Out-File -FilePath '$out'
+'ok' | Out-File -FilePath "$out"
 "@ | Set-Content -Path $scriptFile
 
             Push-Location $tempDir


### PR DESCRIPTION
## Summary
- fix runner here-strings to expand `$out*` paths in `Runner.Tests.ps1`

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847933077e88331bf4835d1cf5102f2