### PR TITLE
Fix remote URL detection in bootstrap

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -140,7 +140,7 @@ The script will do the following if you proceed:
 
 $configOption = Read-Host -prompt "`nEnter a remote URL or local path, or leave blank for default."
 
-if ($configOption -ccontains "https://") {
+if ($configOption -match "https://") {
     Invoke-WebRequest -Uri $configOption -OutFile '.\custom-config.json'
     $ConfigFile = (Join-Path $scriptRoot "custom-config.json")
 }

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -13,4 +13,11 @@ Describe 'kicker-bootstrap utilities' {
         $content | Should -Match '& \\.\\\$runnerScriptName'
         $content | Should -Match 'exit \$LASTEXITCODE'
     }
+
+    It 'detects remote config URLs using -match' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
+        $content = Get-Content $scriptPath -Raw
+        $content | Should -Match '\$configOption\s+-match\s+"https://"'
+        $content | Should -Not -Match '-ccontains'
+    }
 }


### PR DESCRIPTION
## Summary
- fix remote URL check in `kicker-bootstrap.ps1`
- test that bootstrap script uses `-match` for remote URLs

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479904d4088331a6efaa69bc13fc59