### PR TITLE
Parse provider version for hyperv install

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -38,6 +38,23 @@ function Convert-PfxToPem {
     }
 }
 
+function Get-HyperVProviderVersion {
+    [CmdletBinding()]
+    param(
+        [string]$MainTfPath = (Join-Path $PSScriptRoot '..\example-infrastructure\main.tf')
+    )
+
+    if (-not (Test-Path $MainTfPath)) {
+        throw "main.tf not found at $MainTfPath"
+    }
+
+    $content = Get-Content -Path $MainTfPath -Raw
+    if ($content -match 'hyperv\s*=\s*\{[^\}]*?version\s*=\s*"([^"]+)"') {
+        return $matches[1]
+    }
+    throw "Failed to parse hyperv provider version from $MainTfPath"
+}
+
 if ($Config.PrepareHyperVHost -eq $true) {
 
 
@@ -275,8 +292,17 @@ Set-Location $providerDir
 Write-CustomLog "Building hyperv provider with go..."
 go build -o terraform-provider-hyperv.exe
 
-# The version in your default main.tf is 1.2.1, so place it accordingly
-$hypervProviderDir = Join-Path $infraRepoPath ".terraform\\providers\\registry.opentofu.org\\taliesins\\hyperv\\1.2.1"
+# Determine provider version from example-infrastructure/main.tf
+try {
+    $providerVersion = Get-HyperVProviderVersion
+    Write-CustomLog "Using Hyper-V provider version $providerVersion"
+} catch {
+    Write-Warning $_
+    $providerVersion = '1.2.1'
+    Write-CustomLog "Falling back to Hyper-V provider version $providerVersion"
+}
+
+$hypervProviderDir = Join-Path $infraRepoPath ".terraform\\providers\\registry.opentofu.org\\taliesins\\hyperv\\$providerVersion"
 if (!(Test-Path $hypervProviderDir)) {
     New-Item -ItemType Directory -Force -Path $hypervProviderDir | Out-Null
 }

--- a/tests/Get-HyperVProviderVersion.Tests.ps1
+++ b/tests/Get-HyperVProviderVersion.Tests.ps1
@@ -1,0 +1,23 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+Describe 'Get-HyperVProviderVersion' {
+    It 'parses version from main.tf' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        . $scriptPath
+        $tf = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid()).ToString() + '.tf'
+        @'
+terraform {
+  required_providers {
+    hyperv = {
+      source  = "taliesins/hyperv"
+      version = "9.9.9"
+    }
+  }
+}
+'@ | Set-Content -Path $tf
+        try {
+            Get-HyperVProviderVersion -MainTfPath $tf | Should -Be '9.9.9'
+        } finally {
+            Remove-Item $tf -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- parse provider version from `example-infrastructure/main.tf`
- install provider under the detected version
- add unit test for the new parser

## Testing
- `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847990dc07c83319ff789bcb7c04d97