### PR TITLE
Add Initialize-OpenTofu tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,4 @@ jobs:
           if (Get-PSDrive TestDrive -ErrorAction SilentlyContinue) {
             Remove-PSDrive TestDrive -Force -ErrorAction SilentlyContinue
           }
-          Invoke-Pester -CI -ErrorAction Stop
+          Invoke-Pester -Path tests -CI -ErrorAction Stop

--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -1,0 +1,95 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+Describe 'Initialize-OpenTofu script' {
+    BeforeAll {
+        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0009_Initialize-OpenTofu.ps1'
+    }
+
+    It 'clones repo when InfraRepoUrl is provided' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid())
+        $config = [pscustomobject]@{
+            InitializeOpenTofu = $true
+            InfraRepoUrl  = 'https://example.com/repo.git'
+            InfraRepoPath = $tempDir
+            HyperV        = @{}
+        }
+
+        Mock Get-Command {
+            param($Name)
+            if ($Name -eq 'gh') { return @{ Name = 'gh' } }
+            if ($Name -eq 'tofu') { return @{ Name = 'tofu' } }
+        }
+        function global:gh {}
+        function global:tofu {}
+        Mock gh { $global:LASTEXITCODE = 0 }
+        Mock git {}
+        Mock tofu {}
+
+        & $script:ScriptPath -Config $config
+
+        Assert-MockCalled gh  -ParameterFilter { $args[0] -eq 'repo' -and $args[1] -eq 'clone' } -Times 1
+        Assert-MockCalled git -Times 0
+        Assert-MockCalled tofu -ParameterFilter { $args[0] -eq 'init' } -Times 1
+
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
+
+    It 'pulls updates when repo already exists' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path (Join-Path $tempDir '.git') -Force
+        $config = [pscustomobject]@{
+            InitializeOpenTofu = $true
+            InfraRepoUrl  = 'https://example.com/repo.git'
+            InfraRepoPath = $tempDir
+            HyperV        = @{}
+        }
+
+        Mock Get-Command {
+            param($Name)
+            if ($Name -eq 'gh') { return @{ Name = 'gh' } }
+            if ($Name -eq 'tofu') { return @{ Name = 'tofu' } }
+        }
+        function global:gh {}
+        function global:tofu {}
+        Mock git {}
+        Mock gh {}
+        Mock tofu {}
+
+        & $script:ScriptPath -Config $config
+
+        Assert-MockCalled git -ParameterFilter { $args[0] -eq 'pull' } -Times 1
+        Assert-MockCalled git -ParameterFilter { $args[0] -eq 'clone' } -Times 0
+        Assert-MockCalled tofu -ParameterFilter { $args[0] -eq 'init' } -Times 1
+
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
+
+    It 'runs tofu init in InfraRepoPath' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid())
+        $config = [pscustomobject]@{
+            InitializeOpenTofu = $true
+            InfraRepoUrl  = 'https://example.com/repo.git'
+            InfraRepoPath = $tempDir
+            HyperV        = @{}
+        }
+
+        $script:pushed = $null
+        Mock Get-Command {
+            param($Name)
+            if ($Name -eq 'gh') { return @{ Name = 'gh' } }
+            if ($Name -eq 'tofu') { return @{ Name = 'tofu' } }
+        }
+        function global:gh {}
+        function global:tofu {}
+        Mock gh { $global:LASTEXITCODE = 0 }
+        Mock git {}
+        Mock tofu {}
+        Mock Push-Location {}
+        Mock Pop-Location {}
+
+        & $script:ScriptPath -Config $config
+
+        Assert-MockCalled tofu -ParameterFilter { $args[0] -eq 'init' } -Times 1
+
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests for Initialize-OpenTofu runner script
- run `Invoke-Pester` on `tests` path in CI

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/Initialize-OpenTofu.Tests.ps1 -CI"`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI"` *(fails: Expected $true, but got $false)*

------
https://chatgpt.com/codex/tasks/task_e_68479915b8008331868f47b459b3cf07