### PR TITLE
Remove stray BOM in Reset-Git.Tests.ps1

### DIFF
--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -1,5 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-﻿<#
+<#
 .SYNOPSIS
     Tests for runner_scripts\0001_Reset-Git.ps1
 


### PR DESCRIPTION
## Summary
- fix stray BOM at start of `tests/Reset-Git.Tests.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479de686e08331b50ed87ae4f14711