### PR TITLE
Fix temp file path in Hyper-V provider version test

### DIFF
--- a/tests/Get-HyperVProviderVersion.Tests.ps1
+++ b/tests/Get-HyperVProviderVersion.Tests.ps1
@@ -3,7 +3,11 @@ Describe 'Get-HyperVProviderVersion' {
     It 'parses version from main.tf' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
-        $tf = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid()).ToString() + '.tf'
+        $tf = [System.IO.Path]::ChangeExtension(
+            [System.IO.Path]::Combine(
+                [System.IO.Path]::GetTempPath(),
+                ([guid]::NewGuid()).ToString()),
+            '.tf')
         @'
 terraform {
   required_providers {


### PR DESCRIPTION
## Summary
- fix temporary .tf file creation in `Get-HyperVProviderVersion` Pester test

## Testing
- `Invoke-Pester -Script tests/Get-HyperVProviderVersion.Tests.ps1` *(fails: Get-HyperVProviderVersion not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68479df580a88331aa55790e524e6920