### PR TITLE
Fix runner invocation call

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -382,7 +382,7 @@ if (!(Test-Path $runnerScriptName)) {
 }
 
 Write-CustomLog "Running $runnerScriptName from $repoPath ..."
-& ".\$runnerScriptName" -ConfigFile $ConfigFile
+& .\$runnerScriptName -ConfigFile $ConfigFile
 
 if ($LASTEXITCODE -ne 0) {
     Write-CustomLog "Runner script failed with exit code $LASTEXITCODE"

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'kicker-bootstrap utilities' {
     It 'invokes runner with call operator and propagates exit code' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
         $content = Get-Content $scriptPath -Raw
-        $content | Should -Match '& \\.\\\$runnerScriptName'
+        $content | Should -Match '& \\.\\\$runnerScriptName -ConfigFile \$ConfigFile'
         $content | Should -Match 'exit \$LASTEXITCODE'
     }
 


### PR DESCRIPTION
## Summary
- remove quoting around runner invocation
- update unit test with exact runner call

## Testing
- `Invoke-Pester` *(fails: cannot find overload for "Add" and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68479e10d1ec83319a4424ab0a380735