### PR TITLE
Organize OpenTofuInstaller specs

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,22 +1,24 @@
-BeforeAll {
-    # Ensure no lingering TestDrive from previous test runs
-    if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
-        Remove-PSDrive -Name TestDrive -Force -ErrorAction SilentlyContinue
+Describe 'OpenTofuInstaller' {
+
+    BeforeAll {
+        # Ensure no lingering TestDrive from previous test runs
+        if (Get-PSDrive -Name TestDrive -ErrorAction SilentlyContinue) {
+            Remove-PSDrive -Name TestDrive -Force -ErrorAction SilentlyContinue
+        }
     }
-}
 
-BeforeEach {
-    $script:temp = Join-Path $TestDrive ([System.Guid]::NewGuid())
-    New-Item -ItemType Directory -Path $script:temp | Out-Null
-}
+    BeforeEach {
+        $script:temp = Join-Path $TestDrive ([System.Guid]::NewGuid())
+        New-Item -ItemType Directory -Path $script:temp | Out-Null
+    }
 
-AfterEach {
-    Remove-Item -Recurse -Force $script:temp -ErrorAction SilentlyContinue
-}
+    AfterEach {
+        Remove-Item -Recurse -Force $script:temp -ErrorAction SilentlyContinue
+    }
 
 
-Describe 'OpenTofuInstaller logging' {
-    It 'creates log files and removes them for elevated unpack' -Skip:($IsLinux -or $IsMacOS) {
+    Describe 'logging' {
+        It 'creates log files and removes them for elevated unpack' -Skip:($IsLinux -or $IsMacOS) {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
         $temp = $script:temp
         $zipPath = Join-Path $temp 'tofu_0.0.0_windows_amd64.zip'
@@ -44,11 +46,11 @@ Describe 'OpenTofuInstaller logging' {
         & $script:scriptPath -installMethod standalone -opentofuVersion '0.0.0' -installPath $temp -allUsers -skipVerify -skipChangePath | Out-Null
         Assert-MockCalled Start-Process -Times 1
         (Test-Path $script:logFile) | Should -BeFalse
+        }
     }
-}
 
-Describe 'OpenTofuInstaller error handling' {
-    It 'returns install failed exit code when cosign is missing' {
+    Describe 'error handling' {
+        It 'returns install failed exit code when cosign is missing' {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
         $arguments = @(
             '-NoLogo',
@@ -61,5 +63,9 @@ Describe 'OpenTofuInstaller error handling' {
         $proc = Start-Process pwsh -ArgumentList $arguments -Wait -PassThru
         $proc.ExitCode | Should -Be 2
 
+        }
+
     }
+
+
 }


### PR DESCRIPTION
## Summary
- wrap installer tests under a new `OpenTofuInstaller` `Describe`
- move logging and error handling describes inside

## Testing
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: Cannot find an overload for `Add`)*

------
https://chatgpt.com/codex/tasks/task_e_68479e33da0483318cabc8f778af6915