### PR TITLE
Fix Windows-specific test skips

### DIFF
--- a/tests/Config-TrustedHosts.Tests.ps1
+++ b/tests/Config-TrustedHosts.Tests.ps1
@@ -1,6 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe '0114_Config-TrustedHosts' {
-    It 'calls Start-Process with winrm arguments using config value' {
+    It 'calls Start-Process with winrm arguments using config value' -Skip:($IsLinux -or $IsMacOS) {
         $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0114_Config-TrustedHosts.ps1'
         $config = [pscustomobject]@{
             SetTrustedHosts = $true

--- a/tests/Get-HyperVProviderVersion.Tests.ps1
+++ b/tests/Get-HyperVProviderVersion.Tests.ps1
@@ -1,6 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Get-HyperVProviderVersion' {
-    It 'parses version from main.tf' {
+    It 'parses version from main.tf' -Skip:($IsLinux -or $IsMacOS) {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
         $tf = [System.IO.Path]::ChangeExtension(

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -1,6 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Prepare-HyperVProvider path restoration' {
-    It 'restores location after execution' {
+    It 'restores location after execution' -Skip:($IsLinux -or $IsMacOS) {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         $config = [pscustomobject]@{
@@ -40,7 +40,7 @@ Describe 'Prepare-HyperVProvider path restoration' {
 }
 
 Describe 'Prepare-HyperVProvider certificate handling' {
-    It 'creates PEM files and updates providers.tf' {
+    It 'creates PEM files and updates providers.tf' -Skip:($IsLinux -or $IsMacOS) {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
@@ -92,7 +92,7 @@ Describe 'Prepare-HyperVProvider certificate handling' {
 }
 
 Describe 'Convert certificate helpers honour -WhatIf' {
-    It 'skips writing files when WhatIf is used' {
+    It 'skips writing files when WhatIf is used' -Skip:($IsLinux -or $IsMacOS) {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath -Config @{ PrepareHyperVHost = $false }
         $cer = Join-Path $TestDrive (([guid]::NewGuid()).ToString() + '.cer')
@@ -104,7 +104,7 @@ Describe 'Convert certificate helpers honour -WhatIf' {
         Remove-Item $cer -ErrorAction SilentlyContinue
     }
 
-    It 'skips writing PFX outputs when WhatIf is used' {
+    It 'skips writing PFX outputs when WhatIf is used' -Skip:($IsLinux -or $IsMacOS) {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath -Config @{ PrepareHyperVHost = $false }
         $pfx = Join-Path $TestDrive (([guid]::NewGuid()).ToString() + '.pfx')


### PR DESCRIPTION
## Summary
- skip Windows-only hyperv tests on macOS/Linux

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6847a2ed2ebc8331bfb088f17e55fa72