### PR TITLE
Mock admin check in OpenTofu installer test

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -31,6 +31,9 @@ Describe 'OpenTofuInstaller' {
             } else { New-Item -ItemType File -Path $OutFile -Force | Out-Null }
         }
         Mock Expand-Archive {}
+        $principal = New-Object psobject
+        $principal | Add-Member -MemberType ScriptMethod -Name IsInRole -Value { param($role) $false }
+        Mock New-Object -ParameterFilter { $TypeName -eq 'Security.Principal.WindowsPrincipal' } -MockWith { $principal }
         $script:logFile = $null
         Mock Start-Process {
             param($FilePath, $ArgumentList, $RedirectStandardOutput, $RedirectStandardError)


### PR DESCRIPTION
## Summary
- ensure the installer test forces the elevation codepath

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a370e7e08331bc712e4b003c4aa1