### PR TITLE
Fix function visibility for HyperV scripts

### DIFF
--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -1,7 +1,4 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
-Invoke-LabStep -Config $Config -Body {
-    Write-CustomLog 'Running 0006_Install-ValidationTools.ps1'
 
 function Install-Cosign {
     [CmdletBinding(SupportsShouldProcess)]
@@ -57,6 +54,10 @@ function Find-Gpg {
         Write-CustomLog "GPG is already installed."
     }
 }
+
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Invoke-LabStep -Config $Config -Body {
+    Write-CustomLog 'Running 0006_Install-ValidationTools.ps1'
 
 # Execute based on provided switches
 if ($Config.InstallCosign -eq $true) {

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -1,7 +1,4 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
-Invoke-LabStep -Config $Config -Body {
-    Write-CustomLog 'Running 0010_Prepare-HyperVProvider.ps1'
 
 function Convert-CerToPem {
     [CmdletBinding(SupportsShouldProcess)]
@@ -54,6 +51,10 @@ function Get-HyperVProviderVersion {
     }
     throw "Failed to parse hyperv provider version from $MainTfPath"
 }
+
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Invoke-LabStep -Config $Config -Body {
+    Write-CustomLog 'Running 0010_Prepare-HyperVProvider.ps1'
 
 if ($Config.PrepareHyperVHost -eq $true) {
 

--- a/runner_scripts/0106_Install-WAC.ps1
+++ b/runner_scripts/0106_Install-WAC.ps1
@@ -1,4 +1,20 @@
 Param([pscustomobject]$Config)
+
+function Get-WacRegistryInstallation {
+    param(
+        [string]$RegistryPath
+    )
+    $items = Get-ChildItem $RegistryPath -ErrorAction SilentlyContinue
+    foreach ($item in $items) {
+        $itemProps = Get-ItemProperty $item.PSPath -ErrorAction SilentlyContinue
+        # Only check if the DisplayName property exists
+        if ($itemProps.PSObject.Properties['DisplayName'] -and $itemProps.DisplayName -like "*Windows Admin Center*") {
+            return $itemProps
+        }
+    }
+    return $null
+}
+
 . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0106_Install-WAC.ps1'
@@ -12,22 +28,6 @@ if ($Config.InstallWAC -eq $true) {
     }
 
     $installPort = $WacConfig.InstallPort
-
-    # Define a helper function to check a registry path for Windows Admin Center
-    function Get-WacRegistryInstallation {
-        param(
-            [string]$RegistryPath
-        )
-        $items = Get-ChildItem $RegistryPath -ErrorAction SilentlyContinue
-        foreach ($item in $items) {
-            $itemProps = Get-ItemProperty $item.PSPath -ErrorAction SilentlyContinue
-            # Only check if the DisplayName property exists
-            if ($itemProps.PSObject.Properties['DisplayName'] -and $itemProps.DisplayName -like "*Windows Admin Center*") {
-                return $itemProps
-            }
-        }
-        return $null
-    }
 
     # Check both standard and Wow6432Node uninstall registry keys for WAC installation
     $wacInstalled = Get-WacRegistryInstallation -RegistryPath "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall"


### PR DESCRIPTION
## Summary
- expose helper functions in `Prepare-HyperVProvider.ps1`
- expose helper functions in `Install-ValidationTools.ps1`
- expose helper functions in `Install-WAC.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a3546b708331a2b81adaa35d1b35