### PR TITLE
Fix gh command usage in Reset-Git script

### DIFF
--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -20,10 +20,9 @@ if (-not (Test-Path (Join-Path $InfraPath '.git'))) {
     Write-CustomLog "Directory is not a git repository. Cloning repository..."
 
     # Prefer GitHub CLI if present; otherwise use plain git
-    $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
-    if ($ghCmd) {
+    if (Get-Command gh -ErrorAction SilentlyContinue) {
         # Ensure the GitHub CLI is authenticated to avoid Git credential prompts
-        & $ghCmd.Path auth status 2>$null
+        gh auth status 2>$null
         if ($LASTEXITCODE -ne 0) {
             Write-Error "GitHub CLI is not authenticated. Run 'gh auth login' and re-run the script."
             return

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -25,6 +25,7 @@ Describe '0001_Reset-Git' {
             }
 
             Mock Get-Command { @{ Name = 'gh'; Path = 'gh.exe' } } -ParameterFilter { $Name -eq 'gh' }
+            function global:gh {}
             Mock gh { $global:LASTEXITCODE = 0 }
             Mock git {}
 
@@ -45,7 +46,10 @@ Describe '0001_Reset-Git' {
             }
 
             Mock Get-Command { $null } -ParameterFilter { $Name -eq 'gh' }
-            Mock git { $global:LASTEXITCODE = 0 }
+            Mock git {
+                $global:LASTEXITCODE = 0
+                New-Item -ItemType Directory -Path (Join-Path $tempDir '.git') -Force | Out-Null
+            }
             Mock gh  {}
 
             & $script:ScriptPath -Config $config
@@ -93,6 +97,7 @@ Describe '0001_Reset-Git' {
             }
 
             Mock Get-Command { @{ Name = 'gh'; Path = 'gh.exe' } } -ParameterFilter { $Name -eq 'gh' }
+            function global:gh {}
             Mock gh {
                 param($Sub, $Action)
                 if ($Sub -eq 'auth' -and $Action -eq 'status') { $global:LASTEXITCODE = 1 }
@@ -120,7 +125,10 @@ Describe '0001_Reset-Git' {
             }
 
             Mock Get-Command { $null } -ParameterFilter { $Name -eq 'gh' }
-            Mock git { $global:LASTEXITCODE = 0 }
+            Mock git {
+                $global:LASTEXITCODE = 0
+                New-Item -ItemType Directory -Path (Join-Path $tempDir '.git') -Force | Out-Null
+            }
             Mock Write-CustomLog {}
 
             & $script:ScriptPath -Config $config


### PR DESCRIPTION
## Summary
- simplify calling GitHub CLI in `0001_Reset-Git.ps1`
- update Reset-Git tests for new call pattern

## Testing
- `Invoke-Pester -Script tests/Reset-Git.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6847a360ebe48331b11745ebe64521b9