### PR TITLE
Fix RunnerScripts tests

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -2,32 +2,42 @@
 $scriptDir = Join-Path $PSScriptRoot '..' 'runner_scripts'
 $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 
+function Parse-ScriptFile {
+    param([string]$Path)
+    $text = Get-Content -Raw -Encoding UTF8 $Path
+    if ($text.Length -gt 0 -and $text[0] -eq [char]0xFEFF) {
+        $text = $text.Substring(1)
+    }
+    [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$null)
+}
+
 Describe 'Runner scripts parameter and command checks' {
 
-    foreach ($file in $scripts) {
-        Context $file.Name {
-            $script:current = $file
-            It 'declares a Config parameter when required' {
-                $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:current.FullName, [ref]$null, [ref]$null)
-                $configParam = if ($ast) {
-                    $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.ParameterAst] -and $n.Name.VariablePath.UserPath -eq 'Config' }, $true)
-                } else { @() }
-                if ($configParam.Count -eq 0) {
-                    Write-Host "No Config parameter found in $($script:current.FullName)"
-                }
-                $configParam.Count | Should -BeGreaterThan 0
-            }
+    $testCases = $scripts | ForEach-Object { @{ file = $_ } }
 
-            It 'contains at least one command invocation' {
-
-                $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:current.FullName, [ref]$null, [ref]$null)
-                $commands = if ($ast) { $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) } else { @() }
-                if ($commands.Count -eq 0) {
-                    Write-Host "No commands found in $($script:current.FullName)"
-                }
-
-                $commands.Count | Should -BeGreaterThan 0
-            }
+    It 'declares a Config parameter when required' -TestCases $testCases {
+        param($file)
+        $text = Get-Content -Raw -Encoding UTF8 $file.FullName
+        if ($text.Length -gt 0 -and $text[0] -eq [char]0xFEFF) { $text = $text.Substring(1) }
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$null)
+        $configParam = if ($ast) {
+            $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.ParameterAst] -and $n.Name.VariablePath.UserPath -eq 'Config' }, $true)
+        } else { @() }
+        if ($configParam.Count -eq 0) {
+            Write-Host "No Config parameter found in $($file.FullName)"
         }
+        $configParam.Count | Should -BeGreaterThan 0
+    }
+
+    It 'contains at least one command invocation' -TestCases $testCases {
+        param($file)
+        $text = Get-Content -Raw -Encoding UTF8 $file.FullName
+        if ($text.Length -gt 0 -and $text[0] -eq [char]0xFEFF) { $text = $text.Substring(1) }
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$null)
+        $commands = if ($ast) { $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) } else { @() }
+        if ($commands.Count -eq 0) {
+            Write-Host "No commands found in $($file.FullName)"
+        }
+        $commands.Count | Should -BeGreaterThan 0
     }
 }


### PR DESCRIPTION
## Summary
- handle potential BOMs when parsing runner scripts
- check each script individually using Pester `-TestCases`

## Testing
- `Invoke-Pester -Path tests/RunnerScripts.Tests.ps1`
- `Invoke-Pester` *(fails: runner.ps1 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847a373b4b883319a8c2d524db1624c