### PR TITLE
Require pwsh for runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@
 ```
 
 
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/main/kicker-bootstrap.ps1' -OutFile '.\kicker-bootstrap.ps1'; .\kicker-bootstrap.ps1"
+pwsh -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/main/kicker-bootstrap.ps1' -OutFile '.\kicker-bootstrap.ps1'; .\kicker-bootstrap.ps1"
+
+**Note:** These scripts require PowerShell 7 or later. Install the latest `pwsh` and use it instead of `powershell.exe`.
 
 ```
 


### PR DESCRIPTION
## Summary
- update usage instructions to run kicker with `pwsh`
- check for PowerShell 7+ in `runner.ps1`
- replace ternary usage with PowerShell 5 friendly `if` statements

## Testing
- `apt-get update`
- `apt-get install -y snapd` *(fails: debconf errors)*
- `snap install powershell --classic` *(fails: can't connect to snapd)*
- `wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb`
- `dpkg -i packages-microsoft-prod.deb`
- `apt-get install -y powershell`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6847a5337aa4833192dc9a9214a55b50