### PR TITLE
fix: close RunnerScripts test block

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -44,3 +44,4 @@ Describe 'Runner scripts parameter and command checks' {
         $commands.Count | Should -BeGreaterThan 0
     }
 }
+}


### PR DESCRIPTION
## Summary
- close the top-level Describe block in RunnerScripts tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a8d311f0833188faab9a56fcfaa0