### PR TITLE
Fix nested Describe in RunnerScripts.Tests

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -14,8 +14,6 @@ function Parse-ScriptFile {
     [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$null)
 }
 
-Describe 'Runner scripts parameter and command checks' {
-
     $testCases = $scripts | ForEach-Object { @{ file = $_ } }
 
     It 'declares a Config parameter when required' -TestCases $testCases {


### PR DESCRIPTION
## Summary
- refactor `RunnerScripts.Tests.ps1` to remove the inner `Describe` block
- keep the `-Skip` condition on the remaining outer block

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Cannot find an overload for "Add" and the argument count: "1")*

------
https://chatgpt.com/codex/tasks/task_e_6847a929190c8331a6cdf3307edc782c