### PR TITLE
Fix trusted hosts Start-Process call

### DIFF
--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -5,7 +5,7 @@ Invoke-LabStep -Config $Config -Body {
 
 if ($Config.SetTrustedHosts -eq $true) {
     
-    Start-Process cmd.exe -ArgumentList "/d /c winrm set winrm/config/client @{TrustedHosts=`"$Config.TrustedHosts`"}"
+    Start-Process -FilePath cmd.exe -ArgumentList "/d /c winrm set winrm/config/client @{TrustedHosts=`"$Config.TrustedHosts`"}"
 
 } else {
     Write-CustomLog "SetTrustedHosts flag is disabled. Skipping TrustedHosts configuration."


### PR DESCRIPTION
## Summary
- call `Start-Process` with `-FilePath` in `0114_Config-TrustedHosts.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/Config-TrustedHosts.Tests.ps1 -Show None"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a981dd148331ad3ae32d59c85b66