### PR TITLE
Fix regex for runner invocation

### DIFF
--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'kicker-bootstrap utilities' -Skip:($IsLinux -or $IsMacOS) {
     It 'invokes runner with call operator and propagates exit code' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
         $content = Get-Content $scriptPath -Raw
-        $content | Should -Match '& \\.\\\$runnerScriptName -ConfigFile \$ConfigFile'
+        $content | Should -Match '& \\.\\\$runnerScriptName -ConfigFile \$ConfigFile\r?\n'
         $content | Should -Match 'exit \$LASTEXITCODE'
     }
 


### PR DESCRIPTION
## Summary
- ensure tests match the runner invocation on Windows

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a983397c8331802b77eba0f0b87f