### PR TITLE
Add cross-platform machine reset script

### DIFF
--- a/runner_scripts/9999_Reset-Machine.ps1
+++ b/runner_scripts/9999_Reset-Machine.ps1
@@ -1,0 +1,17 @@
+Param([pscustomobject]$Config)
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Invoke-LabStep -Config $Config -Body {
+    if (-not (Get-Command Get-Platform -ErrorAction SilentlyContinue)) {
+        . "$PSScriptRoot/../lab_utils/Get-Platform.ps1"
+    }
+    Write-CustomLog 'Running 9999_Reset-Machine.ps1'
+    $platform = Get-Platform
+    Write-CustomLog "Detected platform: $platform"
+    if ($platform -in @('Windows','Linux','MacOS')) {
+        Write-CustomLog 'Initiating system reboot...'
+        Restart-Computer
+    } else {
+        Write-CustomLog 'Unknown platform; cannot reset.'
+        exit 1
+    }
+}

--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -1,0 +1,38 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+Describe 'Reset-Machine script' {
+    BeforeAll {
+        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '9999_Reset-Machine.ps1'
+        . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')
+    }
+
+    BeforeEach {
+        Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
+    }
+
+    It 'calls Restart-Computer on Windows' {
+        Mock Get-Platform { 'Windows' }
+        Mock Restart-Computer {}
+        . $script:ScriptPath -Config ([pscustomobject]@{})
+        Assert-MockCalled Restart-Computer -Times 1
+    }
+
+    It 'calls Restart-Computer on Linux' {
+        Mock Get-Platform { 'Linux' }
+        Mock Restart-Computer {}
+        . $script:ScriptPath -Config ([pscustomobject]@{})
+        Assert-MockCalled Restart-Computer -Times 1
+    }
+
+    It 'returns exit code 1 for unknown platform' {
+        Mock Get-Platform { 'Unknown' }
+        Mock Restart-Computer {}
+        try {
+            . $script:ScriptPath -Config ([pscustomobject]@{})
+            $code = $LASTEXITCODE
+        } catch {
+            $code = 1
+        }
+        $code | Should -Be 1
+        Assert-MockCalled Restart-Computer -Times 0
+    }
+}


### PR DESCRIPTION
## Summary
- add `9999_Reset-Machine.ps1` for performing a system reboot
- include Pester tests covering Windows, Linux, and unknown platforms

## Testing
- `Invoke-Pester -Configuration @{ Run = @{ Exit = $true } }`

------
https://chatgpt.com/codex/tasks/task_e_6847a7ba93c8833196853732980cf96f