### PR TITLE
Fix Pester v5 not called assertions

### DIFF
--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -34,6 +34,6 @@ Describe '0104_Install-CA script' {
         . $scriptPath
         Install-CA -Config $config
 
-        Assert-MockNotCalled Install-AdcsCertificationAuthority
+        Should -Invoke -CommandName Install-AdcsCertificationAuthority -Times 0
     }
 }

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -43,9 +43,9 @@ Describe 'Node installation scripts' {
         . $core
 
         Install-NodeCore -Config $config
-        Assert-MockNotCalled Invoke-WebRequest
-        Assert-MockNotCalled Start-Process
-        Assert-MockNotCalled Remove-Item
+        Should -Invoke -CommandName Invoke-WebRequest -Times 0
+        Should -Invoke -CommandName Start-Process -Times 0
+        Should -Invoke -CommandName Remove-Item -Times 0
     }
 
     It 'installs packages based on Node_Dependencies flags' {
@@ -63,7 +63,7 @@ Describe 'Node installation scripts' {
         Install-NodeGlobalPackages -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','nodemon') } -Times 1
-        Assert-MockNotCalled npm -ParameterFilter { $testArgs -eq @('install','-g','vite') }
+        Should -Invoke -CommandName npm -Times 0 -ParameterFilter { $testArgs -eq @('install','-g','vite') }
     }
 
     It 'honours -WhatIf for Install-GlobalPackage' {
@@ -75,7 +75,7 @@ Describe 'Node installation scripts' {
         function npm { param([string[]]$testArgs) }
         Mock npm {}
         Install-GlobalPackage 'yarn' -WhatIf
-        Assert-MockNotCalled npm
+        Should -Invoke -CommandName npm -Times 0
     }
 
     It 'uses NpmPath from Node_Dependencies when installing project deps' {

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -102,7 +102,7 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($IsLinux -or $IsMac
         'dummy' | Set-Content -Path $cer
         Mock Set-Content {}
         Convert-CerToPem -CerPath $cer -PemPath $pem -WhatIf
-        Assert-MockNotCalled Set-Content
+        Should -Invoke -CommandName Set-Content -Times 0
         Remove-Item $cer -ErrorAction SilentlyContinue
     }
 
@@ -122,7 +122,7 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($IsLinux -or $IsMac
         Mock New-Object { $stub }
         $securePass = (New-Object System.Net.NetworkCredential('', 'pw')).SecurePassword
         Convert-PfxToPem -PfxPath $pfx -Password $securePass -CertPath $cert -KeyPath $key -WhatIf
-        Assert-MockNotCalled Set-Content
+        Should -Invoke -CommandName Set-Content -Times 0
         Remove-Item $pfx -ErrorAction SilentlyContinue
     }
 }


### PR DESCRIPTION
## Summary
- modernize tests to support Pester v5
- use `Should -Invoke -Times 0` for mocked command assertions

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a9857ba483318aa06e17525468ca