### PR TITLE
Fix CA installer cmdlet lookup for mocking

### DIFF
--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -48,6 +48,8 @@ if ($role.Installed) {
 Write-CustomLog "Configuring CA: $CAName with $($ValidityYears) year validity..."
 
 if ($PSCmdlet.ShouldProcess($CAName, 'Configure Standalone Root CA')) {
+    # Resolve the cmdlet after any Pester mocks have been defined
+    Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue | Out-Null
     Install-AdcsCertificationAuthority `
         -CAType StandaloneRootCA `
         -CACommonName $CAName `


### PR DESCRIPTION
## Summary
- ensure `Install-AdcsCertificationAuthority` is resolved after test mocks

## Testing
- `Invoke-Pester -Passthru` *(fails: Missing closing '}' in RunnerScripts.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_6847a9826eb88331a08dfa64f56a06cc