### PR TITLE
Fix closing brace in RunnerScripts.Tests.ps1

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -44,3 +44,4 @@ Describe 'Runner scripts parameter and command checks' {
         $commands.Count | Should -BeGreaterThan 0
     }
 }
+}


### PR DESCRIPTION
## Summary
- fix missing closing brace so the outer `Describe` block ends correctly

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: MethodException due to Add overload)*

------
https://chatgpt.com/codex/tasks/task_e_6847a9869804833183a0c649b0a9aa1f