### PR TITLE
Fix Start-Process branch test

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -522,9 +522,15 @@ function installStandalone() {
 
         $internalZipFile = Join-Path $tempPath $zipName
 
-        if ($allUsers -and (!
-            (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
-        )
+        $hasAdminPrivileges = $false
+        try {
+            $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+            $hasAdminPrivileges = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+        } catch {
+            $hasAdminPrivileges = $false
+        }
+
+        if ($allUsers -and (-not $hasAdminPrivileges))
         {
             # Note on this section: we are requesting elevated privileges via UAC. Unfortunately, this is only possible
             # by launching the current script again as Administrator. This can cause some weird parsing bugs in

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'OpenTofuInstaller' {
 
 
     Describe 'logging' {
-        It 'creates log files and removes them for elevated unpack' -Skip:($IsLinux -or $IsMacOS) {
+        It 'creates log files and removes them for elevated unpack' {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
         $temp = $script:temp
         $zipPath = Join-Path $temp 'tofu_0.0.0_windows_amd64.zip'
@@ -28,32 +28,49 @@ Describe 'OpenTofuInstaller' {
             param([string]$Uri, [string]$OutFile)
             if ($Uri -match 'SHA256SUMS$') {
                 "${hash}  tofu_0.0.0_windows_amd64.zip" | Set-Content $OutFile
-            } else { New-Item -ItemType File -Path $OutFile -Force | Out-Null }
+            } else { 'dummy' | Set-Content $OutFile }
         }
         Mock Expand-Archive {}
         $principal = New-Object psobject
         $principal | Add-Member -MemberType ScriptMethod -Name IsInRole -Value { param($role) $false }
         Mock New-Object -ParameterFilter { $TypeName -eq 'Security.Principal.WindowsPrincipal' } -MockWith { $principal }
         $script:logFile = $null
-        Mock Start-Process {
-            param($FilePath, $ArgumentList, $RedirectStandardOutput, $RedirectStandardError)
+        $Env:Programfiles = $temp
+        $global:startProcessCalled = $false
+        function global:Start-Process {
+            param(
+                $FilePath,
+                $ArgumentList,
+                $RedirectStandardOutput,
+                $RedirectStandardError,
+                $Verb,
+                $WorkingDirectory,
+                [switch]$Wait,
+                [switch]$Passthru
+            )
+            $global:startProcessCalled = $true
             $null = $FilePath
             $null = $ArgumentList
-            $script:logFile = $RedirectStandardOutput
-            New-Item -ItemType File -Path $RedirectStandardOutput -Force | Out-Null
-            New-Item -ItemType File -Path $RedirectStandardError -Force | Out-Null
-            $proc = New-Object psobject -Property @{ ExitCode = 0 }
+            if ($RedirectStandardOutput) {
+                $script:logFile = $RedirectStandardOutput
+                New-Item -ItemType File -Path $RedirectStandardOutput -Force | Out-Null
+            }
+            if ($RedirectStandardError) {
+                New-Item -ItemType File -Path $RedirectStandardError -Force | Out-Null
+            }
+            $proc = [pscustomobject]@{ ExitCode = 0 }
             $proc | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { }
             return $proc
         }
         & $script:scriptPath -installMethod standalone -opentofuVersion '0.0.0' -installPath $temp -allUsers -skipVerify -skipChangePath | Out-Null
-        Assert-MockCalled Start-Process -Times 1
+        $global:startProcessCalled | Should -BeTrue
         (Test-Path $script:logFile) | Should -BeFalse
+        Remove-Item Function:Start-Process -ErrorAction SilentlyContinue
         }
     }
 
     Describe 'error handling' {
-        It 'returns install failed exit code when cosign is missing' -Skip:($IsLinux -or $IsMacOS) {
+        It 'returns install failed exit code when cosign is missing' {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
         $arguments = @(
             '-NoLogo',
@@ -63,7 +80,8 @@ Describe 'OpenTofuInstaller' {
             '-cosignPath', 'nonexistent.exe',
             '-gpgPath', 'nonexistent.exe'
         )
-        $proc = Start-Process pwsh -ArgumentList $arguments -Wait -PassThru
+        $Env:Programfiles = $script:temp
+        $proc = Microsoft.PowerShell.Management\Start-Process pwsh -ArgumentList $arguments -Wait -PassThru
         $proc.ExitCode | Should -Be 2
 
         }


### PR DESCRIPTION
## Summary
- detect admin privileges with a try/catch and flag
- force elevated unpack path in tests and stub Start-Process
- run installer tests on all platforms

## Testing
- `Invoke-Pester -Output Normal -PassThru | Select-Object -ExpandProperty FailedCount`

------
https://chatgpt.com/codex/tasks/task_e_6847a98487288331b31ccd95d5334209