### PR TITLE
Fix runner.ps1 invocation uses pwsh

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -417,7 +417,7 @@ if (!(Test-Path $runnerScriptName)) {
 }
 
 Write-CustomLog "Running $runnerScriptName from $repoPath ..."
-& .\$runnerScriptName -ConfigFile $ConfigFile
+Start-Process -FilePath $pwshPath -ArgumentList @('-NoLogo','-NoProfile','-File',".\$runnerScriptName",'-ConfigFile',$ConfigFile) -Wait -NoNewWindow
 
 if ($LASTEXITCODE -ne 0) {
     Write-CustomLog "Runner script failed with exit code $LASTEXITCODE"

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -10,7 +10,8 @@ Describe 'kicker-bootstrap utilities' -Skip:($IsLinux -or $IsMacOS) {
     It 'invokes runner with call operator and propagates exit code' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
         $content = Get-Content $scriptPath -Raw
-        $content | Should -Match '& \\.\\\$runnerScriptName -ConfigFile \$ConfigFile\r?\n'
+        $pattern = 'Start-Process -FilePath $pwshPath -ArgumentList .* -Wait -NoNewWindow'
+        $content | Should -Match $pattern
         $content | Should -Match 'exit \$LASTEXITCODE'
     }
 

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -42,4 +42,3 @@ function Parse-ScriptFile {
         $commands.Count | Should -BeGreaterThan 0
     }
 }
-}


### PR DESCRIPTION
## Summary
- run the runner script using PowerShell 7
- update regex in Kicker-Bootstrap tests
- fix closing brace in RunnerScripts.Tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: Cannot find an overload for "Add" and the argument count: "1".)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed -Path tests/Kicker-Bootstrap.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_6847ab821d648331b49aab9e1926f88b