### PR TITLE
Pin Pester version only for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,14 @@ jobs:
           key: ${{ runner.os }}-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pwsh-modules-
       
+      - name: Install Pester (macOS)
+        if: runner.os == 'macOS'
+        shell: pwsh
+        run: |
+          Install-Module -Name Pester -RequiredVersion 5.6.1 -Force -Scope CurrentUser
+
       - name: Install Pester
+        if: runner.os != 'macOS'
         shell: pwsh
         run: |
           Install-Module -Name Pester -Force -Scope CurrentUser


### PR DESCRIPTION
## Summary
- only pin Pester 5.6.1 on `macos-latest` runners

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847aa7949408331b349939e7bb96143