### PR TITLE
Handle admin check on non-Windows

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -523,47 +523,53 @@ function installStandalone() {
         $internalZipFile = Join-Path $tempPath $zipName
 
         $hasAdminPrivileges = $false
-        try {
-            $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-            $hasAdminPrivileges = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-        } catch {
+        if ($IsWindows) {
+            try {
+                $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+                $hasAdminPrivileges = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+            } catch {
+                logWarning "Could not determine admin privileges: $_"
+                $hasAdminPrivileges = $false
+            }
+        } else {
+            # On Linux and macOS there is no built-in equivalent of Start-Process -Verb RunAs.
+            # We therefore skip privilege detection/escalation and continue with current permissions.
             $hasAdminPrivileges = $false
         }
 
         if ($allUsers -and (-not $hasAdminPrivileges))
         {
-            # Note on this section: we are requesting elevated privileges via UAC. Unfortunately, this is only possible
-            # by launching the current script again as Administrator. This can cause some weird parsing bugs in
-            # conjunction with Start-Process and the "powershell" command. (The parameter separation disappears.)
-            # Also note that when using Start-Process with RunAs, it is not possible to pass environment variables.
-            # (The documentation is lying!)
-            #
-            # TL;DR: Make sure to MANUALLY test privilege elevation if you change this as we can't test UAC in CI! Make
-            # sure to test with paths containing spaces too! Did I mention to test this? Test it. I'm serious.
+            if ($IsWindows) {
+                # On Windows we can request elevated privileges via UAC by relaunching the script.
+                # Make sure to manually test this flow, especially with paths containing spaces.
 
-            logInfo "Unpacking with elevated privileges..."
-            $logDir = tempdir
-            $outLog = Join-Path $logDir 'stdout.log'
-            $errLog = Join-Path $logDir 'stderr.log'
-            $argList = @("-NonInteractive", "-File", ($scriptCommand | escapePathArgument), "-internalContinue", "-allUsers", "-installMethod", "standalone", "-installPath", ($installPath | escapePathArgument), "-internalZipFile", ($internalZipFile | escapePathArgument))
-            if ($skipChangePath)
-            {
-                $argList += "-skipChangePath"
-            }
-            $subprocess = Start-Process `
-                -Verb RunAs `
-                -WorkingDirectory (Get-Location) `
-                -Wait `
-                -Passthru `
-                -FilePath 'powershell' `
-                -ArgumentList $argList `
-                -RedirectStandardOutput $outLog `
-                -RedirectStandardError $errLog
-            $subprocess.WaitForExit()
-            if (Test-Path $outLog) { Get-Content $outLog }
-            if (Test-Path $errLog) { Get-Content $errLog }
-            if ($subprocess.ExitCode -ne 0) {
-                throw [InstallFailedException]::new("Unpack failed. (Exit code ${subprocess.ExitCode})")
+                logInfo "Unpacking with elevated privileges..."
+                $logDir = tempdir
+                $outLog = Join-Path $logDir 'stdout.log'
+                $errLog = Join-Path $logDir 'stderr.log'
+                $argList = @("-NonInteractive", "-File", ($scriptCommand | escapePathArgument), "-internalContinue", "-allUsers", "-installMethod", "standalone", "-installPath", ($installPath | escapePathArgument), "-internalZipFile", ($internalZipFile | escapePathArgument))
+                if ($skipChangePath)
+                {
+                    $argList += "-skipChangePath"
+                }
+                $subprocess = Start-Process `
+                    -Verb RunAs `
+                    -WorkingDirectory (Get-Location) `
+                    -Wait `
+                    -Passthru `
+                    -FilePath 'powershell' `
+                    -ArgumentList $argList `
+                    -RedirectStandardOutput $outLog `
+                    -RedirectStandardError $errLog
+                $subprocess.WaitForExit()
+                if (Test-Path $outLog) { Get-Content $outLog }
+                if (Test-Path $errLog) { Get-Content $errLog }
+                if ($subprocess.ExitCode -ne 0) {
+                    throw [InstallFailedException]::new("Unpack failed. (Exit code ${subprocess.ExitCode})")
+                }
+            } else {
+                logWarning "-allUsers specified but privilege escalation is not supported on this platform. Continuing with current privileges."
+                unpackStandalone
             }
         }
         else

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -63,7 +63,12 @@ Describe 'OpenTofuInstaller' {
             return $proc
         }
         & $script:scriptPath -installMethod standalone -opentofuVersion '0.0.0' -installPath $temp -allUsers -skipVerify -skipChangePath | Out-Null
-        $global:startProcessCalled | Should -BeTrue
+        if ($IsWindows) {
+            $global:startProcessCalled | Should -BeTrue
+        } else {
+            # Privilege escalation is skipped on non-Windows platforms.
+            $global:startProcessCalled | Should -BeFalse
+        }
         (Test-Path $script:logFile) | Should -BeFalse
         Remove-Item Function:Start-Process -ErrorAction SilentlyContinue
         }


### PR DESCRIPTION
## Summary
- skip WindowsIdentity privilege check on Linux/macOS and warn instead
- avoid `Start-Process -Verb RunAs` on non-Windows
- update tests for cross-platform behaviour

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b72dea0c833198f69a4c176191bb