### PR TITLE
Adjust OpenTofu installer tests for cross-platform

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'OpenTofuInstaller' {
     }
 
 
-    Describe 'logging' {
+    Describe 'logging' -Skip:($IsLinux -or $IsMacOS) {
         It 'creates log files and removes them for elevated unpack' {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
         $temp = $script:temp


### PR DESCRIPTION
## Summary
- disable logging tests on Linux and macOS

## Testing
- `Invoke-Pester` *(fails: powershell-yaml module missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847b72acdc48331a3eb00eadeb19959