### PR TITLE
Fix log cleanup

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -591,7 +591,7 @@ function installStandalone() {
                 throw
             }
         }
-        if ($logDir) {
+        if ($logDir -and (Test-Path $logDir)) {
             try { Remove-Item -Force -Recurse $logDir }
             catch {
                 $msg = $_.ToString()


### PR DESCRIPTION
## Summary
- remove OpenTofu installer log directory only if it exists
- test cleanup handles missing log directory

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -PassThru"` *(fails: System.Management.Automation.MethodException)*

------
https://chatgpt.com/codex/tasks/task_e_6847b732954c8331b222f919a0ccd3b8