### PR TITLE
Fix macOS installer path handling

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -132,14 +132,23 @@ $normal = "$esc[0m"
 $magenta = "$esc[35m"
 
 $defaultOpenTofuVersion = "latest"
-if (-not $Env:LOCALAPPDATA -and $IsLinux) {
-    # Fallback for Linux where LOCALAPPDATA may not be defined
-    $Env:LOCALAPPDATA = Join-Path $HOME ".local/share"
+# Provide cross-platform defaults when key environment variables are missing
+if (-not $Env:LOCALAPPDATA) {
+    if ($IsLinux) {
+        $Env:LOCALAPPDATA = Join-Path $HOME '.local/share'
+    } elseif ($IsMacOS) {
+        $Env:LOCALAPPDATA = Join-Path $HOME 'Library/Application Support'
+    }
+}
+if ($allUsers -and -not $Env:Programfiles) {
+    if ($IsMacOS -or $IsLinux) {
+        $Env:Programfiles = '/usr/local'
+    }
 }
 if ($allUsers) {
-    $defaultInstallPath = Join-Path $Env:Programfiles "OpenTofu"
+    $defaultInstallPath = Join-Path $Env:Programfiles 'OpenTofu'
 } else {
-    $defaultInstallPath = Join-Path (Join-Path $Env:LOCALAPPDATA "Programs") "OpenTofu"
+    $defaultInstallPath = Join-Path (Join-Path $Env:LOCALAPPDATA 'Programs') 'OpenTofu'
 }
 $defaultCosignPath = "cosign.exe"
 $defaultCosignOidcIssuer = "https://token.actions.githubusercontent.com"

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -84,9 +84,17 @@ Describe 'OpenTofuInstaller' {
         $proc = Microsoft.PowerShell.Management\Start-Process pwsh -ArgumentList $arguments -Wait -PassThru
         $proc.ExitCode | Should -Be 2
 
-        }
-
     }
 
+    Describe 'macOS defaults' {
+        It 'allows -allUsers when Programfiles is missing' -Skip:(-not $IsMacOS) {
+            $scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+            $zip = Join-Path $script:temp 'dummy.zip'
+            'dummy' | Set-Content $zip
+            Mock Expand-Archive {}
+            $Env:Programfiles = $null
+            { & $scriptPath -installMethod standalone -installPath $script:temp -allUsers -skipVerify -skipChangePath -internalContinue -internalZipFile $zip } | Should -Not -Throw
+        }
+    }
 
 }


### PR DESCRIPTION
## Summary
- handle missing LOCALAPPDATA/Programfiles in `OpenTofuInstaller.ps1`
- compute default install path after fallbacks
- test macOS installer scenario

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b73efb8c8331a811725bccb8f394