### PR TITLE
Add debugging logs for script runner

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -159,8 +159,11 @@ function Invoke-Scripts {
 
     if (-not $ScriptsToRun) { Write-CustomLog "No scripts selected."; return $true }
 
+    $names = $ScriptsToRun | ForEach-Object { $_.Name }
+    Write-CustomLog "Selected script order: $($names -join ', ')"
     Write-CustomLog "`n==== Executing selected scripts ===="
     $failed = @()
+    $results = @{}
     foreach ($s in $ScriptsToRun) {
         Write-CustomLog "`n--- Running: $($s.Name) ---"
         try {
@@ -180,6 +183,7 @@ function Invoke-Scripts {
             if ($cmd -and $cmd.Parameters.ContainsKey('Config')) { & $scriptPath -Config $Config }
             else                                               { & $scriptPath }
 
+            $results[$s.Name] = $LASTEXITCODE
             if ($LASTEXITCODE) {
                 Write-CustomLog "ERROR: $($s.Name) exited with code $LASTEXITCODE."
                 $failed += $s.Name
@@ -194,6 +198,8 @@ function Invoke-Scripts {
     }
 
     $Config | ConvertTo-Json -Depth 5 | Out-File $ConfigFile -Encoding utf8
+    $summary = $results.GetEnumerator() | ForEach-Object { "${($_.Key)}=$($_.Value)" } | Sort-Object | Join-String -Separator ', '
+    Write-CustomLog "Results: $summary"
     Write-CustomLog "`n==== Script run complete ===="
     if ($failed) { Write-CustomLog "Failures: $($failed -join ', ')"; return $false }
     return $true


### PR DESCRIPTION
## Summary
- add logging of selected scripts and exit codes in `runner.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Cannot find an overload for "Add" and the argument count: "1".)*

------
https://chatgpt.com/codex/tasks/task_e_6847b74b05608331aba16694432ddb47