### PR TITLE
Fix OpenTofuInstaller log assertions

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -64,6 +64,7 @@ Describe 'OpenTofuInstaller' {
         }
         & $script:scriptPath -installMethod standalone -opentofuVersion '0.0.0' -installPath $temp -allUsers -skipVerify -skipChangePath | Out-Null
         $global:startProcessCalled | Should -BeTrue
+        $script:logFile | Should -Not -BeNullOrEmpty
         (Test-Path $script:logFile) | Should -BeFalse
         Remove-Item Function:Start-Process -ErrorAction SilentlyContinue
         }


### PR DESCRIPTION
## Summary
- test fix: assert the log path is set before checking removal

## Testing
- `Invoke-Pester -Script tests/OpenTofuInstaller.Tests.ps1` *(fails: Expected a value, but got $null or empty)*

------
https://chatgpt.com/codex/tasks/task_e_6847b7473e148331bea95217770a7329