### PR TITLE
Add configurable OpenTofu version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The runner script can run the following:
 
 0007_Install-Go.ps1 - downloads and installs Go
 
-0008_Install-OpenTofu.ps1 - Downloads and installs opentofu standalone (verified with cosign)
+0008_Install-OpenTofu.ps1 - Downloads and installs opentofu standalone (verified with cosign). The version used comes from `OpenTofuVersion` in `default-config.json` and defaults to `latest`.
 
 0009_Initialize-OpenTofu.ps1 - setups up opentofu and the lab-infra repo in C:\temp\base-infra
 

--- a/config_files/default-config.json
+++ b/config_files/default-config.json
@@ -17,6 +17,7 @@
   "InstallWAC": false,
   "InstallGo": false,
   "InstallOpenTofu": false,
+  "OpenTofuVersion": "latest",
   "InitializeOpenTofu": false,
   "PrepareHyperVHost": false,
   "InstallCA": false,

--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -7,7 +7,8 @@ if ($Config.InstallOpenTofu -eq $true) {
     
     $Cosign = Join-Path $Config.CosignPath "cosign-windows-amd64.exe"
     $installer = Join-Path $PSScriptRoot "..\runner_utility_scripts\OpenTofuInstaller.ps1"
-    & $installer -installMethod standalone -cosignPath $Cosign
+    $openTofuVersion = if ($Config.OpenTofuVersion) { $Config.OpenTofuVersion } else { 'latest' }
+    & $installer -installMethod standalone -cosignPath $Cosign -opentofuVersion $openTofuVersion
 } else {
     Write-CustomLog "InstallOpenTofu flag is disabled. Skipping OpenTofu installation."
 }


### PR DESCRIPTION
## Summary
- allow setting the OpenTofu version via `OpenTofuVersion` in `default-config.json`
- pass this version to `OpenTofuInstaller.ps1`
- note the option in the README

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b812bf9c83319e2a49b5b993c71f