### PR TITLE
Remove Git creds from default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
   2) Checks if command-line Git is installed and in PATH. (requirement)
      - Prompts to install a minimal version if missing.
      - Updates PATH if installed but not found in PATH.
+     - Configure your Git username and email manually with:
+       `git config --global user.name "Your Name"` and
+       `git config --global user.email "you@example.com"`.
   3) Checks if GitHub CLI is installed and in PATH. (requirement)
      - Prompts to installs GitHub CLI if missing.
      - Updates PATH if installed but not found in PATH.

--- a/config_files/default-config.json
+++ b/config_files/default-config.json
@@ -46,8 +46,6 @@
   "WAC": {
     "InstallPort": 443
   },
-  "GitUsername": "",
-  "GitEmail": "",
   "GitHubCLIInstallerUrl": "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_windows_amd64.msi",
   "RepoUrl": "https://github.com/wizzense/opentofu-lab-automation.git",
   "LocalPath": "",


### PR DESCRIPTION
## Summary
- drop `GitUsername` and `GitEmail` from `default-config.json`
- mention manual git config steps in README

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: cannot find module 'powershell-yaml' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847b80dfbe08331a637acffbe6da211