### PR TITLE
Add Docker container support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,12 @@ jobs:
             Remove-PSDrive TestDrive -Force -ErrorAction SilentlyContinue
           }
           Invoke-Pester -Path tests -CI -ErrorAction Stop
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: pester
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -t tofu-lab .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/powershell:latest
+
+RUN apt-get update \ 
+    && apt-get install -y git curl \ 
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \ 
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \ 
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \ 
+    && apt-get update \ 
+    && apt-get install -y gh \ 
+    && apt-get clean \ 
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+ENTRYPOINT ["pwsh", "./kicker-bootstrap.ps1"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ brew install --cask powershell
 pwsh -NoLogo -NoProfile -Command "Invoke-Pester"
 ```
 
+## Docker container
+
+Build and run the automation inside a container:
+
+```bash
+docker build -t tofu-lab .
+docker run --rm -it tofu-lab [-ConfigFile path/to/config.json]
+```
+
 ## Utility scripts
 
 `lab_utils/Get-Platform.ps1` detects the current platform.

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker build -t tofu-lab .
+docker run --rm -it tofu-lab "$@"


### PR DESCRIPTION
## Summary
- containerize the repo with a new `Dockerfile`
- document how to build and run the container
- helper script `run-container.sh`
- CI now builds the Docker image on pushes to main

## Testing
- `Invoke-Pester -Path tests -CI` *(fails: Cannot find an overload for "Add")*

------
https://chatgpt.com/codex/tasks/task_e_6847b8c185bc83319d6271c5093f4cdc