### PR TITLE
Add install-test-deps.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ and prevents Git from prompting for a username like `user@github.com`.
 ## Running tests
 
 PowerShell 7 or later is required to run the Pester suite. Install `pwsh` with
-your platform's package manager and then execute the tests:
+your platform's package manager, install the test dependencies, and then run
+the tests:
 
 ```bash
 # Windows
@@ -260,6 +261,7 @@ sudo apt-get update && sudo apt-get install -y powershell
 # macOS
 brew install --cask powershell
 
+pwsh -NoLogo -NoProfile -File ./install-test-deps.ps1
 pwsh -NoLogo -NoProfile -Command "Invoke-Pester"
 ```
 

--- a/install-test-deps.ps1
+++ b/install-test-deps.ps1
@@ -1,0 +1,55 @@
+function Ensure-PSModule {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [string]$RequiredVersion
+    )
+
+    $module = if ($RequiredVersion) {
+        Get-Module -ListAvailable -Name $Name -ErrorAction SilentlyContinue |
+            Where-Object { $_.Version -eq [version]$RequiredVersion } |
+            Select-Object -First 1
+    } else {
+        Get-Module -ListAvailable -Name $Name -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+    }
+
+    if (-not $module) {
+        Write-Output "Installing $Name..."
+        $params = @{ Name = $Name; Force = $true; Scope = 'CurrentUser' }
+        if ($RequiredVersion) { $params.RequiredVersion = $RequiredVersion }
+        try {
+            Install-Module @params -ErrorAction Stop
+            Write-Output "$Name installed"
+        } catch {
+            Write-Error "Failed to install $Name: $_"
+        }
+    } else {
+        Write-Output "$Name $($module.Version) already installed"
+    }
+}
+
+function Install-TestDependencies {
+    [CmdletBinding()]
+    param()
+
+    Ensure-PSModule -Name Pester
+    Ensure-PSModule -Name PSScriptAnalyzer -RequiredVersion '1.24.0'
+    Ensure-PSModule -Name powershell-yaml
+
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    if ($python) {
+        Write-Output 'Installing ruff via pip...'
+        try {
+            & $python.Path -m pip install --user ruff | Out-Null
+            Write-Output 'ruff installed'
+        } catch {
+            Write-Warning "Failed to install ruff: $_"
+        }
+    } else {
+        Write-Output 'Python not found. Skipping ruff installation.'
+    }
+}
+
+Install-TestDependencies


### PR DESCRIPTION
## Summary
- add cross-platform script for installing PowerShell test modules and ruff
- document running the script before Pester tests

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847bc3425488331b4d0edc20b139e7b