### PR TITLE
Fix runner test logger import

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -14,6 +14,7 @@ Describe 'runner.ps1 script selection' -Skip:($IsLinux -or $IsMacOS) {
         $script:runnerPath = Join-Path $PSScriptRoot '..' 'runner.ps1'
         $modulePath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-LabConfig.ps1'
         . $modulePath
+        . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
     }
 
     It 'runs non-interactively when -Scripts is supplied' {


### PR DESCRIPTION
## Summary
- fix Runner.Tests by sourcing Logger.ps1 before mocking Write-CustomLog

## Testing
- `pwsh -NoLogo -NoProfile -Command "Write-Output 'pwsh available'"` *(fails: command not found)*
- `Invoke-ScriptAnalyzer` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847bde75e648331bda7037e77c80d87