### PR TITLE
Fix Pester mock usage for Hyper-V provider script

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -1,5 +1,6 @@
 Param([pscustomobject]$Config)
 
+if (-not (Get-Command Convert-CerToPem -ErrorAction SilentlyContinue)) {
 function Convert-CerToPem {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -11,7 +12,9 @@ function Convert-CerToPem {
     $b64   = [System.Convert]::ToBase64String($bytes, 'InsertLineBreaks')
     "-----BEGIN CERTIFICATE-----`n$b64`n-----END CERTIFICATE-----" | Set-Content -Path $PemPath
 }
+}
 
+if (-not (Get-Command Convert-PfxToPem -ErrorAction SilentlyContinue)) {
 function Convert-PfxToPem {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -33,6 +36,7 @@ function Convert-PfxToPem {
     if ($PSCmdlet.ShouldProcess($KeyPath, 'Write key PEM')) {
         "-----BEGIN PRIVATE KEY-----`n$keyB64`n-----END PRIVATE KEY-----" | Set-Content -Path $KeyPath
     }
+}
 }
 
 function Get-HyperVProviderVersion {


### PR DESCRIPTION
## Summary
- avoid redefining certificate helper functions in `0010_Prepare-HyperVProvider.ps1`

## Testing
- `Invoke-ScriptAnalyzer` on modified script
- `ruff check .`
- `Invoke-Pester -Output Normal` *(fails: Cannot find an overload for "Add" and the argument count: "1")*

------
https://chatgpt.com/codex/tasks/task_e_6847bd705fb083319ac547ab001fa5b3