### PR TITLE
Fix Set-LabConfig prompt order

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -83,7 +83,7 @@ function Set-LabConfig {
     [CmdletBinding(SupportsShouldProcess)]
     param([hashtable]$ConfigObject)
 
-    $installPrompts = @{
+    $installPrompts = [ordered]@{
         InstallGit      = 'Install Git'
         InstallGo       = 'Install Go'
         InstallOpenTofu = 'Install OpenTofu'

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -319,7 +319,7 @@ Describe 'Set-LabConfig' {
             [CmdletBinding(SupportsShouldProcess)]
             param([hashtable]$ConfigObject)
 
-        $installPrompts = @{ 
+        $installPrompts = [ordered]@{
             InstallGit      = 'Install Git'
             InstallGo       = 'Install Go'
             InstallOpenTofu = 'Install OpenTofu'


### PR DESCRIPTION
## Summary
- preserve prompt order using an ordered hashtable
- update tests to match

## Testing
- `Invoke-ScriptAnalyzer -Path .`
- `ruff check .`
- `Invoke-Pester tests/Runner.Tests.ps1 -Passthru`

------
https://chatgpt.com/codex/tasks/task_e_6847bdf570508331b5ad1a48d5901372