### PR TITLE
Fix test setup for runner.ps1 selection prompt

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -249,6 +249,7 @@ Param([PSCustomObject]`$Config)
             Copy-Item $script:runnerPath -Destination $tempDir
             Copy-Item (Join-Path $PSScriptRoot '..' 'runner_utility_scripts') -Destination $tempDir -Recurse
             Copy-Item (Join-Path $PSScriptRoot '..' 'lab_utils') -Destination $tempDir -Recurse
+            Copy-Item (Join-Path $PSScriptRoot '..' 'config_files') -Destination (Join-Path $tempDir 'config_files') -Recurse
             $scriptsDir = Join-Path $tempDir 'runner_scripts'
             $null = New-Item -ItemType Directory -Path $scriptsDir
             $dummy = Join-Path $scriptsDir '0001_Test.ps1'


### PR DESCRIPTION
## Summary
- ensure `config_files` directory is copied when testing interactive mode

## Testing
- `Invoke-Pester` *(fails: powershell-yaml not installed)*
- `Invoke-ScriptAnalyzer` *(fails: Write-Host usage)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6847bdd8b0c48331be23ad72c884ea82