### PR TITLE
Fix missing brace in OpenTofuInstaller.Tests.ps1

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -136,6 +136,8 @@ Describe 'OpenTofuInstaller' {
         $proc = Microsoft.PowerShell.Management\Start-Process pwsh -ArgumentList $arguments -Wait -PassThru
         $proc.ExitCode | Should -Be 2
 
+        }
+
     }
 
     Describe 'macOS defaults' {


### PR DESCRIPTION
## Summary
- fix missing closing brace in `OpenTofuInstaller.Tests.ps1`

## Testing
- `Invoke-ScriptAnalyzer -Path .`
- `Invoke-Pester -Path tests` *(fails: The term 'nonexistent.exe' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6847be194d2883319b04fb5dcc19c7dd