### PR TITLE
Fix Windows cleanup failure in Runner tests

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -36,7 +36,7 @@ exit 0' | Set-Content -Path $dummy
             & "$tempDir/runner.ps1" -Scripts '0001' -Auto | Out-Null
             Pop-Location
         } finally {
-            Remove-Item -Recurse -Force $tempDir
+            Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         }
     }
 
@@ -59,7 +59,7 @@ exit 0' | Set-Content -Path $dummy
 
             $code | Should -Be 1
         } finally {
-            Remove-Item -Recurse -Force $tempDir
+            Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         }
     }
 
@@ -98,7 +98,7 @@ exit 0
             Test-Path $out2 | Should -BeTrue
             $code | Should -Be 1
         } finally {
-            Remove-Item -Recurse -Force $tempDir
+            Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         }
     }
 
@@ -138,7 +138,7 @@ exit 0
             $code | Should -Be 1
         }
         finally {
-            Remove-Item -Recurse -Force $tempDir
+            Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         }
     }
 
@@ -177,7 +177,7 @@ exit 0
             Test-Path $out2 | Should -BeFalse
             $code | Should -Be 0
         } finally {
-            Remove-Item -Recurse -Force $tempDir
+            Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         }
     }
 
@@ -210,7 +210,7 @@ if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath "$out" } else { Wri
             Test-Path $out | Should -BeTrue
             $updated.RunFoo | Should -BeTrue
         }
-        finally { Remove-Item -Recurse -Force $tempDir }
+        finally { Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue }
     }
 
     It 'reports success when script omits an exit statement' {
@@ -239,7 +239,7 @@ Param([PSCustomObject]`$Config)
             Test-Path $out | Should -BeTrue
             $code | Should -Be 0
         }
-        finally { Remove-Item -Recurse -Force $tempDir }
+        finally { Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue }
     }
 
     It 'prompts for script selection when no -Scripts argument is supplied' -Skip:($IsLinux -or $IsMacOS) {
@@ -269,7 +269,7 @@ exit 0' | Set-Content -Path $dummy
             Pop-Location
             $called | Should -BeGreaterThan 0
         } finally {
-            Remove-Item -Recurse -Force $tempDir
+            Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         }
     }
 
@@ -308,7 +308,7 @@ exit 0
             Assert-MockCalled Write-CustomLog -ParameterFilter { $Message -eq 'No scripts selected.' } -Times 1
         }
         finally {
-            Remove-Item -Recurse -Force $tempDir
+            Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid test failures on Windows by ignoring locked temp directories

## Testing
- `Invoke-Pester -Script tests/Runner.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6847bd7f8fac83319e1296ccdb7f6b65