### PR TITLE
Fix parsing issues in Pester tests

### DIFF
--- a/tests/Get-LabConfig.Tests.ps1
+++ b/tests/Get-LabConfig.Tests.ps1
@@ -28,7 +28,7 @@ Describe 'Get-LabConfig' {
         }
     }
 
-    It 'parses valid YAML' {
+    It 'parses valid YAML' -Skip:(-not (Get-Module -ListAvailable 'powershell-yaml')) {
         $modulePath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-LabConfig.ps1'
         . $modulePath
         $yamlFile = Join-Path $PSScriptRoot 'test.yaml'

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -137,6 +137,7 @@ Describe 'OpenTofuInstaller' {
         $proc.ExitCode | Should -Be 2
 
     }
+    }
 
     Describe 'macOS defaults' {
         It 'allows -allUsers when Programfiles is missing' -Skip:(-not $IsMacOS) {


### PR DESCRIPTION
## Summary
- close `error handling` describe block in `OpenTofuInstaller.Tests.ps1`
- skip YAML test when `powershell-yaml` module missing

## Testing
- `Invoke-Pester` *(fails: Cannot find an overload for "Add" and the argument count: "1"*)

------
https://chatgpt.com/codex/tasks/task_e_6847be0e6b1083319f379d980021ef1f