### PR TITLE
Fix script invocation quoting

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -180,8 +180,8 @@ function Invoke-Scripts {
 
             $cmd = Get-Command -Name $scriptPath -ErrorAction SilentlyContinue
             $global:LASTEXITCODE = 0
-            if ($cmd -and $cmd.Parameters.ContainsKey('Config')) { & $scriptPath -Config $Config }
-            else                                               { & $scriptPath }
+            if ($cmd -and $cmd.Parameters.ContainsKey('Config')) { & "$scriptPath" -Config $Config }
+            else                                               { & "$scriptPath" }
 
             $results[$s.Name] = $LASTEXITCODE
             if ($LASTEXITCODE) {


### PR DESCRIPTION
## Summary
- quote script paths so PowerShell handles directories containing spaces

## Testing
- `Invoke-Pester -Path tests/Runner.Tests.ps1 -PassThru`
- `Invoke-ScriptAnalyzer -Path .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6847bd9e780483318c223c55cadcd978