### PR TITLE
Fix prefix parsing in runner

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -208,7 +208,8 @@ function Invoke-Scripts {
 function Select-Scripts {
     param([string]$Input)
     if ($Input -eq 'all') { return $ScriptFiles }
-    $prefixes = $Input -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -match '^\d{4}$' }
+    $clean    = $Input.Trim()
+    $prefixes = $clean -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -match '^\d{4}$' }
     if (-not $prefixes)   { Write-CustomLog "No valid prefixes."; return @() }
     $matches  = $ScriptFiles | Where-Object { $prefixes -contains $_.Name.Substring(0,4) }
     if (-not $matches)    { Write-CustomLog "No matching scripts."; }


### PR DESCRIPTION
## Summary
- handle stray whitespace in `Select-Scripts`

## Testing
- `Invoke-Pester` *(fails: `ParseException` in OpenTofuInstaller.Tests.ps1)*
- `Invoke-ScriptAnalyzer -Path . -Recurse -ReportSummary`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6847bd8ea00c83319dc6bcd6c88b4ce5