### PR TITLE
Fix cleanup script selection

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -207,12 +207,22 @@ function Invoke-Scripts {
 
 function Select-Scripts {
     param([string]$Input)
+
+    if (-not $Input) { Write-CustomLog 'No script selection provided.'; return @() }
     if ($Input -eq 'all') { return $ScriptFiles }
-    $prefixes = $Input -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -match '^\d{4}$' }
-    if (-not $prefixes)   { Write-CustomLog "No valid prefixes."; return @() }
-    $matches  = $ScriptFiles | Where-Object { $prefixes -contains $_.Name.Substring(0,4) }
-    if (-not $matches)    { Write-CustomLog "No matching scripts."; }
-    return $matches
+
+    $prefixes = $Input -split ',' |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -match '^\d{4}$' }
+
+    if (-not $prefixes) { Write-CustomLog 'No valid prefixes.'; return @() }
+
+    $ordered = foreach ($p in $prefixes) {
+        $ScriptFiles | Where-Object { $_.Name.Substring(0,4) -eq $p } | Select-Object -First 1
+    } | Where-Object { $_ }
+
+    if (-not $ordered) { Write-CustomLog 'No matching scripts.' }
+    return $ordered
 }
 
 # ─── Non-interactive or interactive execution ────────────────────────────────


### PR DESCRIPTION
## Summary
- ensure Select-Scripts handles input robustly and preserves order

## Testing
- `Invoke-Pester -Path tests/Runner.Tests.ps1 -Output Detailed`
- `Invoke-ScriptAnalyzer -Path .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6847bdac2b748331bf69bf1d3e13cfd2