### PR TITLE
Fix runner to execute scripts in current scope

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -180,8 +180,8 @@ function Invoke-Scripts {
 
             $cmd = Get-Command -Name $scriptPath -ErrorAction SilentlyContinue
             $global:LASTEXITCODE = 0
-            if ($cmd -and $cmd.Parameters.ContainsKey('Config')) { & $scriptPath -Config $Config }
-            else                                               { & $scriptPath }
+            if ($cmd -and $cmd.Parameters.ContainsKey('Config')) { . $scriptPath -Config $Config }
+            else                                               { . $scriptPath }
 
             $results[$s.Name] = $LASTEXITCODE
             if ($LASTEXITCODE) {


### PR DESCRIPTION
## Summary
- source scripts instead of executing in a child scope

## Testing
- `Invoke-Pester` *(fails: Cannot find an overload for "Add" and the argument count: "1".)*
- `Invoke-ScriptAnalyzer -Path .` *(fails: The term 'Invoke-ScriptAnalyzer' is not recognized as a name of a cmdlet, function, script file, or executable program.)*

------
https://chatgpt.com/codex/tasks/task_e_6847bdbc7e6c8331b2ca523cf748f28f