### PR TITLE
Fix Pester parse error in OpenTofuInstaller tests

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -138,6 +138,8 @@ Describe 'OpenTofuInstaller' {
 
     }
 
+    }
+
     Describe 'macOS defaults' {
         It 'allows -allUsers when Programfiles is missing' -Skip:(-not $IsMacOS) {
             $scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'


### PR DESCRIPTION
## Summary
- close the `Describe 'error handling'` block in `OpenTofuInstaller.Tests.ps1`

## Testing
- `Invoke-Pester -Path tests -CI` *(fails: Cannot find an overload for "Add" and the argument count: "1")*

------
https://chatgpt.com/codex/tasks/task_e_6847be4f9f788331b9347d6bddeff857