### PR TITLE
Clarify optional YAML module for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,13 @@ brew install --cask powershell
 pwsh -NoLogo -NoProfile -Command "Invoke-Pester"
 ```
 
+The suite includes a YAML parsing test that is skipped unless the
+`powershell-yaml` module is installed. Install it (optionally) with:
+
+```powershell
+Install-Module powershell-yaml -Scope CurrentUser
+```
+
 ## Utility scripts
 
 `lab_utils/Get-Platform.ps1` detects the current platform.


### PR DESCRIPTION
## Summary
- note that `powershell-yaml` is optional but recommended
- include example install command in the README

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c26019208331beef9d9e31961c51