### PR TITLE
Fix Pester install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,17 +99,10 @@ jobs:
           key: ${{ runner.os }}-pwsh-modules-${{ hashFiles('.github/actions/lint/requirements.txt') }}
           restore-keys: ${{ runner.os }}-pwsh-modules-
       
-      - name: Install Pester (macOS)
-        if: runner.os == 'macOS'
+      - name: Install Pester
         shell: pwsh
         run: |
           Install-Module -Name Pester -RequiredVersion 5.6.1 -Force -Scope CurrentUser
-
-      - name: Install Pester
-        if: runner.os != 'macOS'
-        shell: pwsh
-        run: |
-          Install-Module -Name Pester -Force -Scope CurrentUser
           
       - name: Install powershell-yaml
         shell: pwsh


### PR DESCRIPTION
## Summary
- pin Pester 5.6.1 on all platforms by removing the macOS special case

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module Pester; Invoke-Pester -CI"` *(fails: Cannot find an overload for `Add`)*

------
https://chatgpt.com/codex/tasks/task_e_6847c2529ef88331adbfd0c9b5e0810a