### PR TITLE
Fix certificate generation checks

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -140,7 +140,7 @@ $UserInput = Read-Host -Prompt "Enter the password for the Root CA certificate" 
 $rootCaPassword = $UserInput
 $rootCaCertificate = Get-ChildItem cert:\LocalMachine\Root | Where-Object {$_.Subject -eq "CN=$rootCaName"}
 
-if ($rootCaCertificate) {
+if (-not $rootCaCertificate) {
     # Cleanup if present
     Get-ChildItem cert:\LocalMachine\My | Where-Object {$_.subject -eq "CN=$rootCaName"} | Remove-Item -Force -ErrorAction SilentlyContinue
     Remove-Item ".\$rootCaName.cer" -Force -ErrorAction SilentlyContinue
@@ -182,7 +182,7 @@ $UserInput = Read-Host -Prompt "Enter the password for the host." -AsSecureStrin
 $hostPassword = $UserInput
 $hostCertificate = Get-ChildItem cert:\LocalMachine\My | Where-Object {$_.Subject -eq "CN=$hostName"}
 
-if ($hostCertificate) {
+if (-not $hostCertificate) {
     # Cleanup if present
     Get-ChildItem cert:\LocalMachine\My | Where-Object {$_.subject -eq "CN=$hostName"} | Remove-Item -Force -ErrorAction SilentlyContinue
     Remove-Item ".\$hostName.cer" -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- ensure CA and host certificate creation run when certs are absent
- keep PEM conversion after certificate generation

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `ruff .` *(fails: unrecognized subcommand)*

------
https://chatgpt.com/codex/tasks/task_e_6847c31758a48331807bbb7c0bce3d7d