### PR TITLE
Graceful CA install check

### DIFF
--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -49,7 +49,11 @@ Write-CustomLog "Configuring CA: $CAName with $($ValidityYears) year validity...
 
 if ($PSCmdlet.ShouldProcess($CAName, 'Configure Standalone Root CA')) {
     # Resolve the cmdlet after any Pester mocks have been defined
-    Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue | Out-Null
+    $adcsCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
+    if (-not $adcsCmd) {
+        Write-CustomLog 'Install-AdcsCertificationAuthority command not found. Ensure AD CS features are available. Skipping CA installation.'
+        return
+    }
     Install-AdcsCertificationAuthority `
         -CAType StandaloneRootCA `
         -CACommonName $CAName `


### PR DESCRIPTION
## Summary
- check for `Install-AdcsCertificationAuthority` before invoking it

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c37a1f8083318a3bf23dbd001c9d