### PR TITLE
Handle missing CA install cmdlet

### DIFF
--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -28,7 +28,7 @@ if (-not $CAName) {
 $role = Get-WindowsFeature -Name Adcs-Cert-Authority
 if ($role.Installed) {
     Write-CustomLog "Certificate Authority role is already installed. Checking CA configuration..."
-    
+
     # Check if a CA is already configured
     $existingCA = Get-Item -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\CertSvc\Configuration' -ErrorAction SilentlyContinue
     if ($existingCA) {
@@ -49,7 +49,11 @@ Write-CustomLog "Configuring CA: $CAName with $($ValidityYears) year validity...
 
 if ($PSCmdlet.ShouldProcess($CAName, 'Configure Standalone Root CA')) {
     # Resolve the cmdlet after any Pester mocks have been defined
-    Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue | Out-Null
+    $installCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
+    if (-not $installCmd) {
+        Write-CustomLog 'Install-AdcsCertificationAuthority command not found. Ensure AD CS features are available.'
+        return
+    }
     Install-AdcsCertificationAuthority `
         -CAType StandaloneRootCA `
         -CACommonName $CAName `


### PR DESCRIPTION
## Summary
- improve certificate installation script to gracefully handle missing Install-AdcsCertificationAuthority command

## Testing
- `Invoke-Pester` *(fails: MethodException)*
- `Invoke-ScriptAnalyzer -Path runner_scripts/0104_Install-CA.ps1`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6847c396b88c8331b64e59f6a1a68fb0