### PR TITLE
Validate menu module path

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -14,7 +14,12 @@ if ($PSVersionTable.PSVersion.Major -lt 7) {
 . "$PSScriptRoot\runner_utility_scripts\Logger.ps1"
 . "$PSScriptRoot\lab_utils\Get-LabConfig.ps1"
 . "$PSScriptRoot\lab_utils\Format-Config.ps1"
-. "$PSScriptRoot\lab_utils\Menu.ps1"
+$menuPath = Join-Path $PSScriptRoot 'lab_utils' 'Menu.ps1'
+if (-not (Test-Path $menuPath)) {
+    Write-Error "Menu module not found at $menuPath"
+    exit 1
+}
+. $menuPath
 
 # ─── Default log path ─────────────────────────────────────────────────────────
 if (-not (Get-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue) -and


### PR DESCRIPTION
## Summary
- check for `lab_utils/Menu.ps1` before importing

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer` *(fails: `pwsh: command not found`)*
- `Invoke-Pester` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847c31364a483318c2dfadb24902df2