### PR TITLE
Fix Runner tests missing Menu.ps1 import

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -15,6 +15,7 @@ Describe 'runner.ps1 script selection' -Skip:($IsLinux -or $IsMacOS) {
         $modulePath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-LabConfig.ps1'
         . $modulePath
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+        . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Menu.ps1')
     }
 
     It 'runs non-interactively when -Scripts is supplied' {


### PR DESCRIPTION
## Summary
- import `Menu.ps1` in `Runner.Tests.ps1`

## Testing
- `Invoke-ScriptAnalyzer -Path . -Severity Warning,Error`
- `ruff check .`
- `Invoke-Pester -Script tests/Runner.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6847c3fae9308331b3f997548432b7b5