### PR TITLE
Fix Pester test parse error

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -139,9 +139,6 @@ Describe 'OpenTofuInstaller' {
         }
 
     }
-    }
-
-    }
 
     Describe 'macOS defaults' {
         It 'allows -allUsers when Programfiles is missing' -Skip:(-not $IsMacOS) {


### PR DESCRIPTION
## Summary
- remove stray closing braces from `OpenTofuInstaller.Tests.ps1`

## Testing
- `Invoke-ScriptAnalyzer -Path .`
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_6847c35c76108331aceb87916e27e477