### PR TITLE
Fix regex in Kicker-Bootstrap test

### DIFF
--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'kicker-bootstrap utilities' -Skip:($IsLinux -or $IsMacOS) {
     It 'invokes runner with call operator and propagates exit code' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
         $content = Get-Content $scriptPath -Raw
-        $pattern = 'Start-Process -FilePath $pwshPath -ArgumentList .* -Wait -NoNewWindow'
+        $pattern = 'Start-Process -FilePath \$pwshPath -ArgumentList .* -Wait -NoNewWindow'
         $content | Should -Match $pattern
         $content | Should -Match 'exit \$LASTEXITCODE'
     }


### PR DESCRIPTION
## Summary
- fix escaping in `Kicker-Bootstrap.Tests.ps1`

## Testing
- `Invoke-Pester` *(fails: Cannot find an overload for "Add" and the argument count: "1")*

------
https://chatgpt.com/codex/tasks/task_e_6847c3accea883318aff7974bc3d9015