### PR TITLE
Fix runner script selection by avoiding $input conflict

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -212,12 +212,12 @@ function Invoke-Scripts {
 }
 
 function Select-Scripts {
-    param([string]$Input)
+    param([string]$Spec)
 
-    if (-not $Input) { Write-CustomLog 'No script selection provided.'; return @() }
-    if ($Input -eq 'all') { return $ScriptFiles }
+    if (-not $Spec) { Write-CustomLog 'No script selection provided.'; return @() }
+    if ($Spec -eq 'all') { return $ScriptFiles }
 
-    $prefixes = $Input -split ',' |
+    $prefixes = $Spec -split ',' |
         ForEach-Object { $_.Trim() } |
         Where-Object { $_ -match '^\d{4}$' }
 
@@ -238,8 +238,8 @@ function Prompt-Scripts {
 
 # ─── Non-interactive or interactive execution ────────────────────────────────
 if ($Scripts) {
-    if ($Scripts -eq 'all') { $sel = Select-Scripts -Input 'all' }
-    else                    { $sel = Select-Scripts -Input $Scripts }
+    if ($Scripts -eq 'all') { $sel = Select-Scripts -Spec 'all' }
+    else                    { $sel = Select-Scripts -Spec $Scripts }
     if (-not $sel -or $sel.Count -eq 0) { exit 1 }
     if (-not (Invoke-Scripts -ScriptsToRun $sel)) { exit 1 }
     exit 0


### PR DESCRIPTION
## Summary
- fix script selection when `-Scripts` is provided

## Testing
- `Invoke-Pester` *(fails: MethodException)*

------
https://chatgpt.com/codex/tasks/task_e_6847c3d8750483318f491d6f6816f213