### PR TITLE
Fix script path join in runner

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -167,7 +167,7 @@ function Invoke-Scripts {
     foreach ($s in $ScriptsToRun) {
         Write-CustomLog "`n--- Running: $($s.Name) ---"
         try {
-            $scriptPath = "$PSScriptRoot\runner_scripts\$($s.Name)"
+            $scriptPath = Join-Path $PSScriptRoot "runner_scripts" $($s.Name)
             if (-not (Test-Path $scriptPath)) {
                 Write-CustomLog "ERROR: Script not found at $scriptPath"
                 $failed += $s.Name


### PR DESCRIPTION
## Summary
- fix path joining for runner script execution

## Testing
- `Invoke-ScriptAnalyzer -Path .`
- `ruff check .`
- `Invoke-Pester -Script ./tests/Runner.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6847c3df318c83318aacea97f910afaa