### PR TITLE
Fix Install-CA test

### DIFF
--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -14,6 +14,7 @@ Describe '0104_Install-CA script' {
         Mock Get-WindowsFeature { @{ Installed = $false } } -ParameterFilter { $Name -eq 'Adcs-Cert-Authority' }
         Mock Install-WindowsFeature {}
         Mock Get-Item { $null }
+        function global:Install-AdcsCertificationAuthority {}
         Mock Install-AdcsCertificationAuthority {}
 
         . $scriptPath
@@ -29,6 +30,7 @@ Describe '0104_Install-CA script' {
             CertificateAuthority = @{ CommonName = 'TestCA'; ValidityYears = 1 }
         }
         Mock Write-CustomLog {}
+        function global:Install-AdcsCertificationAuthority {}
         Mock Install-AdcsCertificationAuthority {}
 
         . $scriptPath


### PR DESCRIPTION
## Summary
- stub `Install-AdcsCertificationAuthority` as a global function in Install-CA Pester tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'labctl')*
- `Invoke-Pester` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847c8d1698083318a562790e00c6116