### PR TITLE
Fix installer exit code

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -720,3 +720,5 @@ try
     logError($_.ToString())
     exit $exitCodeInstallFailed
 }
+
+exit $exitCodeOK


### PR DESCRIPTION
## Summary
- fix exit code after running OpenTofuInstaller

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c8fa070c833192a4dde6838c0697