### PR TITLE
Fix quoting in Config-TrustedHosts

### DIFF
--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -5,7 +5,7 @@ Invoke-LabStep -Config $Config -Body {
 
 if ($Config.SetTrustedHosts -eq $true) {
     
-    Start-Process -FilePath cmd.exe -ArgumentList "/d /c winrm set winrm/config/client @{TrustedHosts=`"$Config.TrustedHosts`"}"
+    Start-Process -FilePath cmd.exe -ArgumentList "/d /c winrm set winrm/config/client @{TrustedHosts=`"$Config.TrustedHosts`"}
 
 } else {
     Write-CustomLog "SetTrustedHosts flag is disabled. Skipping TrustedHosts configuration."


### PR DESCRIPTION
## Summary
- remove stray quote when setting TrustedHosts

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command Invoke-ScriptAnalyzer` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester tests/Config-TrustedHosts.Tests.ps1 -Show None` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c96def7883319a265fe024f16868