### PR TITLE
Fix secure input mocks in tests

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -37,7 +37,7 @@ Describe 'Prepare-HyperVProvider path restoration' -Skip:($IsLinux -or $IsMacOS)
         Mock git {}
         Mock go {}
         Mock Copy-Item {}
-        Mock Read-Host { '' }
+        Mock Read-Host { ConvertTo-SecureString '' -AsPlainText -Force }
         Mock Resolve-Path { param([string]$Path) @{ Path = $Path } }
 
         . $script:scriptPath -Config $config
@@ -74,7 +74,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         Mock Convert-CerToPem -MockWith { & $script:origConvertCerToPem @PSBoundParameters }
         Mock Convert-PfxToPem -MockWith { & $script:origConvertPfxToPem @PSBoundParameters }
         Mock Copy-Item {}
-        Mock Read-Host { 'pw' }
+        Mock Read-Host { ConvertTo-SecureString 'pw' -AsPlainText -Force }
 
         $providerFile = Join-Path $tempDir 'providers.tf'
         @(


### PR DESCRIPTION
## Summary
- update `PrepareHyperVProvider.Tests.ps1` to return SecureStrings from `Read-Host`

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ca28420c833185af5c8b9026e997