### PR TITLE
Refactor admin check

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -303,6 +303,28 @@ function unpackStandalone() {
     }
 }
 
+# Helper to check whether the current user has administrative privileges.
+# On Windows the Administrators group membership is queried. Other
+# platforms always return `$false` as privilege escalation is not
+# supported.
+function Test-IsAdmin {
+    $hasAdmin = $false
+    if ($IsWindows) {
+        try {
+            $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+            $hasAdmin = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+        } catch {
+            logWarning "Could not determine admin privileges: $_"
+            $hasAdmin = $false
+        }
+    } else {
+        # On Linux and macOS there is no built-in equivalent of Start-Process -Verb RunAs.
+        # We therefore skip privilege detection/escalation and continue with current permissions.
+        $hasAdmin = $false
+    }
+    return $hasAdmin
+}
+
 function installStandalone() {
     if ($internalContinue) {
         logInfo "Continuing standalone installation..."
@@ -531,20 +553,7 @@ function installStandalone() {
 
         $internalZipFile = Join-Path $tempPath $zipName
 
-        $hasAdminPrivileges = $false
-        if ($IsWindows) {
-            try {
-                $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-                $hasAdminPrivileges = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-            } catch {
-                logWarning "Could not determine admin privileges: $_"
-                $hasAdminPrivileges = $false
-            }
-        } else {
-            # On Linux and macOS there is no built-in equivalent of Start-Process -Verb RunAs.
-            # We therefore skip privilege detection/escalation and continue with current permissions.
-            $hasAdminPrivileges = $false
-        }
+        $hasAdminPrivileges = Test-IsAdmin
 
         if ($allUsers -and (-not $hasAdminPrivileges))
         {

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -31,9 +31,7 @@ Describe 'OpenTofuInstaller' {
             } else { 'dummy' | Set-Content $OutFile }
         }
         Mock Expand-Archive {}
-        $principal = New-Object psobject
-        $principal | Add-Member -MemberType ScriptMethod -Name IsInRole -Value { param($role) $false }
-        Mock New-Object -ParameterFilter { $TypeName -eq 'Security.Principal.WindowsPrincipal' } -MockWith { $principal }
+        Mock Test-IsAdmin { $false }
         $script:logFile = $null
         $Env:Programfiles = $temp
         $global:startProcessCalled = $false
@@ -91,9 +89,7 @@ Describe 'OpenTofuInstaller' {
             } else { 'dummy' | Set-Content $OutFile }
         }
         Mock Expand-Archive {}
-        $principal = New-Object psobject
-        $principal | Add-Member -MemberType ScriptMethod -Name IsInRole -Value { param($role) $false }
-        Mock New-Object -ParameterFilter { $TypeName -eq 'Security.Principal.WindowsPrincipal' } -MockWith { $principal }
+        Mock Test-IsAdmin { $false }
         $Env:Programfiles = $temp
         $global:startProcessCalled = $false
         function global:Start-Process {


### PR DESCRIPTION
## Summary
- create a helper function `Test-IsAdmin` to check for administrator rights
- call `Test-IsAdmin` inside `installStandalone`
- mock the new helper in tests

## Testing
- `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ca31812c833195434e5c4db8d8e5