### PR TITLE
Capture runner exit code

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -436,12 +436,12 @@ Write-CustomLog "Running $runnerScriptName from $repoPath ..."
 
 $args = @('-NoLogo','-NoProfile','-File',".\$runnerScriptName",'-ConfigFile',$ConfigFile)
 if ($Quiet) { $args += '-Quiet' }
-Start-Process -FilePath $pwshPath -ArgumentList $args -Wait -NoNewWindow
+$proc = Start-Process -FilePath $pwshPath -ArgumentList $args -Wait -NoNewWindow -PassThru
+$exitCode = $proc.ExitCode
 
-
-if ($LASTEXITCODE -ne 0) {
-    Write-CustomLog "Runner script failed with exit code $LASTEXITCODE"
-    exit $LASTEXITCODE
+if ($exitCode -ne 0) {
+    Write-CustomLog "Runner script failed with exit code $exitCode"
+    exit $exitCode
 }
 
 Write-CustomLog "`n=== Kicker script finished successfully! ==="

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -7,12 +7,13 @@ Describe 'kicker-bootstrap utilities' -Skip:($IsLinux -or $IsMacOS) {
         ($funcs.Name -contains 'Write-CustomLog') | Should -BeTrue
     }
 
-    It 'invokes runner with call operator and propagates exit code' {
+    It 'invokes runner and propagates exit code using PassThru' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
         $content = Get-Content $scriptPath -Raw
-        $pattern = 'Start-Process -FilePath \$pwshPath -ArgumentList .* -Wait -NoNewWindow'
+        $pattern = 'Start-Process -FilePath \$pwshPath -ArgumentList .* -Wait -NoNewWindow -PassThru'
         $content | Should -Match $pattern
-        $content | Should -Match 'exit \$LASTEXITCODE'
+        $content | Should -Match '\$exitCode\s*=\s*\$proc.ExitCode'
+        $content | Should -Match 'exit \$exitCode'
     }
 
     It 'detects remote config URLs using -match' {


### PR DESCRIPTION
## Summary
- use Start-Process -PassThru in `kicker-bootstrap.ps1`
- check `$exitCode` instead of `$LASTEXITCODE`
- update Kicker-Bootstrap tests for new exit code handling

## Testing
- `Invoke-Pester -Configuration @{ Run = @{ Exit = $false } }` *(fails: Cannot find an overload for "Add" and the argument count: "1")*

------
https://chatgpt.com/codex/tasks/task_e_6847cdcdb83883318bff9c8306b99f77