### PR TITLE
Fix Reset-Git test bullets

### DIFF
--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -3,9 +3,9 @@
 .SYNOPSIS
     Tests for runner_scripts\0001_Reset-Git.ps1
 
-    • Verifies that the script prefers `gh repo clone` when the GitHub CLI exists.
-    • Verifies that it falls back to `git clone` when `gh` is absent.
-    • Verifies that it exits with a non-zero code (or throws) when the clone fails.
+    - Verifies that the script prefers `gh repo clone` when the GitHub CLI exists.
+    - Verifies that it falls back to `git clone` when `gh` is absent.
+    - Verifies that it exits with a non-zero code (or throws) when the clone fails.
 #>
 
 Describe '0001_Reset-Git' -Skip:($IsLinux -or $IsMacOS) {


### PR DESCRIPTION
## Summary
- replace Unicode bullet characters with ASCII

## Testing
- `Invoke-ScriptAnalyzer -Path tests/Reset-Git.Tests.ps1` *(fails: `pwsh` not found)*
- `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ce4b5d748331ad9e6d77873826c6