### PR TITLE
Fix quoting for TrustedHosts script

### DIFF
--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -3,11 +3,10 @@ Param([pscustomobject]$Config)
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0114_Config-TrustedHosts.ps1'
 
-if ($Config.SetTrustedHosts -eq $true) {
-    
-    Start-Process -FilePath cmd.exe -ArgumentList "/d /c winrm set winrm/config/client @{TrustedHosts=`"$Config.TrustedHosts`"}
-
-} else {
-    Write-CustomLog "SetTrustedHosts flag is disabled. Skipping TrustedHosts configuration."
-}
+    if ($Config.SetTrustedHosts -eq $true) {
+        $args = "/d /c winrm set winrm/config/client @{TrustedHosts=`"$($Config.TrustedHosts)`"}"
+        Start-Process -FilePath cmd.exe -ArgumentList $args
+    } else {
+        Write-CustomLog "SetTrustedHosts flag is disabled. Skipping TrustedHosts configuration."
+    }
 }


### PR DESCRIPTION
## Summary
- fix quoting on the TrustedHosts configuration script

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer ."`
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Cannot find an overload for `Add`)*

------
https://chatgpt.com/codex/tasks/task_e_6847cd5cd8608331b1f7f0ba82c30c26