### PR TITLE
Fix secure string generation in tests

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -37,7 +37,7 @@ Describe 'Prepare-HyperVProvider path restoration' -Skip:($IsLinux -or $IsMacOS)
         Mock git {}
         Mock go {}
         Mock Copy-Item {}
-        Mock Read-Host { ConvertTo-SecureString '' -AsPlainText -Force }
+        Mock Read-Host { (New-Object System.Net.NetworkCredential('', '')).SecurePassword }
         Mock Resolve-Path { param([string]$Path) @{ Path = $Path } }
 
         . $script:scriptPath -Config $config
@@ -74,7 +74,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         Mock Convert-CerToPem -MockWith { & $script:origConvertCerToPem @PSBoundParameters }
         Mock Convert-PfxToPem -MockWith { & $script:origConvertPfxToPem @PSBoundParameters }
         Mock Copy-Item {}
-        Mock Read-Host { ConvertTo-SecureString 'pw' -AsPlainText -Force }
+        Mock Read-Host { (New-Object System.Net.NetworkCredential('', 'pw')).SecurePassword }
 
         $providerFile = Join-Path $tempDir 'providers.tf'
         @(


### PR DESCRIPTION
## Summary
- update `PrepareHyperVProvider.Tests.ps1` to use `NetworkCredential.SecurePassword`

## Testing
- `Invoke-ScriptAnalyzer -Path .`
- `Invoke-Pester`


------
https://chatgpt.com/codex/tasks/task_e_6847ce4a1fe08331a909aa857784c5d1