### PR TITLE
Rename Parse-ScriptFile to Get-ScriptAst

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -5,7 +5,7 @@ $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 
 Describe 'Runner scripts parameter and command checks' -Skip:($IsLinux -or $IsMacOS) {
 
-function Parse-ScriptFile {
+function Get-ScriptAst {
     param([string]$Path)
     $text = Get-Content -Raw -Encoding UTF8 $Path
     if ($text.Length -gt 0 -and $text[0] -eq [char]0xFEFF) {
@@ -18,9 +18,7 @@ function Parse-ScriptFile {
 
     It 'declares a Config parameter when required' -TestCases $testCases {
         param($file)
-        $text = Get-Content -Raw -Encoding UTF8 $file.FullName
-        if ($text.Length -gt 0 -and $text[0] -eq [char]0xFEFF) { $text = $text.Substring(1) }
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$null)
+        $ast = Get-ScriptAst $file.FullName
         $configParam = if ($ast) {
             $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.ParameterAst] -and $n.Name.VariablePath.UserPath -eq 'Config' }, $true)
         } else { @() }
@@ -32,9 +30,7 @@ function Parse-ScriptFile {
 
     It 'contains at least one command invocation' -TestCases $testCases {
         param($file)
-        $text = Get-Content -Raw -Encoding UTF8 $file.FullName
-        if ($text.Length -gt 0 -and $text[0] -eq [char]0xFEFF) { $text = $text.Substring(1) }
-        $ast = [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$null)
+        $ast = Get-ScriptAst $file.FullName
         $commands = if ($ast) { $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) } else { @() }
         if ($commands.Count -eq 0) {
             Write-Host "No commands found in $($file.FullName)"


### PR DESCRIPTION
## Summary
- rename Parse-ScriptFile to Get-ScriptAst
- use the helper function inside tests

## Testing
- `Invoke-Pester -Script tests/RunnerScripts.Tests.ps1 -EnableExit`
- `Invoke-ScriptAnalyzer -Path tests/RunnerScripts.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6847ce4c49808331858add4231eb2502