### PR TITLE
Fix ShouldProcess usage in Runner tests

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -311,6 +311,10 @@ Describe 'Set-LabConfig' {
             [CmdletBinding(SupportsShouldProcess)]
             param([hashtable]$ConfigObject)
 
+            if (-not $PSCmdlet.ShouldProcess('ConfigObject', 'Update configuration prompts')) {
+                return $ConfigObject
+            }
+
         $installPrompts = [ordered]@{
             InstallGit      = 'Install Git'
             InstallGo       = 'Install Go'


### PR DESCRIPTION
## Summary
- call `$PSCmdlet.ShouldProcess()` in Runner.Tests
- keep existing function attribute to avoid warnings

## Testing
- `Invoke-ScriptAnalyzer -Path tests/Runner.Tests.ps1`
- `Invoke-Pester -Path tests -CI`


------
https://chatgpt.com/codex/tasks/task_e_6847ce4c0108833191644aee9c9c7d87