### PR TITLE
Refactor Get-ScriptAst helper

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -1,18 +1,11 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'Get-ScriptAst.ps1')
 $scriptDir = Join-Path $PSScriptRoot '..' 'runner_scripts'
 $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 
 
 Describe 'Runner scripts parameter and command checks' -Skip:($IsLinux -or $IsMacOS) {
 
-function Get-ScriptAst {
-    param([string]$Path)
-    $text = Get-Content -Raw -Encoding UTF8 $Path
-    if ($text.Length -gt 0 -and $text[0] -eq [char]0xFEFF) {
-        $text = $text.Substring(1)
-    }
-    [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$null)
-}
 
     $testCases = $scripts | ForEach-Object { @{ file = $_ } }
 

--- a/tests/helpers/Get-ScriptAst.ps1
+++ b/tests/helpers/Get-ScriptAst.ps1
@@ -1,0 +1,8 @@
+function Get-ScriptAst {
+    param([string]$Path)
+    $text = Get-Content -Raw -Encoding UTF8 $Path
+    if ($text.Length -gt 0 -and $text[0] -eq [char]0xFEFF) {
+        $text = $text.Substring(1)
+    }
+    [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$null)
+}


### PR DESCRIPTION
## Summary
- add `tests/helpers/Get-ScriptAst.ps1`
- refactor `tests/RunnerScripts.Tests.ps1` to dot-source the helper

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d59f70c4833182bbdfe5b501ddc4