### PR TITLE
Fix config path in CLI

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -15,10 +15,11 @@ Poetry creates a virtual environment with `labctl` and the test tools.
 
 ## Running the CLI
 
-Invoke the helper commands through Poetry:
+Invoke the helper commands through Poetry. The CLI loads
+`config_files/default-config.json` automatically:
 
 ```bash
-poetry run labctl hv facts --config ../config_files/default-config.json
+poetry run labctl hv facts
 ```
 
 See `labctl --help` for available options.

--- a/py/labctl/cli.py
+++ b/py/labctl/cli.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import typer
 import yaml
 
+BASE_DIR = Path(__file__).resolve().parents[1]
+
 app = typer.Typer()
 hv_app = typer.Typer()
 app.add_typer(hv_app, name="hv")
@@ -16,7 +18,11 @@ def load_config(path: Path) -> dict:
 
 
 @hv_app.command()
-def facts(config: Path = typer.Option(Path("../config_files/default-config.json"), exists=True)):
+def facts(
+    config: Path = typer.Option(
+        Path(BASE_DIR / "config_files" / "default-config.json"), exists=True
+    )
+):
     """Show hypervisor facts from config."""
     cfg = load_config(config)
     hv = cfg.get("HyperV", {})
@@ -24,7 +30,11 @@ def facts(config: Path = typer.Option(Path("../config_files/default-config.json"
 
 
 @hv_app.command()
-def deploy(config: Path = typer.Option(Path("../config_files/default-config.json"), exists=True)):
+def deploy(
+    config: Path = typer.Option(
+        Path(BASE_DIR / "config_files" / "default-config.json"), exists=True
+    )
+):
     """Pretend to deploy using the hypervisor config."""
     cfg = load_config(config)
     hv = cfg.get("HyperV", {})


### PR DESCRIPTION
## Summary
- compute BASE_DIR for labctl
- use absolute config path for CLI defaults
- update docs to show default config usage

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration @{ Run = @{ Exit=$true } }"` *(fails: command not found)*
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d5a374b4833186b6081447e3fdb2