### PR TITLE
Add helper check to Pester job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,16 @@ jobs:
         shell: pwsh
         run: |
           Install-Module -Name powershell-yaml -Force -Scope CurrentUser
-          
+
+      - name: Verify test helpers
+        shell: pwsh
+        run: |
+          . ./tests/helpers/Get-ScriptAst.ps1
+          if (-not (Get-Command Get-ScriptAst -ErrorAction SilentlyContinue)) {
+              Write-Error 'Get-ScriptAst helper not loaded'
+              exit 1
+          }
+
       - name: Run Pester
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- verify test helper scripts are loaded before invoking Pester

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI -ErrorAction Stop"` *(fails: Cannot find an overload for "Add" and argument count 1)*

------
https://chatgpt.com/codex/tasks/task_e_6847d5a891e483318930ceb2dcbb63fa