### PR TITLE
Use package resource for labctl default config

### DIFF
--- a/py/labctl/config_files/default-config.json
+++ b/py/labctl/config_files/default-config.json
@@ -1,0 +1,76 @@
+{
+  "ComputerName": "default-lab",
+  "SetComputerName": false,
+  "DNSServers": "8.8.8.8,1.1.1.1",
+  "SetDNSServers": false,
+  "TrustedHosts": "",
+  "SetTrustedHosts": false,
+  "DisableTCPIP6": false,
+  "AllowRemoteDesktop": false,
+  "ConfigureFirewall": false,
+  "FirewallPorts": [3389, 5985, 5986, 445, 135, "49152-65535"],
+  "ConfigPXE": false,
+  "InstallGit": true,
+  "InstallGitHubCLI": true,
+  "InstallPwsh": true,
+  "InstallHyperV": false,
+  "InstallWAC": false,
+  "InstallGo": false,
+  "InstallOpenTofu": false,
+  "OpenTofuVersion": "latest",
+  "InitializeOpenTofu": false,
+  "PrepareHyperVHost": false,
+  "InstallCA": false,
+  "InstallCosign": false,
+  "CosignURL": "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-windows-amd64.exe",
+  "CosignPath": "C:\\temp\\cosign",
+  "InstallGPG": false,
+  "CertificateAuthority": {
+    "CommonName": "default-lab-RootCA",
+    "ValidityYears": 5
+  },
+  "HyperV": {
+    "User": "",
+    "Password": "",
+    "Host": "",
+    "Port": 5986,
+    "Https": true,
+    "Insecure": true,
+    "UseNtlm": true,
+    "EnableManagementTools": true,
+    "TlsServerName": "",
+    "CacertPath": "",
+    "CertPath": "",
+    "KeyPath": "",
+    "ScriptPath": "C:/Temp/terraform_%RAND%.cmd",
+    "Timeout": "30s"
+  },
+  "WAC": {
+    "InstallPort": 443
+  },
+  "GitHubCLIInstallerUrl": "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_windows_amd64.msi",
+  "RepoUrl": "https://github.com/wizzense/opentofu-lab-automation.git",
+  "LocalPath": "",
+  "RunnerScriptName": "runner.ps1",
+  "ConfigFile": "./config_files/default-config.json",
+  "Go": {
+    "InstallerUrl": "https://go.dev/dl/go1.24.1.windows-amd64.msi"
+  },
+
+  "InfraRepoUrl": "https://github.com/wizzense/tofu-tan-lab.git",   
+  "InfraRepoPath": "C:\\Temp\\base-infra",
+
+  "Node_Dependencies": {
+  "InstallNode": true,
+  "InstallYarn": true,
+  "InstallVite": true,
+  "InstallNodemon": true,
+  "InstallNpm": true,
+  "GlobalPackages": ["yarn", "vite", "nodemon"],
+  "NpmPath": "C:\\Projects\\vde-mvp\\frontend",
+  "CreateNpmPath": false,
+  "Node": {
+    "InstallerUrl": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
+  }
+}
+}

--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -1,19 +1,18 @@
-from pathlib import Path
 from typer.testing import CliRunner
 from labctl.cli import app
 
-CONFIG_PATH = Path(__file__).resolve().parents[2] / "config_files" / "default-config.json"
 
-
-def test_hv_facts():
+def test_hv_facts_default():
     runner = CliRunner()
-    result = runner.invoke(app, ["hv", "facts", "--config", str(CONFIG_PATH)])
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["hv", "facts"])
     assert result.exit_code == 0
     assert "\"Host\"" in result.output
 
 
-def test_hv_deploy():
+def test_hv_deploy_default():
     runner = CliRunner()
-    result = runner.invoke(app, ["hv", "deploy", "--config", str(CONFIG_PATH)])
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["hv", "deploy"])
     assert result.exit_code == 0
     assert "Deploying Hyper-V host" in result.output


### PR DESCRIPTION
## Summary
- package the default config with labctl
- load packaged default config using `importlib.resources`
- exercise the CLI from an isolated directory in tests

## Testing
- `ruff check .`
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d742a4ac8331bd592db2120fbafa