### PR TITLE
Fix RunnerScripts tests

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -14,26 +14,28 @@ function Get-ScriptAst {
     [System.Management.Automation.Language.Parser]::ParseInput($text, [ref]$null, [ref]$null)
 }
 
-    $testCases = $scripts | ForEach-Object { @{ file = $_ } }
+    $testCases = $scripts | ForEach-Object {
+        @{ Name = $_.Name; File = $_ }
+    }
 
     It 'declares a Config parameter when required' -TestCases $testCases {
-        param($file)
-        $ast = Get-ScriptAst $file.FullName
+        param($File)
+        $ast = Get-ScriptAst $File.FullName
         $configParam = if ($ast) {
             $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.ParameterAst] -and $n.Name.VariablePath.UserPath -eq 'Config' }, $true)
         } else { @() }
         if ($configParam.Count -eq 0) {
-            Write-Host "No Config parameter found in $($file.FullName)"
+            Write-Host "No Config parameter found in $($File.FullName)"
         }
         $configParam.Count | Should -BeGreaterThan 0
     }
 
     It 'contains at least one command invocation' -TestCases $testCases {
-        param($file)
-        $ast = Get-ScriptAst $file.FullName
+        param($File)
+        $ast = Get-ScriptAst $File.FullName
         $commands = if ($ast) { $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) } else { @() }
         if ($commands.Count -eq 0) {
-            Write-Host "No commands found in $($file.FullName)"
+            Write-Host "No commands found in $($File.FullName)"
         }
         $commands.Count | Should -BeGreaterThan 0
     }


### PR DESCRIPTION
## Summary
- add Name and File keys to test cases
- adjust test parameter names

## Testing
- `Invoke-Pester -Script tests/RunnerScripts.Tests.ps1 -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_6847d61a2ab8833186e39db874c5c824