### PR TITLE
Fix Pester helper import for RunnerScripts

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -1,13 +1,15 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-. (Join-Path $PSScriptRoot 'helpers' 'Get-ScriptAst.ps1')
 
 if ($IsLinux -or $IsMacOS) { return }
 
 $scriptDir = Join-Path $PSScriptRoot '..' 'runner_scripts'
 $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 
-
 Describe 'Runner scripts parameter and command checks' -Skip:($IsLinux -or $IsMacOS) {
+
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'helpers' 'Get-ScriptAst.ps1')
+    }
 
 
     $testCases = $scripts | ForEach-Object { @{ file = $_ } }


### PR DESCRIPTION
## Summary
- load Get-ScriptAst helper inside `BeforeAll` so the function is available to each Pester test

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI -ErrorAction Stop"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d81bd2888331b936a975b727ed6c