### PR TITLE
Fix logging tests by defining Test-IsAdmin

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -11,10 +11,12 @@ if ($IsLinux -or $IsMacOS) { return }
     BeforeEach {
         $script:temp = Join-Path $TestDrive ([System.Guid]::NewGuid())
         New-Item -ItemType Directory -Path $script:temp | Out-Null
+        function Test-IsAdmin {}
     }
 
     AfterEach {
         Remove-Item -Recurse -Force $script:temp -ErrorAction SilentlyContinue
+        Remove-Item Function:Test-IsAdmin -ErrorAction SilentlyContinue
     }
 
 


### PR DESCRIPTION
## Summary
- define `Test-IsAdmin` before tests so mocking works
- clean up the helper function after each test run

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path .`
- `Invoke-Pester` *(fails: `MethodException: Cannot find an overload for "Add"`)*

------
https://chatgpt.com/codex/tasks/task_e_6847db75022c8331ba94faead8c0ea58