### PR TITLE
Fix certificate helper test stub

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -137,7 +137,7 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($IsLinux -or $IsMac
         $stub | Add-Member -MemberType ScriptMethod -Name Export -Value { param($t) @() }
         $stub | Add-Member -MemberType ScriptMethod -Name GetRSAPrivateKey -Value { $rsa }
         Mock Set-Content {}
-        Mock New-Object { $stub }
+        Mock New-Object { $stub } -ParameterFilter { $TypeName -eq 'System.Security.Cryptography.X509Certificates.X509Certificate2' }
         $securePass = New-Object System.Security.SecureString
         foreach ($c in 'pw'.ToCharArray()) { $securePass.AppendChar($c) }
         $securePass.MakeReadOnly()


### PR DESCRIPTION
## Summary
- restrict `Mock New-Object` to intercept only `X509Certificate2`

## Testing
- `Invoke-ScriptAnalyzer -Path .`
- `ruff check .`
- `Invoke-Pester` *(fails: Cannot find an overload for "Add" and the argument count: "1".)*

------
https://chatgpt.com/codex/tasks/task_e_6847db77021883318750f315e0eeb828