### PR TITLE
Fix admin detection override

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -307,6 +307,7 @@ function unpackStandalone() {
 # On Windows the Administrators group membership is queried. Other
 # platforms always return `$false` as privilege escalation is not
 # supported.
+if (-not (Get-Command Test-IsAdmin -ErrorAction SilentlyContinue)) {
 function Test-IsAdmin {
     $hasAdmin = $false
     if ($IsWindows) {
@@ -323,6 +324,7 @@ function Test-IsAdmin {
         $hasAdmin = $false
     }
     return $hasAdmin
+}
 }
 
 function installStandalone() {


### PR DESCRIPTION
## Summary
- allow OpenTofuInstaller's `Test-IsAdmin` function to be mocked in tests

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path runner_utility_scripts/OpenTofuInstaller.ps1`
- `Invoke-Pester` *(fails: Cannot find an overload for "Add")*

------
https://chatgpt.com/codex/tasks/task_e_6847df02f86c83319361b783c2ee061f