### PR TITLE
Fix default for Install-NpmDependencies

### DIFF
--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -46,7 +46,12 @@ if ($Config -is [hashtable]) {
     return
 }
 
-if ($Config.Node_Dependencies.InstallNpm) {
+$installNpm = $true
+if ($Config.Node_Dependencies.PSObject.Properties.Name -contains 'InstallNpm') {
+    $installNpm = [bool]$Config.Node_Dependencies.InstallNpm
+}
+
+if ($installNpm) {
 
 # Determine frontend path
 $frontendPath = if ($Config.Node_Dependencies.NpmPath) {


### PR DESCRIPTION
## Summary
- ensure `Install-NpmDependencies` runs even when `InstallNpm` isn't specified

## Testing
- `Invoke-ScriptAnalyzer -Path runner_scripts/0203_Install-npm.ps1`
- `Invoke-Pester -Path tests/Install-npm.Tests.ps1 -CI` *(fails: Config missing Node_Dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847dedb622883318ceaede76d766459