### PR TITLE
Fix npm path creation logic

### DIFF
--- a/runner_utility_scripts/ScriptTemplate.ps1
+++ b/runner_utility_scripts/ScriptTemplate.ps1
@@ -3,6 +3,6 @@ function Invoke-LabStep {
     . $PSScriptRoot/Logger.ps1
     Set-StrictMode -Version Latest
     $ErrorActionPreference = 'Stop'
-    try { . $Body } catch { Write-CustomLog "ERROR: $_"; exit 1 }
+    try { & $Body $Config } catch { Write-CustomLog "ERROR: $_"; exit 1 }
 }
 


### PR DESCRIPTION
## Summary
- handle missing InstallNpm and CreateNpmPath options
- create package.json when path is generated
- execute npm install without ShouldProcess
- pass config argument through ScriptTemplate

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path .`
- `Invoke-Pester` *(fails: MethodException in Pester)*

------
https://chatgpt.com/codex/tasks/task_e_6847def36c888331b2456c5a14f48b4e