### PR TITLE
Fix log file test admin scope

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -11,7 +11,7 @@ if ($IsLinux -or $IsMacOS) { return }
     BeforeEach {
         $script:temp = Join-Path $TestDrive ([System.Guid]::NewGuid())
         New-Item -ItemType Directory -Path $script:temp | Out-Null
-        function Test-IsAdmin {}
+        function global:Test-IsAdmin {}
     }
 
     AfterEach {


### PR DESCRIPTION
## Summary
- ensure the `Test-IsAdmin` stub is created in the global scope

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e57459288331b3eba2873834903b