### PR TITLE
Fix Node global package detection

### DIFF
--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -61,25 +61,23 @@ if (-not $nodeDeps) {
 }
 
 $packages = @()
-if ($nodeDeps.PSObject.Properties.Name -contains 'GlobalPackages') {
+if ($nodeDeps -is [hashtable]) {
+    if ($nodeDeps.ContainsKey('GlobalPackages')) {
+        $packages = $nodeDeps['GlobalPackages']
+    }
+} elseif ($nodeDeps.PSObject.Properties.Name -contains 'GlobalPackages') {
     $packages = $nodeDeps.GlobalPackages
-} else {
-    if ($nodeDeps.InstallYarn) {
-        $packages += 'yarn'
-    } else {
-        Write-CustomLog "InstallYarn flag is disabled. Skipping yarn installation."
-    }
+}
 
-    if ($nodeDeps.InstallVite) {
-        $packages += 'vite'
+if (-not $packages) {
+    if ($nodeDeps -is [hashtable]) {
+        if ($nodeDeps['InstallYarn']) { $packages += 'yarn' } else { Write-CustomLog "InstallYarn flag is disabled. Skipping yarn installation." }
+        if ($nodeDeps['InstallVite']) { $packages += 'vite' } else { Write-CustomLog "InstallVite flag is disabled. Skipping vite installation." }
+        if ($nodeDeps['InstallNodemon']) { $packages += 'nodemon' } else { Write-CustomLog "InstallNodemon flag is disabled. Skipping nodemon installation." }
     } else {
-        Write-CustomLog "InstallVite flag is disabled. Skipping vite installation."
-    }
-
-    if ($nodeDeps.InstallNodemon) {
-        $packages += 'nodemon'
-    } else {
-        Write-CustomLog "InstallNodemon flag is disabled. Skipping nodemon installation."
+        if ($nodeDeps.InstallYarn) { $packages += 'yarn' } else { Write-CustomLog "InstallYarn flag is disabled. Skipping yarn installation." }
+        if ($nodeDeps.InstallVite) { $packages += 'vite' } else { Write-CustomLog "InstallVite flag is disabled. Skipping vite installation." }
+        if ($nodeDeps.InstallNodemon) { $packages += 'nodemon' } else { Write-CustomLog "InstallNodemon flag is disabled. Skipping nodemon installation." }
     }
 }
 


### PR DESCRIPTION
## Summary
- fix detection of Node global package list when using hashtable config
- adjust fallback boolean checks

## Testing
- `ruff check .`
- `Invoke-Pester` *(fails: pwsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847e5a30a348331bfd9d38d92e80afc