### PR TITLE
Fix cross-platform npm path test

### DIFF
--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -10,7 +10,7 @@ Describe '0203_Install-npm' {
         $script:calledPath = $null
         function npm {
             param([string[]]$NpmArgs)
-            $script:calledPath = (Get-Location).ProviderPath
+            $script:calledPath = (Get-Location).Path
             $null = $NpmArgs
         }
 
@@ -66,7 +66,7 @@ Describe '0203_Install-npm' {
         $config = @{ Node_Dependencies = @{ NpmPath = $npmDir; CreateNpmPath = $true } }
 
         $script:calledPath = $null
-        function npm { param([string[]]$Args) $script:calledPath = (Get-Location).ProviderPath }
+        function npm { param([string[]]$Args) $script:calledPath = (Get-Location).Path }
 
         . $script -Config @{}
         Install-NpmDependencies -Config $config


### PR DESCRIPTION
## Summary
- ensure Install-npm tests check location with `Path` property

## Testing
- `ruff check .`
- `Invoke-Pester` *(fails: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847e5c5ec8c83319feb840aaba46b74