### PR TITLE
Ensure default config exists in CLI tests

### DIFF
--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -3,6 +3,7 @@ from typer.testing import CliRunner
 from labctl.cli import app
 
 CONFIG_PATH = Path(__file__).resolve().parents[2] / "config_files" / "default-config.json"
+assert CONFIG_PATH.exists(), f"Config file missing: {CONFIG_PATH}"
 
 
 def test_hv_facts():


### PR DESCRIPTION
## Summary
- verify the computed `CONFIG_PATH` exists in CLI tests

## Testing
- `ruff check .`
- `pytest -q`
- `Invoke-ScriptAnalyzer` *(fails: `pwsh` not found)*
- `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e6d4b8988331b1b10435b2a500da