### PR TITLE
Add -Confirm:$false to Install-CA tests

### DIFF
--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -19,7 +19,7 @@ Describe '0104_Install-CA script' {
         Mock Install-AdcsCertificationAuthority {}
 
         . $scriptPath
-        Install-CA -Config $config
+        Install-CA -Config $config -Confirm:$false
 
         Assert-MockCalled Install-AdcsCertificationAuthority -Times 1
     }
@@ -35,7 +35,7 @@ Describe '0104_Install-CA script' {
         Mock Install-AdcsCertificationAuthority {}
 
         . $scriptPath
-        Install-CA -Config $config
+        Install-CA -Config $config -Confirm:$false
 
         Should -Invoke -CommandName Install-AdcsCertificationAuthority -Times 0
     }


### PR DESCRIPTION
## Summary
- update `Install-CA.Tests.ps1` so Install-CA is called with `-Confirm:$false`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `bash: pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847e71b4a388331a5d3afdd792ee5b4