### PR TITLE
Update ScriptTemplate error handling

### DIFF
--- a/runner_utility_scripts/ScriptTemplate.ps1
+++ b/runner_utility_scripts/ScriptTemplate.ps1
@@ -4,7 +4,7 @@ function Invoke-LabStep {
 
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'
-    try { & $Body $Config } catch { Write-CustomLog "ERROR: $_"; exit 1 }
+    try { & $Body $Config } catch { Write-CustomLog "ERROR: $_"; throw }
 
 }
 


### PR DESCRIPTION
## Summary
- modify `Invoke-LabStep` to throw after logging errors instead of exiting

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path ."` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6847e6cde2dc8331b65258f875832fc7