### PR TITLE
Fix Install-NodeCore config parsing

### DIFF
--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -35,10 +35,16 @@ if (-not $nodeDeps) {
 
 if ($nodeDeps.InstallNode) {
     try {
-        $url = if ($nodeDeps.Node.InstallerUrl) {
-            $nodeDeps.Node.InstallerUrl
-        } else {
-            "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
+        $url = $null
+        if ($nodeDeps.Node) {
+            if ($nodeDeps.Node -is [hashtable]) {
+                $url = $nodeDeps.Node['InstallerUrl']
+            } elseif ($nodeDeps.Node.PSObject.Properties.Match('InstallerUrl').Count -gt 0) {
+                $url = $nodeDeps.Node.InstallerUrl
+            }
+        }
+        if (-not $url) {
+            $url = "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
         }
 
         $installerPath = Join-Path $env:TEMP "node-installer.msi"


### PR DESCRIPTION
## Summary
- handle `InstallerUrl` whether Node config is hashtable or object

## Testing
- `Invoke-Pester` *(fails: 31 passed, 7 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6847e5acc7f483319111f7b6cb9050b8