### PR TITLE
Add documentation for helper scripts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# OpenTofu Lab Automation Documentation
+
+Welcome! This folder collects notes and guides for working with the project.
+
+- [Lab Utility Scripts](lab_utils.md)
+- [ISO Customization Tools](iso_tools.md)
+

--- a/docs/iso_tools.md
+++ b/docs/iso_tools.md
@@ -1,0 +1,10 @@
+# ISO Customization Tools
+
+The `iso_tools` directory contains scripts for building automated installation media.
+
+- **Customize-ISO.ps1** – Mounts a Windows ISO, injects a `bootstrap.ps1` script and an answer file, then rebuilds a bootable ISO using the Windows ADK.
+- **bootstrap.ps1** – Downloads `kicker-bootstrap.ps1` from this repository and runs it. Used inside customized ISOs.
+- **autounattend - generic.xml** – Example unattended installation file for Windows Server.
+- **headlessunattend.xml** – Sample answer file for fully headless deployments.
+
+These resources can be adapted to streamline automated lab setups.

--- a/docs/lab_utils.md
+++ b/docs/lab_utils.md
@@ -1,0 +1,13 @@
+# Lab Utility Scripts
+
+This folder contains helper tools used across the project. Each script focuses on a small task so they can be composed in other workflows.
+
+- **Expand-All.ps1** – Expands a specified ZIP archive or every archive in the current directory tree.
+- **Format-Config.ps1** – Converts a configuration object into pretty JSON for easier logging.
+- **Get-LabConfig.ps1** – Loads a JSON or YAML file and returns it as a PowerShell object.
+- **Get-Platform.ps1** – Detects the host operating system.
+- **Menu.ps1** – Provides an interactive menu for selecting items from a list.
+- **Hypervisor.psm1** – Stub module defining `Get-HVFacts`, `Enable-Provider` and `Deploy-VM` functions.
+- **get_platform.py** – Python version of `Get-Platform.ps1`.
+
+The `__init__.py` file is currently empty and simply marks the folder as a Python package.


### PR DESCRIPTION
## Summary
- document helper scripts under `lab_utils/`
- document ISO customization tools
- add docs index with links to new pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847e7246c9483319d6888a3882943d4