### PR TITLE
Add runner usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The configuration reads variables from `lab_config.yaml`, which you can copy fro
   4) Clones this repository from config.json -> RepoUrl to config.json -> LocalPath (or a default path).
   5) Invokes runner.ps1 from this repo. Runner can be ran with optional parameters to automatically run, but it will prompt you to manually select which scripts to run by default.
      - Use `-ConfigFile <path>` to specify an alternative configuration file. If omitted, `runner.ps1` loads `config_files/default-config.json`.
+     - See [docs/runner.md](docs/runner.md) for detailed usage including non-interactive mode.
 
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Documentation
+
+This folder will hold reference guides for automation scripts and modules.
+
+- [Runner script usage](runner.md)

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -1,0 +1,25 @@
+# runner.ps1 guide
+
+`runner.ps1` orchestrates the numbered scripts under `runner_scripts/`.
+It loads `config_files/default-config.json` by default and then prompts for script selection unless told otherwise.
+
+## Interactive mode
+
+Simply invoke the script with no parameters:
+
+```powershell
+./runner.ps1
+```
+
+You will be shown a menu to choose which scripts to run. This path is taken when the `-Scripts` parameter is omitted, as seen around lines 259-275 of `runner.ps1`.
+
+## Non-interactive mode
+
+Supply a comma-separated list of 4-digit script prefixes via `-Scripts` to run without prompts. Combine this with `-Auto` to skip configuration customization and cleanup confirmations.
+
+```powershell
+./runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto
+```
+
+The default configuration path (`./config_files/default-config.json`) and the `-Auto` switch are defined on lines 1-6. The logic that runs scripts directly when `-Scripts` is provided lives at lines 259-264. Prompts for editing the configuration or confirming cleanup only occur when `-Auto` is not specified, as shown on lines 135-168.
+


### PR DESCRIPTION
## Summary
- document how to run runner.ps1
- link docs from README

## Testing
- `mkdocs build` *(fails: Config file 'mkdocs.yml' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6847e7251b2883319c66f89c23fcf3ff