### PR TITLE
Improve Windows reset logic

### DIFF
--- a/runner_scripts/9999_Reset-Machine.ps1
+++ b/runner_scripts/9999_Reset-Machine.ps1
@@ -7,7 +7,16 @@ Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 9999_Reset-Machine.ps1'
     $platform = Get-Platform
     Write-CustomLog "Detected platform: $platform"
-    if ($platform -in @('Windows','Linux','MacOS')) {
+    if ($platform -eq 'Windows') {
+        $sysprep = 'C:\\Windows\\System32\\Sysprep\\Sysprep.exe'
+        if (Test-Path $sysprep) {
+            Write-CustomLog "Invoking sysprep at $sysprep"
+            Start-Process $sysprep -ArgumentList '/generalize /oobe /shutdown /quiet' -Wait
+        } else {
+            Write-CustomLog 'Sysprep not found; unable to reset.' -Level 'ERROR'
+            exit 1
+        }
+    } elseif ($platform -in @('Linux','MacOS')) {
         Write-CustomLog 'Initiating system reboot...'
         Restart-Computer
     } else {

--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -9,11 +9,15 @@ Describe 'Reset-Machine script' {
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
     }
 
-    It 'calls Restart-Computer on Windows' {
+    It 'invokes sysprep on Windows' {
         Mock Get-Platform { 'Windows' }
-        Mock Restart-Computer {}
+        $sysprep = 'C:\\Windows\\System32\\Sysprep\\Sysprep.exe'
+        Mock Test-Path { $true } -ParameterFilter { $Path -eq $sysprep }
+        Mock Start-Process {}
         . $script:ScriptPath -Config ([pscustomobject]@{})
-        Assert-MockCalled Restart-Computer -Times 1
+        Assert-MockCalled Start-Process -Times 1 -ParameterFilter {
+            $FilePath -eq $sysprep -and $ArgumentList -eq '/generalize /oobe /shutdown /quiet' -and $Wait
+        }
     }
 
     It 'calls Restart-Computer on Linux' {


### PR DESCRIPTION
## Summary
- sysprep the machine when resetting Windows
- update Reset-Machine tests for sysprep behaviour

## Testing
- `Invoke-ScriptAnalyzer -Path .` *(fails: cmdlet not found)*
- `ruff check .`
- `Invoke-Pester` *(fails: 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6847e5ff793c8331a81aee7a5242863d