### PR TITLE
Fix config clobbering in NodeScripts tests

### DIFF
--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Node installation scripts' {
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command { @{Name='node'} } -ParameterFilter { $Name -eq 'node' }
-        . $core
+        . $core -Config $config
 
         Install-NodeCore -Config $config
         Assert-MockCalled Invoke-WebRequest -ParameterFilter { $Uri -eq 'http://example.com/node.msi' } -Times 1
@@ -40,7 +40,7 @@ Describe 'Node installation scripts' {
         Mock Remove-Item {}
         Mock Get-Command {}
 
-        . $core
+        . $core -Config $config
 
         Install-NodeCore -Config $config
         Should -Invoke -CommandName Invoke-WebRequest -Times 0
@@ -58,7 +58,7 @@ Describe 'Node installation scripts' {
         }
         Mock npm {}
 
-        . $global
+        . $global -Config $config
 
         Install-NodeGlobalPackages -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
@@ -76,7 +76,7 @@ Describe 'Node installation scripts' {
         }
         Mock npm {}
 
-        . $global
+        . $global -Config $config
 
         Install-NodeGlobalPackages -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
@@ -87,7 +87,7 @@ Describe 'Node installation scripts' {
     It 'honours -WhatIf for Install-GlobalPackage' {
     
         $global = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0202_Install-NodeGlobalPackages.ps1')).Path
-        . $global
+        . $global -Config @{}
 
         Install-NodeGlobalPackages -Config @{ Node_Dependencies = @{ InstallYarn=$false; InstallVite=$false; InstallNodemon=$false } }
         function npm { param([string[]]$testArgs) }
@@ -108,7 +108,7 @@ Describe 'Node installation scripts' {
         $npmPath = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0203_Install-npm.ps1')).Path
         Mock npm {}
 
-        . $npmPath
+        . $npmPath -Config $config
 
         Install-NpmDependencies -Config $config
         Assert-MockCalled npm -ParameterFilter { $testArgs[0] -eq 'install' } -Times 1


### PR DESCRIPTION
## Summary
- ensure NodeScripts tests dot-source scripts with a `-Config` argument

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: `pwsh` not found)*
- `pwsh -NoLogo -NoProfile -Command Invoke-ScriptAnalyzer -Path .` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e58089e48331bed941924a8085ab