### PR TITLE
Add docs for python CLI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# OpenTofu Lab Automation Docs
+
+This folder contains early documentation for the project.
+
+- [labctl Python CLI](python-cli.md)
+

--- a/docs/python-cli.md
+++ b/docs/python-cli.md
@@ -1,0 +1,34 @@
+# labctl Python CLI
+
+The `labctl` command line tool exposes cross-platform helpers written in Python. It reads its settings from a JSON or YAML configuration file, loading `config_files/default-config.json` when no explicit path is given.
+
+## Subcommands
+
+### `hv facts`
+Display the Hyper-V section from the configuration file:
+
+```bash
+poetry run labctl hv facts
+```
+
+Specify an alternative config file with `--config`:
+
+```bash
+poetry run labctl hv facts --config my-config.yaml
+```
+
+### `hv deploy`
+Simulate deploying using the Hyper-V configuration:
+
+```bash
+poetry run labctl hv deploy
+```
+
+Provide a custom configuration path the same way:
+
+```bash
+poetry run labctl hv deploy --config path/to/config.json
+```
+
+Both commands simply parse the configuration and print details to the console at this stage.
+

--- a/py/README.md
+++ b/py/README.md
@@ -24,6 +24,9 @@ poetry run labctl hv facts
 
 See `labctl --help` for available options.
 
+Further examples of the available subcommands are provided in
+[the Python CLI documentation](../docs/python-cli.md).
+
 ## Running tests
 
 Execute the pytest suite from this directory:


### PR DESCRIPTION
## Summary
- document `labctl` subcommands in new page `docs/python-cli.md`
- start docs folder with index linking to Python CLI page
- cross-link docs from `py/README.md`

## Testing
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e75b1f10833193b4d01f8cc6c901