### PR TITLE
Fix Node global package installation in tests

### DIFF
--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -7,9 +7,11 @@ function Install-GlobalPackage {
         [string]$package
     )
 
+    . "$PSScriptRoot/../runner_utility_scripts/Logger.ps1"
+
     if (Get-Command npm -ErrorAction SilentlyContinue) {
         Write-CustomLog "Installing npm package: $package..."
-        if ($PSCmdlet.ShouldProcess($package, 'Install npm package')) {
+        if ($PSCmdlet.ShouldProcess($package, 'Install npm package') -and -not $WhatIfPreference) {
             npm install -g $package
         }
     } else {

--- a/runner_utility_scripts/ScriptTemplate.ps1
+++ b/runner_utility_scripts/ScriptTemplate.ps1
@@ -4,7 +4,13 @@ function Invoke-LabStep {
 
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'
-    try { & $Body $Config } catch { Write-CustomLog "ERROR: $_"; throw }
-
+    try {
+        . $Body $Config
+    } catch {
+        Write-CustomLog "ERROR: $_"
+        throw
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
 }
 


### PR DESCRIPTION
## Summary
- allow `Invoke-LabStep` to run in caller scope so Pester mocks work
- import logger and respect `-WhatIf` when installing npm packages

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e805b79c833182e9f3ef8dbb9967