### PR TITLE
Fix Hyper-V cert conversion

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -8,7 +8,7 @@ function Convert-CerToPem {
         [string]$PemPath
     )
     if (-not $PSCmdlet.ShouldProcess($PemPath, 'Create PEM file')) { return }
-    $bytes = Get-Content -Path $CerPath -Encoding Byte
+    $bytes = Get-Content -Path $CerPath -AsByteStream
     $b64   = [System.Convert]::ToBase64String($bytes, 'InsertLineBreaks')
     "-----BEGIN CERTIFICATE-----`n$b64`n-----END CERTIFICATE-----" | Set-Content -Path $PemPath
 }


### PR DESCRIPTION
## Summary
- avoid unsupported `Byte` encoding during certificate conversion

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path .` *(fails: `pwsh` not found)*
- `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847eb144fe8833183c4f2c3e0c0014c