### PR TITLE
Fix Node global package install

### DIFF
--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -23,6 +23,7 @@ function Install-NodeGlobalPackages {
 
     . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
     Invoke-LabStep -Config $Config -Body {
+    param($Config)
     Write-CustomLog 'Running 0202_Install-NodeGlobalPackages.ps1'
 <#
 .SYNOPSIS
@@ -76,10 +77,13 @@ if ($nodeDeps -is [hashtable] -and $nodeDeps.ContainsKey('GlobalPackages')) {
         $packages += 'vite'
     } else {
         Write-CustomLog "InstallVite flag is disabled. Skipping vite installation."
-
     }
-} elseif ($nodeDeps.PSObject.Properties.Name -contains 'GlobalPackages') {
-    $packages = $nodeDeps.GlobalPackages
+
+    if ($nodeDeps.InstallNodemon) {
+        $packages += 'nodemon'
+    } else {
+        Write-CustomLog "InstallNodemon flag is disabled. Skipping nodemon installation."
+    }
 }
 
 if (-not $packages) {


### PR DESCRIPTION
## Summary
- ensure 0202_Install-NodeGlobalPackages.ps1 receives Config in its body
- handle InstallNodemon flag and remove stray conditional

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -Command Invoke-ScriptAnalyzer -Path .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ea2ef2788331b0455809e183b813