### PR TITLE
Fix certificate conversion test mocks

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -78,8 +78,14 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         Mock Test-Path { $false }
         Mock git {}
         Mock go {}
-        Mock Convert-CerToPem -MockWith { & $script:origConvertCerToPem @PSBoundParameters }
-        Mock Convert-PfxToPem -MockWith { & $script:origConvertPfxToPem @PSBoundParameters }
+        Mock Convert-CerToPem {
+            param($CerPath, $PemPath)
+            & $script:origConvertCerToPem -CerPath $CerPath -PemPath $PemPath
+        }
+        Mock Convert-PfxToPem {
+            param($PfxPath, $Password, $CertPath, $KeyPath)
+            & $script:origConvertPfxToPem -PfxPath $PfxPath -Password $Password -CertPath $CertPath -KeyPath $KeyPath
+        }
         Mock Copy-Item {}
         Mock Read-Host {
             $pwd = New-Object System.Security.SecureString


### PR DESCRIPTION
## Summary
- ensure certificate conversion mocks pass parameters correctly in `PrepareHyperVProvider.Tests.ps1`

## Testing
- `ruff check .`
- `Invoke-Pester` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847ea71d76c83319be3226c849daba1