### PR TITLE
Fix Convert-CerToPem byte read method

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -8,7 +8,7 @@ function Convert-CerToPem {
         [string]$PemPath
     )
     if (-not $PSCmdlet.ShouldProcess($PemPath, 'Create PEM file')) { return }
-    $bytes = Get-Content -Path $CerPath -Encoding Byte
+    $bytes = [System.IO.File]::ReadAllBytes($CerPath)
     $b64   = [System.Convert]::ToBase64String($bytes, 'InsertLineBreaks')
     "-----BEGIN CERTIFICATE-----`n$b64`n-----END CERTIFICATE-----" | Set-Content -Path $PemPath
 }


### PR DESCRIPTION
## Summary
- use `[System.IO.File]::ReadAllBytes()` in `Convert-CerToPem`

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command Invoke-ScriptAnalyzer -Path . -Recurse` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847eb65d3708331a67902f128cd5cab