### PR TITLE
tests: mock gh clone creates .git folder

### DIFF
--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -27,7 +27,10 @@ Describe '0001_Reset-Git' -Skip:($IsLinux -or $IsMacOS) {
 
             Mock Get-Command { @{ Name = 'gh'; Path = 'gh.exe' } } -ParameterFilter { $Name -eq 'gh' }
             function global:gh {}
-            Mock gh { $global:LASTEXITCODE = 0 }
+            Mock gh {
+                $global:LASTEXITCODE = 0
+                New-Item -ItemType Directory -Path (Join-Path $tempDir '.git') -Force | Out-Null
+            }
             Mock git {}
 
             & $script:ScriptPath -Config $config


### PR DESCRIPTION
## Summary
- update Reset-Git gh mock to create a `.git` folder

## Testing
- `pytest -q`
- `pwsh` & `Invoke-Pester` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ebc6d1308331bad4389a47bd7b81