### PR TITLE
Add early helper script check

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -1,3 +1,9 @@
+
+$helperPath = Join-Path $PSScriptRoot 'helpers' 'Get-ScriptAst.ps1'
+if (-not (Test-Path $helperPath)) {
+    throw "Required helper script is missing: $helperPath"
+}
+
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 
 if ($IsLinux -or $IsMacOS) { return }


### PR DESCRIPTION
## Summary
- validate that `tests/helpers/Get-ScriptAst.ps1` exists before running `RunnerScripts.Tests.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path tests/RunnerScripts.Tests.ps1"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ebe3b1ec8331b31b7e7b9c2da4a8