### PR TITLE
Fix npm path lookup and cleanup global npm script

### DIFF
--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -78,8 +78,6 @@ if ($nodeDeps -is [hashtable] -and $nodeDeps.ContainsKey('GlobalPackages')) {
         Write-CustomLog "InstallVite flag is disabled. Skipping vite installation."
 
     }
-} elseif ($nodeDeps.PSObject.Properties.Name -contains 'GlobalPackages') {
-    $packages = $nodeDeps.GlobalPackages
 }
 
 if (-not $packages) {

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -59,11 +59,16 @@ if ($Config.Node_Dependencies -is [hashtable]) {
 if ($installNpm) {
 
 # Determine frontend path
-$frontendPath = if ($nodeDeps.NpmPath) {
-
-    $nodeDeps.NpmPath
-} else {
-    Join-Path $PSScriptRoot "..\frontend"
+$frontendPath = $null
+if ($nodeDeps -is [hashtable]) {
+    if ($nodeDeps.ContainsKey('NpmPath')) {
+        $frontendPath = $nodeDeps['NpmPath']
+    }
+} elseif ($nodeDeps.PSObject.Properties.Match('NpmPath').Count -gt 0) {
+    $frontendPath = $nodeDeps.NpmPath
+}
+if (-not $frontendPath) {
+    $frontendPath = Join-Path $PSScriptRoot "..\frontend"
 }
 
 $createPath = $false


### PR DESCRIPTION
## Summary
- ensure NpmPath is read from hashtables
- remove stray `elseif` in Install-NodeGlobalPackages

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: Tests Passed: 36, Failed: 2)*

------
https://chatgpt.com/codex/tasks/task_e_6847ea21843483318cb2f71ded73a9b9