### PR TITLE
Fix Install-CA test call

### DIFF
--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -18,8 +18,7 @@ Describe '0104_Install-CA script' {
         function global:Install-AdcsCertificationAuthority {}
         Mock Install-AdcsCertificationAuthority {}
 
-        . $scriptPath
-        Install-CA -Config $config -Confirm:$false
+        & $scriptPath -Config $config -Confirm:$false
 
         Assert-MockCalled Install-AdcsCertificationAuthority -Times 1
     }
@@ -34,8 +33,7 @@ Describe '0104_Install-CA script' {
         function global:Install-AdcsCertificationAuthority {}
         Mock Install-AdcsCertificationAuthority {}
 
-        . $scriptPath
-        Install-CA -Config $config -Confirm:$false
+        & $scriptPath -Config $config -Confirm:$false
 
         Should -Invoke -CommandName Install-AdcsCertificationAuthority -Times 0
     }


### PR DESCRIPTION
## Summary
- invoke CA script with normal call, not dot-source

## Testing
- `Invoke-Pester -Path tests/Install-CA.Tests.ps1 -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_6847eb6c64ac8331950f825209540252