### PR TITLE
Add gh auth step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Authenticate gh
+        shell: bash
+        run: gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
       - name: Install PowerShell
         if: runner.os != 'Windows'
         shell: bash
@@ -65,6 +68,9 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
+      - name: Authenticate gh
+        shell: bash
+        run: gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
       - name: Install PowerShell
         if: runner.os != 'Windows'
         shell: bash
@@ -129,6 +135,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Authenticate gh
+        shell: bash
+        run: gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- authenticate GitHub CLI before running any scripts in the CI matrix

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path . -Recurse`
- `Invoke-Pester -Path tests -CI -ErrorAction Stop` *(fails: Expected npm to be called at least 1 times)*

------
https://chatgpt.com/codex/tasks/task_e_6847ebd17674833181c718ddb7832905