### PR TITLE
Fix CLI test import path

### DIFF
--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -1,5 +1,9 @@
 from pathlib import Path
+import sys
 from typer.testing import CliRunner
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from labctl.cli import app
 
 CONFIG_PATH = Path(__file__).resolve().parents[2] / "config_files" / "default-config.json"


### PR DESCRIPTION
## Summary
- ensure `labctl` package path is appended in tests

## Testing
- `ruff check .`
- `poetry run pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ebebfb548331a6eb509419ed8475