### PR TITLE
Add input checks for PEM conversion

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -7,6 +7,12 @@ function Convert-CerToPem {
         [string]$CerPath,
         [string]$PemPath
     )
+    if ([string]::IsNullOrWhiteSpace($CerPath)) {
+        throw 'Convert-CerToPem: CerPath is required'
+    }
+    if ([string]::IsNullOrWhiteSpace($PemPath)) {
+        throw 'Convert-CerToPem: PemPath is required'
+    }
     if (-not $PSCmdlet.ShouldProcess($PemPath, 'Create PEM file')) { return }
 
     $bytes = [System.IO.File]::ReadAllBytes($CerPath)
@@ -25,6 +31,15 @@ function Convert-PfxToPem {
         [string]$CertPath,
         [string]$KeyPath
     )
+    if ([string]::IsNullOrWhiteSpace($PfxPath)) {
+        throw 'Convert-PfxToPem: PfxPath is required'
+    }
+    if ([string]::IsNullOrWhiteSpace($CertPath)) {
+        throw 'Convert-PfxToPem: CertPath is required'
+    }
+    if ([string]::IsNullOrWhiteSpace($KeyPath)) {
+        throw 'Convert-PfxToPem: KeyPath is required'
+    }
     if (-not $PSCmdlet.ShouldProcess($PfxPath, 'Convert PFX to PEM')) { return }
     $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($PfxPath,$Password,[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
     $certBytes = $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -169,3 +169,23 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($IsLinux -or $IsMac
         Remove-Item $pfx -ErrorAction SilentlyContinue
     }
 }
+
+Describe 'Convert certificate helpers validate paths' -Skip:($IsLinux -or $IsMacOS) {
+    It 'errors when CerPath or PemPath is missing' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        . $scriptPath
+        { Convert-CerToPem -CerPath '' -PemPath 'x' } | Should -Throw 'Convert-CerToPem: CerPath is required'
+        { Convert-CerToPem -CerPath 'x' -PemPath '' } | Should -Throw 'Convert-CerToPem: PemPath is required'
+    }
+
+    It 'errors when PfxPath, CertPath, or KeyPath is missing' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        . $scriptPath
+        $pwd = New-Object System.Security.SecureString
+        foreach ($c in 'pw'.ToCharArray()) { $pwd.AppendChar($c) }
+        $pwd.MakeReadOnly()
+        { Convert-PfxToPem -PfxPath '' -Password $pwd -CertPath 'c' -KeyPath 'k' } | Should -Throw 'Convert-PfxToPem: PfxPath is required'
+        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath '' -KeyPath 'k' } | Should -Throw 'Convert-PfxToPem: CertPath is required'
+        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath 'c' -KeyPath '' } | Should -Throw 'Convert-PfxToPem: KeyPath is required'
+    }
+}


### PR DESCRIPTION
## Summary
- validate file paths in `Convert-CerToPem` and `Convert-PfxToPem`
- ensure tests expect validation errors

## Testing
- `Invoke-ScriptAnalyzer -Path . -EnableExit`
- `Invoke-Pester` *(fails: Tests Passed: 36, Failed: 2, Skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_6847ec31c6d883319410565f839c215d