### PR TITLE
Improve platform detection for reboot script

### DIFF
--- a/lab_utils/Get-Platform.ps1
+++ b/lab_utils/Get-Platform.ps1
@@ -1,7 +1,13 @@
 function Get-Platform {
-    if ($IsWindows) { return 'Windows' }
-    elseif ($IsLinux) { return 'Linux' }
-    elseif ($IsMacOS) { return 'MacOS' }
+    if ($IsWindows -or [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        return 'Windows'
+    }
+    elseif ($IsLinux -or [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Linux)) {
+        return 'Linux'
+    }
+    elseif ($IsMacOS -or [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX)) {
+        return 'MacOS'
+    }
     elseif ($PSVersionTable.OS) {
         if ($PSVersionTable.OS -match 'Windows') { return 'Windows' }
         elseif ($PSVersionTable.OS -match 'Darwin') { return 'MacOS' }


### PR DESCRIPTION
## Summary
- account for OS detection using RuntimeInformation

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6847edb9c3e483318d125e15069cdb91