### PR TITLE
Update Reset-Git gh clone test

### DIFF
--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -28,6 +28,7 @@ Describe '0001_Reset-Git' -Skip:($IsLinux -or $IsMacOS) {
             Mock Get-Command { @{ Name = 'gh'; Path = 'gh.exe' } } -ParameterFilter { $Name -eq 'gh' }
             function global:gh {}
             Mock gh { $global:LASTEXITCODE = 0 }
+            New-Item -ItemType Directory -Path (Join-Path $tempDir '.git') -Force
             Mock git {}
 
             & $script:ScriptPath -Config $config


### PR DESCRIPTION
## Summary
- adjust `Reset-Git.Tests.ps1` to create `.git` when gh clone succeeds

## Testing
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Path tests'` *(fails: Tests Passed: 36, Failed: 2)*

------
https://chatgpt.com/codex/tasks/task_e_6847eb7d63608331bcf835797209972e