### PR TITLE
Fix Test-IsAdmin mocking

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -11,7 +11,6 @@ if ($IsLinux -or $IsMacOS) { return }
     BeforeEach {
         $script:temp = Join-Path $TestDrive ([System.Guid]::NewGuid())
         New-Item -ItemType Directory -Path $script:temp | Out-Null
-        function global:Test-IsAdmin {}
     }
 
     AfterEach {
@@ -34,7 +33,7 @@ if ($IsLinux -or $IsMacOS) { return }
             } else { 'dummy' | Set-Content $OutFile }
         }
         Mock Expand-Archive {}
-        Mock Test-IsAdmin { $false }
+        function global:Test-IsAdmin { $false }
         $script:logFile = $null
         $Env:Programfiles = $temp
         $global:startProcessCalled = $false
@@ -92,7 +91,7 @@ if ($IsLinux -or $IsMacOS) { return }
             } else { 'dummy' | Set-Content $OutFile }
         }
         Mock Expand-Archive {}
-        Mock Test-IsAdmin { $false }
+        function global:Test-IsAdmin { $false }
         $Env:Programfiles = $temp
         $global:startProcessCalled = $false
         function global:Start-Process {


### PR DESCRIPTION
## Summary
- adjust OpenTofuInstaller tests to override `Test-IsAdmin` globally

## Testing
- `ruff check .`
- `Invoke-Pester` *(fails: Tests Passed: 36, Failed: 2)*

------
https://chatgpt.com/codex/tasks/task_e_6847ec3ea1048331bbcbb80763808b75