### PR TITLE
Fix NodeDeps hashtable handling

### DIFF
--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -70,24 +70,15 @@ if ($nodeDeps -is [hashtable] -and $nodeDeps.ContainsKey('GlobalPackages')) {
     $packages = $nodeDeps.GlobalPackages
 
 } else {
-    if ($nodeDeps.InstallYarn) {
-        $packages += 'yarn'
+    if ($nodeDeps -is [hashtable]) {
+        if ($nodeDeps['InstallYarn'])    { $packages += 'yarn' }
+        if ($nodeDeps['InstallVite'])    { $packages += 'vite' }
+        if ($nodeDeps['InstallNodemon']) { $packages += 'nodemon' }
     } else {
-        Write-CustomLog "InstallYarn flag is disabled. Skipping yarn installation."
+        if ($nodeDeps.InstallYarn)    { $packages += 'yarn' }
+        if ($nodeDeps.InstallVite)    { $packages += 'vite' }
+        if ($nodeDeps.InstallNodemon) { $packages += 'nodemon' }
     }
-
-    if ($nodeDeps.InstallVite) {
-        $packages += 'vite'
-    } else {
-        Write-CustomLog "InstallVite flag is disabled. Skipping vite installation."
-    }
-
-    if ($nodeDeps.InstallNodemon) {
-        $packages += 'nodemon'
-    } else {
-        Write-CustomLog "InstallNodemon flag is disabled. Skipping nodemon installation."
-    }
-
 }
 
 if (-not $packages) {


### PR DESCRIPTION
## Summary
- clean up 0202_Install-NodeGlobalPackages.ps1
  - properly check boolean flags when `$nodeDeps` is a hashtable
  - drop duplicate "flag is disabled" messages in the main branch

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ef5b7d14833197de327dc6d22e31