### PR TITLE
Fix NodeScript tests' parameter filters

### DIFF
--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -53,7 +53,7 @@ Describe 'Node installation scripts' {
         $global = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0202_Install-NodeGlobalPackages.ps1')).Path
         Mock Get-Command { @{Name='npm'} } -ParameterFilter { $Name -eq 'npm' }
         function npm {
-            param([string[]]$testArgs)
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]]$testArgs)
             $null = $testArgs
         }
         Mock npm {}
@@ -61,9 +61,9 @@ Describe 'Node installation scripts' {
         . $global -Config $config
 
         Install-NodeGlobalPackages -Config $cfg
-        Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
-        Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','nodemon') } -Times 1
-        Should -Invoke -CommandName npm -Times 0 -ParameterFilter { $testArgs -eq @('install','-g','vite') }
+        Assert-MockCalled npm -ParameterFilter { ($testArgs -join ' ') -eq 'install -g yarn' } -Times 1
+        Assert-MockCalled npm -ParameterFilter { ($testArgs -join ' ') -eq 'install -g nodemon' } -Times 1
+        Should -Invoke -CommandName npm -Times 0 -ParameterFilter { ($testArgs -join ' ') -eq 'install -g vite' }
     }
 
     It 'falls back to boolean flags when GlobalPackages is missing' {
@@ -71,7 +71,7 @@ Describe 'Node installation scripts' {
         $global = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0202_Install-NodeGlobalPackages.ps1')).Path
         Mock Get-Command { @{Name='npm'} } -ParameterFilter { $Name -eq 'npm' }
         function npm {
-            param([string[]]$testArgs)
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]]$testArgs)
             $null = $testArgs
         }
         Mock npm {}
@@ -79,16 +79,16 @@ Describe 'Node installation scripts' {
         . $global -Config $config
 
         Install-NodeGlobalPackages -Config $cfg
-        Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','yarn') } -Times 1
-        Assert-MockCalled npm -ParameterFilter { $testArgs -eq @('install','-g','nodemon') } -Times 1
-        Should -Invoke -CommandName npm -Times 0 -ParameterFilter { $testArgs -eq @('install','-g','vite') }
+        Assert-MockCalled npm -ParameterFilter { ($testArgs -join ' ') -eq 'install -g yarn' } -Times 1
+        Assert-MockCalled npm -ParameterFilter { ($testArgs -join ' ') -eq 'install -g nodemon' } -Times 1
+        Should -Invoke -CommandName npm -Times 0 -ParameterFilter { ($testArgs -join ' ') -eq 'install -g vite' }
     }
 
     It 'honours -WhatIf for Install-GlobalPackage' {
     
         $global = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0202_Install-NodeGlobalPackages.ps1')).Path
 
-        function npm { param([string[]]$testArgs) }
+        function npm { param([Parameter(ValueFromRemainingArguments = $true)][string[]]$testArgs) }
         Mock npm {}
         . $global
         Install-NodeGlobalPackages -Config @{ Node_Dependencies = @{ InstallYarn=$false; InstallVite=$false; InstallNodemon=$false } } -WhatIf
@@ -101,7 +101,7 @@ Describe 'Node installation scripts' {
         New-Item -ItemType File -Path (Join-Path $temp 'package.json') | Out-Null
         $cfg = @{ Node_Dependencies = @{ NpmPath = $temp } }
         function npm {
-            param([string[]]$testArgs)
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]]$testArgs)
             $null = $testArgs
         }
         $npmPath = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0203_Install-npm.ps1')).Path


### PR DESCRIPTION
## Summary
- match npm argument arrays using joined string comparison
- collect remaining npm arguments so tests detect the call

## Testing
- `Invoke-ScriptAnalyzer -Path .`
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_6847ef5abe40833198a4a6f390346bc0