### PR TITLE
Add interactive menu loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Detailed guides and module references are located in the [docs](docs/) directory
      - Prompts for authentication if not already authenticated.
      - Run `gh auth login` before using `0001_Reset-Git.ps1` or `0009_Initialize-OpenTofu.ps1`.
   4) Clones this repository from config.json -> RepoUrl to config.json -> LocalPath (or a default path).
-  5) Invokes runner.ps1 from this repo. Runner can be ran with optional parameters to automatically run, but it will prompt you to manually select which scripts to run by default.
+  5) Invokes runner.ps1 from this repo. Runner can be ran with optional parameters to automatically run, but it will prompt you to manually select which scripts to run by default. After a selection completes, the menu is shown again so you can run more scripts or type `exit` to quit.
      - Use `-ConfigFile <path>` to specify an alternative configuration file. If omitted, `runner.ps1` loads `config_files/default-config.json`.
      - See [docs/runner.md](docs/runner.md) for detailed usage including non-interactive mode.
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -11,7 +11,7 @@ Simply invoke the script with no parameters:
 ./runner.ps1
 ```
 
-You will be shown a menu to choose which scripts to run. This path is taken when the `-Scripts` parameter is omitted, as seen around lines 259-275 of `runner.ps1`.
+You will be shown a menu to choose which scripts to run. After the selected scripts complete, the menu will appear again so you can run additional scripts without restarting the runner. Type `exit` at the prompt when you are finished.
 
 ## Non-interactive mode
 

--- a/runner.ps1
+++ b/runner.ps1
@@ -264,12 +264,16 @@ if ($Scripts) {
     exit 0
 }
 
-$selection = Prompt-Scripts
-if ($selection.Count -eq 0) {
-    Write-CustomLog 'No scripts selected.'
-    exit 0
+$overallSuccess = $true
+while ($true) {
+    $selection = Prompt-Scripts
+    if ($selection.Count -eq 0) {
+        Write-CustomLog 'No scripts selected.'
+        break
+    }
+    if (-not (Invoke-Scripts -ScriptsToRun $selection)) { $overallSuccess = $false }
 }
-if (-not (Invoke-Scripts -ScriptsToRun $selection)) { exit 1 }
 
 Write-CustomLog "`nAll done!"
+if (-not $overallSuccess) { exit 1 }
 exit 0

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -259,13 +259,20 @@ Param([PSCustomObject]`$Config)
             'Param([PSCustomObject]$Config)
 exit 0' | Set-Content -Path $dummy
 
-            Mock Get-MenuSelection { '0001_Test.ps1' }
+            $script:idx = 0
+            Mock Get-MenuSelection {
+                if ($script:idx -eq 0) {
+                    $script:idx++
+                    return '0001_Test.ps1'
+                }
+                return @()
+            }
 
             Push-Location $tempDir
             & "$tempDir/runner.ps1" -Auto | Out-Null
             Pop-Location
 
-            Assert-MockCalled Get-MenuSelection -Times 1
+            Assert-MockCalled Get-MenuSelection -Times 2
         } finally {
             Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         }


### PR DESCRIPTION
## Summary
- rerun selection menu after executing scripts
- note behavior in docs and README
- adjust tests for menu loop

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer` *(failed: `pwsh` not installed)*
- `Invoke-Pester` *(failed: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847f48276908331a0d90c200ff8eecb