### PR TITLE
Add help block for npm install script

### DIFF
--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -13,6 +13,20 @@ function Install-NpmDependencies {
         param($Config)
 
         Write-CustomLog 'Running 0203_Install-npm.ps1'
+<#
+.SYNOPSIS
+    Installs npm dependencies for the frontend project.
+
+.DESCRIPTION
+    Runs `npm install` in the configured frontend directory.
+    Can create the directory and a blank package.json when enabled.
+
+.PARAMETER Config
+    Hashed config object passed from runner.ps1
+
+.EXAMPLE
+    .\0203_Install-npm.ps1 -Config $Config
+#>
 
         # Pull Node_Dependencies block
         $nodeDeps = if ($Config -is [hashtable]) { $Config['Node_Dependencies'] } else { $Config.Node_Dependencies }


### PR DESCRIPTION
## Summary
- update `0203_Install-npm.ps1` with comment-based help

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer"` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f5360b648331a582ac0359a461ff