### PR TITLE
Use static CA certificate in tests

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -94,10 +94,11 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
             $pwd
         }
 
-        # create dummy certificate files for conversion
+        # prepare certificate files for conversion using static test data
         $rootCaName = $config.CertificateAuthority.CommonName
         $hostName   = [System.Net.Dns]::GetHostName()
-        'dummy' | Set-Content -Path (Join-Path $PWD "$rootCaName.cer")
+        $sourceCert = Join-Path $PSScriptRoot 'data' 'TestCA.cer'
+        Copy-Item -Path $sourceCert -Destination (Join-Path $PWD "$rootCaName.cer") -Force
         'dummy' | Set-Content -Path (Join-Path $PWD "$hostName.pfx")
 
         $providerFile = Join-Path $tempDir 'providers.tf'
@@ -123,6 +124,13 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         Test-Path (Join-Path $tempDir ("$(hostname).pem")) | Should -BeTrue
         Test-Path (Join-Path $tempDir ("$(hostname)-key.pem")) | Should -BeTrue
         (Get-Content $providerFile -Raw) | Should -Match 'insecure\s*=\s*false'
+
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $PWD "$rootCaName.cer") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $PWD "$rootCaName.pem") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $PWD "$hostName.pfx") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $PWD "$hostName.pem") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $PWD "$hostName-key.pem") -ErrorAction SilentlyContinue
     }
 
     It 'does not redefine Convert-PfxToPem when sourced twice' {

--- a/tests/data/TestCA.cer
+++ b/tests/data/TestCA.cer
@@ -1,0 +1,1 @@
+Dummy Test Certificate


### PR DESCRIPTION
## Summary
- add placeholder certificate under tests/data
- read the static cert in `PrepareHyperVProvider.Tests.ps1`
- clean up generated certificate files after running the test

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path . -Recurse"`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Invoke-Pester not found / interactive issues)*

------
https://chatgpt.com/codex/tasks/task_e_6847f537c7d483318b334de35e06929c