### PR TITLE
Fix Get-MenuSelection mocking in runner tests

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -18,14 +18,14 @@ $script:Quiet = $Quiet.IsPresent
 . (Join-Path $PSScriptRoot 'runner_utility_scripts' 'Logger.ps1')
 . (Join-Path $PSScriptRoot 'lab_utils' 'Get-LabConfig.ps1')
 . (Join-Path $PSScriptRoot 'lab_utils' 'Format-Config.ps1')
-. (Join-Path $PSScriptRoot 'lab_utils' 'Menu.ps1')
-
 $menuPath = Join-Path $PSScriptRoot 'lab_utils' 'Menu.ps1'
 if (-not (Test-Path $menuPath)) {
     Write-Error "Menu module not found at $menuPath"
     exit 1
 }
-. $menuPath
+if (-not (Get-Command Get-MenuSelection -ErrorAction SilentlyContinue)) {
+    . $menuPath
+}
 
 
 # ─── Default log path ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- avoid redefining `Get-MenuSelection` when already present

## Testing
- `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f6ea2e948331b7d06d509406ce5a