### PR TITLE
Introduce verbosity switch and slim logging

### DIFF
--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -17,15 +17,17 @@ Describe 'Write-CustomLog' {
         Set-StrictMode -Off
     }
 
-    It 'writes to specified log file when provided' {
-
+    It 'appends to log file when LogFilePath is set' {
         $tempFile = (Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())) + '.log'
-        Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
-        Remove-Variable -Name LogFilePath -Scope Global -ErrorAction SilentlyContinue
-        Write-CustomLog 'hello world' -LogFile $tempFile
-        $content = Get-Content $tempFile -Raw
-        $content | Should -Match 'hello world'
-        Remove-Item $tempFile -ErrorAction SilentlyContinue
+        $script:LogFilePath = $tempFile
+        try {
+            Write-CustomLog 'hello world'
+            $content = Get-Content $tempFile -Raw
+            $content | Should -Match 'hello world'
+        } finally {
+            Remove-Item $tempFile -ErrorAction SilentlyContinue
+            Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
+        }
     }
 
     It 'defaults to LogFilePath variable when not provided' {


### PR DESCRIPTION
## Summary
- add Verbosity parameter and console level to kicker bootstrap
- refactor fallback logger to respect verbosity
- pipe git operations to log files
- add matching Verbosity parameter to runner
- overhaul `Write-CustomLog` implementation
- update logger tests for new behavior

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path . -Recurse`
- `Invoke-Pester -CI` *(failed: prompts for script parameters)*

------
https://chatgpt.com/codex/tasks/task_e_6847f63e0cdc8331b38671a394d1003d