### PR TITLE
Fix npm tests to pass Config

### DIFF
--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -15,7 +15,7 @@ Describe '0203_Install-npm' {
         }
 
 
-        . $script
+        . $script -Config $cfg
         Install-NpmDependencies -Config $cfg
 
         $script:calledPath | Should -Be (Get-Item $npmDir).FullName
@@ -36,7 +36,7 @@ Describe '0203_Install-npm' {
             $null = $testArgs
         }
 
-        . $script
+        . $script -Config $cfg
         Install-NpmDependencies -Config $cfg
         $success = $?
 
@@ -54,7 +54,7 @@ Describe '0203_Install-npm' {
         $script:called = $false
         function global:npm { $script:called = $true }
 
-        . $script
+        . $script -Config $cfg
         { Install-NpmDependencies -Config $cfg } | Should -Throw
         $script:called | Should -BeFalse
         Remove-Item function:npm -ErrorAction SilentlyContinue
@@ -67,7 +67,7 @@ Describe '0203_Install-npm' {
         $script:called = $false
         function global:npm { $script:called = $true }
 
-        . $script
+        . $script -Config $cfg
         { Install-NpmDependencies -Config $cfg } | Should -Throw
         $script:called | Should -BeFalse
         Remove-Item function:npm -ErrorAction SilentlyContinue
@@ -81,7 +81,7 @@ Describe '0203_Install-npm' {
         $script:calledPath = $null
         function global:npm { param([string[]]$Args) $script:calledPath = (Get-Location).Path }
 
-        . $script
+        . $script -Config $cfg
         Install-NpmDependencies -Config $cfg
 
         $script:calledPath | Should -Be (Get-Item $npmDir).FullName


### PR DESCRIPTION
## Summary
- ensure `Install-npm.Tests.ps1` passes `-Config` when dot-sourcing script

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847f865a06483318d2f821c1117b3a9