### PR TITLE
Fix runner error handling

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -205,7 +205,7 @@ function Invoke-Scripts {
                 exit $LASTEXITCODE
             }
 
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Quiet.IsPresent
+            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Quiet.IsPresent 2>&1
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 
             $results[$s.Name] = $LASTEXITCODE


### PR DESCRIPTION
## Summary
- pipe child pwsh stderr so runner doesn't terminate when scripts emit errors

## Testing
- `ruff check .`
- `Invoke-Pester` *(fails: `Invoke-Pester` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f9841e4c8331b1b5bd9610b3ff65