### PR TITLE
Package config files with labctl

### DIFF
--- a/py/labctl/cli.py
+++ b/py/labctl/cli.py
@@ -1,9 +1,12 @@
 import json
 from pathlib import Path
+from importlib.resources import files
 import typer
 import yaml
 
-BASE_DIR = Path(__file__).resolve().parents[1]
+
+def default_config_path() -> Path:
+    return Path(files("labctl").joinpath("config_files", "default-config.json"))
 
 app = typer.Typer()
 hv_app = typer.Typer()
@@ -19,9 +22,7 @@ def load_config(path: Path) -> dict:
 
 @hv_app.command()
 def facts(
-    config: Path = typer.Option(
-        Path(BASE_DIR / "config_files" / "default-config.json"), exists=True
-    )
+    config: Path = typer.Option(default_config_path(), exists=True)
 ):
     """Show hypervisor facts from config."""
     cfg = load_config(config)
@@ -31,9 +32,7 @@ def facts(
 
 @hv_app.command()
 def deploy(
-    config: Path = typer.Option(
-        Path(BASE_DIR / "config_files" / "default-config.json"), exists=True
-    )
+    config: Path = typer.Option(default_config_path(), exists=True)
 ):
     """Pretend to deploy using the hypervisor config."""
     cfg = load_config(config)
@@ -43,3 +42,4 @@ def deploy(
 
 if __name__ == "__main__":
     app()
+

--- a/py/labctl/config_files/default-config.json
+++ b/py/labctl/config_files/default-config.json
@@ -1,0 +1,76 @@
+{
+  "ComputerName": "default-lab",
+  "SetComputerName": false,
+  "DNSServers": "8.8.8.8,1.1.1.1",
+  "SetDNSServers": false,
+  "TrustedHosts": "",
+  "SetTrustedHosts": false,
+  "DisableTCPIP6": false,
+  "AllowRemoteDesktop": false,
+  "ConfigureFirewall": false,
+  "FirewallPorts": [3389, 5985, 5986, 445, 135, "49152-65535"],
+  "ConfigPXE": false,
+  "InstallGit": true,
+  "InstallGitHubCLI": true,
+  "InstallPwsh": true,
+  "InstallHyperV": false,
+  "InstallWAC": false,
+  "InstallGo": false,
+  "InstallOpenTofu": false,
+  "OpenTofuVersion": "latest",
+  "InitializeOpenTofu": false,
+  "PrepareHyperVHost": false,
+  "InstallCA": false,
+  "InstallCosign": false,
+  "CosignURL": "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-windows-amd64.exe",
+  "CosignPath": "C:\\temp\\cosign",
+  "InstallGPG": false,
+  "CertificateAuthority": {
+    "CommonName": "default-lab-RootCA",
+    "ValidityYears": 5
+  },
+  "HyperV": {
+    "User": "",
+    "Password": "",
+    "Host": "",
+    "Port": 5986,
+    "Https": true,
+    "Insecure": true,
+    "UseNtlm": true,
+    "EnableManagementTools": true,
+    "TlsServerName": "",
+    "CacertPath": "",
+    "CertPath": "",
+    "KeyPath": "",
+    "ScriptPath": "C:/Temp/terraform_%RAND%.cmd",
+    "Timeout": "30s"
+  },
+  "WAC": {
+    "InstallPort": 443
+  },
+  "GitHubCLIInstallerUrl": "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_windows_amd64.msi",
+  "RepoUrl": "https://github.com/wizzense/opentofu-lab-automation.git",
+  "LocalPath": "",
+  "RunnerScriptName": "runner.ps1",
+  "ConfigFile": "./config_files/default-config.json",
+  "Go": {
+    "InstallerUrl": "https://go.dev/dl/go1.24.1.windows-amd64.msi"
+  },
+
+  "InfraRepoUrl": "https://github.com/wizzense/tofu-tan-lab.git",   
+  "InfraRepoPath": "C:\\Temp\\base-infra",
+
+  "Node_Dependencies": {
+  "InstallNode": true,
+  "InstallYarn": true,
+  "InstallVite": true,
+  "InstallNodemon": true,
+  "InstallNpm": true,
+  "GlobalPackages": ["yarn", "vite", "nodemon"],
+  "NpmPath": "C:\\Projects\\vde-mvp\\frontend",
+  "CreateNpmPath": false,
+  "Node": {
+    "InstallerUrl": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
+  }
+}
+}

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -23,3 +23,11 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.0"
 
+[tool.poetry]
+packages = [
+  { include = "labctl" }
+]
+include = [
+  "labctl/config_files/**"
+]
+

--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -4,21 +4,22 @@ from typer.testing import CliRunner
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from labctl.cli import app
+from labctl.cli import app, default_config_path
 
-CONFIG_PATH = Path(__file__).resolve().parents[2] / "config_files" / "default-config.json"
-assert CONFIG_PATH.exists(), f"Config file missing: {CONFIG_PATH}"
+
+def test_default_config_packaged():
+    assert default_config_path().exists()
 
 
 def test_hv_facts():
     runner = CliRunner()
-    result = runner.invoke(app, ["hv", "facts", "--config", str(CONFIG_PATH)])
+    result = runner.invoke(app, ["hv", "facts"])
     assert result.exit_code == 0
     assert "\"Host\"" in result.output
 
 
 def test_hv_deploy():
     runner = CliRunner()
-    result = runner.invoke(app, ["hv", "deploy", "--config", str(CONFIG_PATH)])
+    result = runner.invoke(app, ["hv", "deploy"])
     assert result.exit_code == 0
     assert "Deploying Hyper-V host" in result.output


### PR DESCRIPTION
## Summary
- include `config_files` in the labctl package
- load packaged config via `importlib.resources`
- test that the default config file is packaged and defaults work

## Testing
- `pytest -q`
- `poetry build` *(verifies wheel contents)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester" | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fd90d2c0833186346160074b816e