### PR TITLE
Fix HyperV provider path test

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -39,6 +39,7 @@ Describe 'Prepare-HyperVProvider path restoration' -Skip:($IsLinux -or $IsMacOS)
         Mock git {}
         Mock go {}
         Mock Copy-Item {}
+        Mock Convert-CerToPem {}
         Mock Read-Host {
             $pwd = New-Object System.Security.SecureString
             foreach ($c in ''.ToCharArray()) { $pwd.AppendChar($c) }


### PR DESCRIPTION
## Summary
- ensure path restoration test mocks Convert-CerToPem

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fdba3b548331b7d49dd4f96b2766