### PR TITLE
Fix Convert-PfxToPem mock cleanup

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -179,6 +179,11 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($IsLinux -or $IsMac
 }
 
 Describe 'Convert certificate helpers validate paths' -Skip:($IsLinux -or $IsMacOS) {
+    BeforeAll {
+        Remove-Mock -CommandName Convert-PfxToPem -ErrorAction SilentlyContinue
+        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        . $scriptPath
+    }
     It 'errors when CerPath or PemPath is missing' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath


### PR DESCRIPTION
## Summary
- clean up Convert-PfxToPem mock before validation tests

## Testing
- `Invoke-Pester` *(fails: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847fdcb85888331acec3697536fae28