### PR TITLE
Fix Install-npm flags handling

### DIFF
--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -38,13 +38,15 @@ function Install-NpmDependencies {
         # Determine flags
         $installNpm = $true
         $createPath = $false
-        foreach ($key in @('InstallNpm','CreateNpmPath')) {
-            if ($nodeDeps -is [hashtable]) {
-                if ($nodeDeps.ContainsKey($key)) {
-                    Set-Variable -Name $key.ToLower() -Value ([bool]$nodeDeps[$key]) -Scope Local
-                }
-            } elseif ($nodeDeps.PSObject.Properties.Match($key).Count) {
-                Set-Variable -Name $key.ToLower() -Value ([bool]$nodeDeps.$key) -Scope Local
+        if ($nodeDeps -is [hashtable]) {
+            if ($nodeDeps.ContainsKey('InstallNpm'))    { $installNpm = [bool]$nodeDeps['InstallNpm'] }
+            if ($nodeDeps.ContainsKey('CreateNpmPath')) { $createPath = [bool]$nodeDeps['CreateNpmPath'] }
+        } else {
+            if ($nodeDeps.PSObject.Properties.Match('InstallNpm').Count) {
+                $installNpm = [bool]$nodeDeps.InstallNpm
+            }
+            if ($nodeDeps.PSObject.Properties.Match('CreateNpmPath').Count) {
+                $createPath = [bool]$nodeDeps.CreateNpmPath
             }
         }
 
@@ -62,7 +64,7 @@ function Install-NpmDependencies {
         }
         if (-not $frontendPath) { $frontendPath = Join-Path $PSScriptRoot '..' 'frontend' }
 
-        if ($nodeDeps.PSObject.Properties.Match('NpmPath').Count -and [string]::IsNullOrWhiteSpace($nodeDeps.NpmPath)) {
+        if ($nodeDeps.PSObject.Properties.Match('NpmPath').Count -and [string]::IsNullOrWhiteSpace($nodeDeps.NpmPath) -and -not $createPath) {
             throw 'Node_Dependencies.NpmPath is empty and CreateNpmPath is false.'
         }
 

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -8,6 +8,7 @@ Describe 'Node installation scripts' {
         $script:npm    = (Resolve-Path -ErrorAction Stop (Join-Path $script:scriptRoot '0203_Install-npm.ps1')).Path
         $env:TEMP = Join-Path ([System.IO.Path]::GetTempPath()) 'pester-temp'
         New-Item -ItemType Directory -Path $env:TEMP -Force | Out-Null
+        $script:config = [pscustomobject]@{}
     }
 
     It 'resolves script paths from the tests directory' {


### PR DESCRIPTION
## Summary
- handle InstallNpm/CreateNpmPath correctly in Install-npm script
- honour CreateNpmPath when NpmPath is blank
- initialise `$config` in NodeScripts tests

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_6847fd75da2c8331b42c8e153df49b43