### PR TITLE
Update Prepare-HyperVProvider certificate logic

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -78,6 +78,8 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         Mock Test-Path { $false }
         Mock git {}
         Mock go {}
+        Mock Import-PfxCertificate {}
+        Mock New-SelfSignedCertificate {}
         Mock Convert-CerToPem {
             param($CerPath, $PemPath)
             & $script:origConvertCerToPem -CerPath $CerPath -PemPath $PemPath
@@ -99,6 +101,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         $hostName   = [System.Net.Dns]::GetHostName()
         $sourceCert = Join-Path $PSScriptRoot 'data' 'TestCA.cer'
         Copy-Item -Path $sourceCert -Destination (Join-Path $PWD "$rootCaName.cer") -Force
+        'dummy' | Set-Content -Path (Join-Path $PWD "$rootCaName.pfx")
         'dummy' | Set-Content -Path (Join-Path $PWD "$hostName.pfx")
 
         $providerFile = Join-Path $tempDir 'providers.tf'
@@ -117,6 +120,8 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         . $script:scriptPath -Config $config
         $cmdAfter  = Get-Command Convert-PfxToPem
         $cmdAfter | Should -Be $cmdBefore
+        Assert-MockCalled Import-PfxCertificate -Times 2
+        Assert-MockCalled New-SelfSignedCertificate -Times 0
         Assert-MockCalled Convert-CerToPem -Times 1
         Assert-MockCalled Convert-PfxToPem -Times 1
 
@@ -128,6 +133,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         Remove-Item (Join-Path $PWD "$rootCaName.cer") -ErrorAction SilentlyContinue
         Remove-Item (Join-Path $PWD "$rootCaName.pem") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $PWD "$rootCaName.pfx") -ErrorAction SilentlyContinue
         Remove-Item (Join-Path $PWD "$hostName.pfx") -ErrorAction SilentlyContinue
         Remove-Item (Join-Path $PWD "$hostName.pem") -ErrorAction SilentlyContinue
         Remove-Item (Join-Path $PWD "$hostName-key.pem") -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- reuse saved CA cert files in `0010_Prepare-HyperVProvider.ps1`
- ensure PEM generation honours existing files
- test certificate import path

## Testing
- `Invoke-Pester` *(fails: Frontend folder not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fdc0ed58833188e60676b0e0118c