### PR TITLE
Fix Reset-Git test for gh mock

### DIFF
--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -28,8 +28,10 @@ Describe '0001_Reset-Git' -Skip:($IsLinux -or $IsMacOS) {
             Mock Get-Command { @{ Name = 'gh'; Path = 'gh.exe' } } -ParameterFilter { $Name -eq 'gh' }
             function global:gh {}
             
-            Mock gh { $global:LASTEXITCODE = 0 }
-            New-Item -ItemType Directory -Path (Join-Path $tempDir '.git') -Force
+            Mock gh {
+                $global:LASTEXITCODE = 0
+                New-Item -ItemType Directory -Path (Join-Path $tempDir '.git') -Force | Out-Null
+            }
 
             Mock git {}
 


### PR DESCRIPTION
## Summary
- update tests to create `.git` directory inside the `gh` mock

## Testing
- `Invoke-Pester tests/Reset-Git.Tests.ps1` *(fails to run any tests on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_6847fdd711048331bceaa0c8e3b2f86a