### PR TITLE
Handle git safe directory in bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,15 @@ gh repo clone <owner/repo>
 Using `gh` avoids the COM initialization issues seen with some Git installations
 and prevents Git from prompting for a username like `user@github.com`.
 
+The bootstrap script automatically marks the cloned repository as a
+`safe.directory` in your global Git config. If you encounter a
+"detected dubious ownership" error when running Git manually,
+add the path yourself:
+
+```powershell
+git config --global --add safe.directory <path>
+```
+
 ## Running tests
 
 PowerShell 7 or later is required to run the Pester suite. Install `pwsh` with

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -375,6 +375,10 @@ if (-not $repoPath) {
     exit 1
 }
 
+# Configure git safe.directory to avoid dubious ownership errors
+$resolvedRepoPath = (Resolve-Path $repoPath).ProviderPath
+& "$gitPath" config --global --add safe.directory $resolvedRepoPath 2>$null
+
 if (!(Test-Path $repoPath)) {
     Write-CustomLog "Cloning repository from $($config.RepoUrl) to $repoPath..."
 

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -23,4 +23,10 @@ Describe 'kicker-bootstrap utilities' -Skip:($IsLinux -or $IsMacOS) {
         $content | Should -Match '\$configOption\s+-match\s+"https://"'
         $content | Should -Not -Match '-ccontains'
     }
+
+    It 'adds repo path to git safe.directory' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
+        $content = Get-Content $scriptPath -Raw
+        $content | Should -Match 'gitPath"\s+config\s+--global\s+--add\s+safe.directory'
+    }
 }


### PR DESCRIPTION
## Summary
- add `git config --global --add safe.directory` to `kicker-bootstrap.ps1`
- document automatic safe directory config in README
- check for safe directory command in Pester tests

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_6847ffcff47c8331af33327d3f9b1fdc