### PR TITLE
Fix duplicate Copy-Item in Runner.Tests

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -27,7 +27,6 @@ Describe 'runner.ps1 script selection' -Skip:($IsLinux -or $IsMacOS) {
             Copy-Item (Join-Path $PSScriptRoot '..' 'runner_utility_scripts') -Destination $tempDir -Recurse
             Copy-Item (Join-Path $PSScriptRoot '..' 'lab_utils') -Destination $tempDir -Recurse
             Copy-Item (Join-Path $PSScriptRoot '..' 'config_files') -Destination (Join-Path $tempDir 'config_files') -Recurse
-            Copy-Item (Join-Path $PSScriptRoot '..' 'config_files') -Destination (Join-Path $tempDir 'config_files') -Recurse
             $scriptsDir = Join-Path $tempDir 'runner_scripts'
             $null = New-Item -ItemType Directory -Path $scriptsDir
             $dummy = Join-Path $scriptsDir '0001_Test.ps1'


### PR DESCRIPTION
## Summary
- remove redundant `Copy-Item` call in `Runner.Tests.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684801caff6c8331a5ce9666339304ec