### PR TITLE
Ignore Terraform and ruff caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ __pycache__/
 
 # Ignore log files
 *.log
+
+# Ignore development caches
+.ruff_cache/
+.terraform/
+
+# Ignore Terraform state files
+*.tfstate*


### PR DESCRIPTION
## Summary
- keep `.ruff_cache/` and `.terraform/` out of git
- avoid committing Terraform state files

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483bf63f3c8331948e0f04543c9d01