### PR TITLE
Add Pester tests for install scripts

### DIFF
--- a/tests/Install-Go.Tests.ps1
+++ b/tests/Install-Go.Tests.ps1
@@ -1,0 +1,37 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+if ($IsLinux -or $IsMacOS) { return }
+Describe '0007_Install-Go' -Skip:($IsLinux -or $IsMacOS) {
+    BeforeAll { $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0007_Install-Go.ps1' }
+
+    It 'installs Go when enabled' {
+        $cfg = [pscustomobject]@{ InstallGo = $true; Go = @{ InstallerUrl = 'http://example.com/go.msi' } }
+        Mock Get-Command {} -ParameterFilter { $Name -eq 'go' }
+        Mock Invoke-WebRequest {}
+        Mock Start-Process {}
+        Mock Write-CustomLog {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Invoke-WebRequest -ParameterFilter { $Uri -eq $cfg.Go.InstallerUrl } -Times 1
+        Assert-MockCalled Start-Process -ParameterFilter { $FilePath -eq 'msiexec.exe' } -Times 1
+    }
+
+    It 'skips when InstallGo is false' {
+        $cfg = [pscustomobject]@{ InstallGo = $false; Go = @{ InstallerUrl = 'http://example.com/go.msi' } }
+        Mock Invoke-WebRequest {}
+        Mock Start-Process {}
+        Mock Write-CustomLog {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Invoke-WebRequest -Times 0
+        Assert-MockCalled Start-Process -Times 0
+    }
+
+    It 'does nothing when Go is already installed' {
+        $cfg = [pscustomobject]@{ InstallGo = $true; Go = @{ InstallerUrl = 'http://example.com/go.msi' } }
+        Mock Get-Command { @{ Name = 'go' } } -ParameterFilter { $Name -eq 'go' }
+        Mock Invoke-WebRequest {}
+        Mock Start-Process {}
+        Mock Write-CustomLog {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Invoke-WebRequest -Times 0
+        Assert-MockCalled Start-Process -Times 0
+    }
+}

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -1,0 +1,31 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+if ($IsLinux -or $IsMacOS) { return }
+Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
+    BeforeAll { $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0008_Install-OpenTofu.ps1' }
+
+    It 'calls OpenTofuInstaller when enabled' {
+        $cfg = [pscustomobject]@{
+            InstallOpenTofu = $true
+            CosignPath      = 'C:\\temp'
+            OpenTofuVersion = '1.2.3'
+        }
+        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        Mock $installerPath {}
+        Mock Write-CustomLog {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled $installerPath -Times 1 -ParameterFilter {
+            $installMethod -eq 'standalone' -and
+            $cosignPath -eq (Join-Path $cfg.CosignPath 'cosign-windows-amd64.exe') -and
+            $opentofuVersion -eq $cfg.OpenTofuVersion
+        }
+    }
+
+    It 'skips install when flag is false' {
+        $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
+        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        Mock $installerPath {}
+        Mock Write-CustomLog {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled $installerPath -Times 0
+    }
+}

--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -1,0 +1,36 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+if ($IsLinux -or $IsMacOS) { return }
+Describe '0006_Install-ValidationTools' -Skip:($IsLinux -or $IsMacOS) {
+    BeforeAll {
+        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0006_Install-ValidationTools.ps1'
+    }
+
+    It 'downloads cosign when InstallCosign is true' {
+        $cfg = [pscustomobject]@{
+            InstallCosign = $true
+            CosignURL     = 'http://example.com/cosign.exe'
+            CosignPath    = Join-Path $env:TEMP ([guid]::NewGuid())
+        }
+        Mock Invoke-WebRequest {}
+        Mock New-Item {}
+        Mock Test-Path { $false }
+        Mock Write-CustomLog {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Invoke-WebRequest -Times 1 -ParameterFilter { $Uri -eq $cfg.CosignURL }
+    }
+
+    It 'checks for gpg when InstallGpg is true' {
+        $cfg = [pscustomobject]@{ InstallGpg = $true }
+        Mock Get-Command {} -ParameterFilter { $Name -eq 'gpg' }
+        Mock Write-CustomLog {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Get-Command -ParameterFilter { $Name -eq 'gpg' } -Times 1
+    }
+
+    It 'logs a message when no option specified' {
+        $cfg = [pscustomobject]@{ InstallCosign = $false; InstallGpg = $false }
+        Mock Write-CustomLog {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Write-CustomLog -ParameterFilter { $Message -like 'No installation option*' } -Times 1
+    }
+}


### PR DESCRIPTION
## Summary
- cover Install-ValidationTools, Install-Go and Install-OpenTofu scripts with new tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI"`

------
https://chatgpt.com/codex/tasks/task_e_68483bffb5f48331af79ba29427babed