### PR TITLE
Document local test commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,16 +11,23 @@ consistently across images.
 
 ## Running tests
 
-1. Install PowerShell and the Pester module if they are not already available.
-2. From the repository root, execute:
+Run the Pester suite using PowerShell:
 
-```powershell
-Invoke-Pester -Path tests
+```bash
+pwsh -NoLogo -NoProfile -Command "Invoke-Pester"
 ```
 
-This runs the test suite found under the `tests/` directory. When adding
-Windows‑specific tests, guard them with `-Skip:($IsLinux -or $IsMacOS)` so the
-suite succeeds across all platforms.
+Python tests live under the `py` directory:
+
+```bash
+cd py && pytest
+```
+
+The `task test` shortcut (defined in InvokeBuild) wraps these commands and
+executes the same steps as the CI pipeline.
+
+When adding Windows‑specific tests, guard them with
+`-Skip:($IsLinux -or $IsMacOS)` so the suite succeeds across all platforms.
 
 ## CI failure issues
 


### PR DESCRIPTION
## Summary
- explain how to run tests in `CONTRIBUTING.md`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `cd py && pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68483c0171f88331813bba87b8dfd9a0