### PR TITLE
Fix OpenTofu installer test path

### DIFF
--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -9,7 +9,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
             CosignPath      = 'C:\\temp'
             OpenTofuVersion = '1.2.3'
         }
-        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $installerPath = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1')).Path
         Mock $installerPath {}
         Mock Write-CustomLog {}
         & $script:ScriptPath -Config $cfg
@@ -22,7 +22,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
 
     It 'skips install when flag is false' {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
-        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $installerPath = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1')).Path
         Mock $installerPath {}
         Mock Write-CustomLog {}
         & $script:ScriptPath -Config $cfg


### PR DESCRIPTION
## Summary
- resolve OpenTofuInstaller path in `Install-OpenTofu.Tests.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI -ErrorAction Stop"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68483ec463e0833198dfd12a0c72a231