### PR TITLE
Fix OpenTofu install test paths

### DIFF
--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -1,7 +1,13 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 if ($IsLinux -or $IsMacOS) { return }
 Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
-    BeforeAll { $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0008_Install-OpenTofu.ps1' }
+    BeforeAll {
+        $script:ScriptPath = (
+            Resolve-Path -ErrorAction Stop (
+                Join-Path $PSScriptRoot '..' 'runner_scripts' '0008_Install-OpenTofu.ps1'
+            )
+        ).Path
+    }
 
     It 'calls OpenTofuInstaller when enabled' {
         $cfg = [pscustomobject]@{
@@ -9,7 +15,11 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
             CosignPath      = 'C:\\temp'
             OpenTofuVersion = '1.2.3'
         }
-        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $installerPath = (
+            Resolve-Path -ErrorAction Stop (
+                Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+            )
+        ).Path
         Mock $installerPath {}
         Mock Write-CustomLog {}
         & $script:ScriptPath -Config $cfg
@@ -22,7 +32,11 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
 
     It 'skips install when flag is false' {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
-        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $installerPath = (
+            Resolve-Path -ErrorAction Stop (
+                Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+            )
+        ).Path
         Mock $installerPath {}
         Mock Write-CustomLog {}
         & $script:ScriptPath -Config $cfg


### PR DESCRIPTION
## Summary
- resolve script paths in `Install-OpenTofu.Tests.ps1`

## Testing
- `Invoke-Pester -CI` *(fails: pwsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68483ef06e1483318ec4c0b2ee48db5f