### PR TITLE
Fix path setup in Hyper-V prep script

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -79,6 +79,15 @@ Invoke-LabStep -Config $Config -Body {
 
 if ($Config.PrepareHyperVHost -eq $true) {
 
+# Use Config to find the infra repo path early so certificate
+# operations can copy files correctly.
+    $infraRepoPath = if ([string]::IsNullOrWhiteSpace($Config.InfraRepoPath)) {
+        Join-Path $PSScriptRoot "my-infra"
+    } else {
+        $Config.InfraRepoPath
+    }
+
+
 
 # ------------------------------
 # 1) Environment Preparation
@@ -297,12 +306,9 @@ New-NetFirewallRule -DisplayName "Windows Remote Management (HTTP-In)" -Name "Wi
 # 4) Build & Install Hyper-V Provider in InfraRepoPath
 # ------------------------------
 
-# Use Config to find the infra repo path, fallback if empty
-$infraRepoPath = if ([string]::IsNullOrWhiteSpace($Config.InfraRepoPath)) {
-    Join-Path $PSScriptRoot "my-infra"
-} else {
-    $Config.InfraRepoPath
-}
+
+# infraRepoPath is already set earlier; ensure it exists before build
+$null = New-Item -ItemType Directory -Force -Path $infraRepoPath -ErrorAction SilentlyContinue
 
 Write-CustomLog "InfraRepoPath for hyperv provider: $infraRepoPath"
 


### PR DESCRIPTION
## Summary
- set `$infraRepoPath` before using it in Hyper-V provider prep
- ensure infra repo directory exists when installing provider

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483f27ba708331a4dbb589b3a6d10c