### PR TITLE
Fix missing logger in validation tools tests

### DIFF
--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -3,6 +3,7 @@ if ($IsLinux -or $IsMacOS) { return }
 Describe '0006_Install-ValidationTools' -Skip:($IsLinux -or $IsMacOS) {
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0006_Install-ValidationTools.ps1'
+        . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
     }
 
     It 'downloads cosign when InstallCosign is true' {


### PR DESCRIPTION
## Summary
- dot-source Logger.ps1 before mocking Write-CustomLog in Install-ValidationTools tests

## Testing
- `Invoke-Pester -Path tests -ExcludeTag skip -Passthru | Select-Object -Property PassedCount,FailedCount` *(fails: environment lacks Windows support)*

------
https://chatgpt.com/codex/tasks/task_e_68483f008684833194230c6ceca9c0a9