### PR TITLE
Fix Hyper-V provider tests with certificate objects

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -93,8 +93,8 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         }
         Mock Copy-Item {}
         # certificate operations should not touch the real store
-        $rootStub = [pscustomobject]@{ Thumbprint = 'ROOT123'; Subject = "CN=$($config.CertificateAuthority.CommonName)" }
-        $hostStub = [pscustomobject]@{ Thumbprint = 'HOST123'; Subject = "CN=$(hostname)" }
+        $rootStub = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+        $hostStub = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
         $certCall = 0
         Mock New-SelfSignedCertificate { if ($certCall++ -eq 0) { $rootStub } else { $hostStub } }
         Mock Export-Certificate {}


### PR DESCRIPTION
## Summary
- use real certificate objects in HyperV provider tests so parameter binding works

## Testing
- `Invoke-Pester -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_68483f37d2cc83319f608b85e01ce406