### PR TITLE
Fix Convert-PfxToPem mock cleanup

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -198,7 +198,11 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($IsLinux -or $IsMac
 
 Describe 'Convert certificate helpers validate paths' -Skip:($IsLinux -or $IsMacOS) {
     BeforeAll {
-        Remove-Mock -CommandName Convert-PfxToPem -ErrorAction SilentlyContinue
+        if (Get-Command Unmock -ErrorAction SilentlyContinue) {
+            Unmock Convert-PfxToPem -ErrorAction SilentlyContinue
+        } elseif (Get-Command Remove-Mock -ErrorAction SilentlyContinue) {
+            Remove-Mock -CommandName Convert-PfxToPem -ErrorAction SilentlyContinue
+        }
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
     }


### PR DESCRIPTION
## Summary
- ensure Pester test un-mocks `Convert-PfxToPem` using `Unmock` when available

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI"`

------
https://chatgpt.com/codex/tasks/task_e_68483fd7fe7483319b06133aada1f173