### PR TITLE
Fix script selection loop in runner.ps1

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -257,6 +257,7 @@ function Prompt-Scripts {
     $names = $ScriptFiles | ForEach-Object { $_.Name }
     $selNames = Get-MenuSelection -Items $names -Title 'Select scripts to run' -AllowAll
     if (-not $selNames) { return @() }
+    $selNames = @($selNames)  # ensure array semantics for single selections
     return $ScriptFiles | Where-Object { $selNames -contains $_.Name }
 }
 


### PR DESCRIPTION
## Summary
- ensure Prompt-Scripts treats single selections as an array

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483fc11f9c8331b23c222d17743730