### PR TITLE
Fix cleanup script execution in runner

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -209,7 +209,7 @@ function Invoke-Scripts {
             }
 
 
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Quiet.IsPresent 2>&1
+            & pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## Summary
- ensure PowerShell script runner uses `-ExecutionPolicy Bypass`
- pass configured verbosity into child process instead of unused `$Quiet`

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path . -Recurse` *(fails: `pwsh: command not found`)*
- `Invoke-Pester -Path tests -CI` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68483f7deb74833185618aeaaa371366