### PR TITLE
Fix runner verbosity invocation and update test

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -209,7 +209,7 @@ function Invoke-Scripts {
             }
 
 
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Quiet.IsPresent 2>&1
+            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -244,7 +244,7 @@ Param([PSCustomObject]`$Config)
         finally { Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue }
     }
 
-    It 'suppresses informational logs when -Quiet is used' {
+    It 'suppresses informational logs when -Verbosity silent is used' {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $tempDir
         try {
@@ -268,7 +268,7 @@ Write-Error 'err message'
                       [Parameter(Position=1)][string]$ForegroundColor)
                 $script:logLines += $Object
             }
-            $output = & "$tempDir/runner.ps1" -Scripts '0001' -Auto -Quiet *>&1
+            $output = & "$tempDir/runner.ps1" -Scripts '0001' -Auto -Verbosity 'silent' *>&1
             Remove-Item Function:\Write-Host -ErrorAction SilentlyContinue
             Pop-Location
 


### PR DESCRIPTION
## Summary
- pass `-Verbosity` value when invoking scripts in `runner.ps1`
- align quiet log test with new `-Verbosity` switch

## Testing
- `Invoke-Pester -Path tests -CI`
- `Invoke-ScriptAnalyzer -Path runner.ps1`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68483f6eeb2c8331988082db48cfbcdc