### PR TITLE
Fix test failure in runner.ps1

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -3,9 +3,12 @@ param(
     [switch]$Auto,
     [string]$Scripts,
     [switch]$Force,
+    [switch]$Quiet,
     [ValidateSet('silent','normal','detailed')]
     [string]$Verbosity = 'normal'
 )
+
+if ($Quiet) { $Verbosity = 'silent' }
 
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     Write-Error "PowerShell 7 or later is required. Current version: $($PSVersionTable.PSVersion)"
@@ -209,7 +212,7 @@ function Invoke-Scripts {
             }
 
 
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Quiet.IsPresent 2>&1
+            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## Summary
- fix `$Quiet` variable reference when invoking child scripts
- support a `-Quiet` switch that maps to Verbosity "silent"

## Testing
- `task test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483f5f4b9c8331bdea2f1e38890ea8