### PR TITLE
Consolidate quiet interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   4) Clones this repository from config.json -> RepoUrl to config.json -> LocalPath (or a default path).
   5) Invokes runner.ps1 from this repo. Runner can be ran with optional parameters to automatically run, but it will prompt you to manually select which scripts to run by default. After a selection completes, the menu is shown again so you can run more scripts or type `exit` to quit.
      - Use `-ConfigFile <path>` to specify an alternative configuration file. If omitted, `runner.ps1` loads `config_files/default-config.json`.
-     - Use `-Quiet` to hide most informational output.
+    - Use `-Quiet` to hide most informational output. The previous `-Verbosity` option has been removed.
      - See [docs/runner.md](docs/runner.md) for detailed usage including non-interactive mode.
 
 ```
@@ -81,7 +81,7 @@ See [docs/python-cli.md](docs/python-cli.md) for further details.
   4) Clones this repository from config.json -> RepoUrl to config.json -> LocalPath (or a default path).
   5) Invokes runner.ps1 from this repo. Runner can be ran with optional parameters to automatically run, but it will prompt you to manually select which scripts to run by default. After a selection completes, the menu is shown again so you can run more scripts or type `exit` to quit.
      - Use `-ConfigFile <path>` to specify an alternative configuration file. If omitted, `runner.ps1` loads `config_files/default-config.json`.
-     - Use `-Quiet` to hide most informational output.
+    - Use `-Quiet` to hide most informational output. The previous `-Verbosity` option has been removed.
      - See [docs/runner.md](docs/runner.md) for detailed usage including non-interactive mode.
 
 ```

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -28,5 +28,7 @@ example, to run scripts `0006` and `0007` silently and non-interactively:
 ./runner.ps1 -Scripts '0006,0007' -Auto -Quiet
 ```
 
+`runner.ps1` no longer accepts a `-Verbosity` parameter.
+
 The default configuration path (`./config_files/default-config.json`) and the `-Auto` switch are defined on lines 1-6. The logic that runs scripts directly when `-Scripts` is provided lives at lines 259-264. Prompts for editing the configuration or confirming cleanup only occur when `-Auto` is not specified, as shown on lines 135-168.
 

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -16,11 +16,11 @@
 
 param(
     [string]$ConfigFile,
-    [ValidateSet('silent','normal','detailed')]
-    [string]$Verbosity = 'normal'
+    [switch]$Quiet
 )
 
 $script:VerbosityLevels = @{ silent = 0; normal = 1; detailed = 2 }
+if ($Quiet) { $Verbosity = 'silent' } else { $Verbosity = 'normal' }
 $script:ConsoleLevel    = $script:VerbosityLevels[$Verbosity]
 
 $targetBranch = 'main'
@@ -446,7 +446,8 @@ if (!(Test-Path $runnerScriptName)) {
 
 Write-CustomLog "Running $runnerScriptName from $repoPath ..."
 
-$args = @('-NoLogo','-NoProfile','-File',".\$runnerScriptName",'-ConfigFile',$ConfigFile,'-Verbosity',$Verbosity)
+$args = @('-NoLogo','-NoProfile','-File',".\$runnerScriptName",'-ConfigFile',$ConfigFile)
+if ($Quiet) { $args += '-Quiet' }
 $proc = Start-Process -FilePath $pwshPath -ArgumentList $args -Wait -NoNewWindow -PassThru
 $exitCode = $proc.ExitCode
 

--- a/runner.ps1
+++ b/runner.ps1
@@ -3,12 +3,10 @@ param(
     [switch]$Auto,
     [string]$Scripts,
     [switch]$Force,
-    [switch]$Quiet,
-    [ValidateSet('silent','normal','detailed')]
-    [string]$Verbosity = 'normal'
+    [switch]$Quiet
 )
 
-if ($Quiet) { $Verbosity = 'silent' }
+if ($Quiet) { $Verbosity = 'silent' } else { $Verbosity = 'normal' }
 
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     Write-Error "PowerShell 7 or later is required. Current version: $($PSVersionTable.PSVersion)"

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -244,7 +244,7 @@ Param([PSCustomObject]`$Config)
         finally { Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue }
     }
 
-    It 'suppresses informational logs when -Quiet is used' {
+    It 'suppresses informational logs when -Quiet is used (no -Verbosity parameter)' {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $tempDir
         try {


### PR DESCRIPTION
## Summary
- drop `-Verbosity` parameter
- use `-Quiet` switch everywhere
- update docs and tests to mention the simplified interface

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer` *(fails: `pwsh` not found)*
- `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484ba8300883318ebf406233c185e9