### PR TITLE
Fix path resolution in Install-OpenTofu test

### DIFF
--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -1,7 +1,11 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 if ($IsLinux -or $IsMacOS) { return }
 Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
-    BeforeAll { $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0008_Install-OpenTofu.ps1' }
+    BeforeAll {
+        $script:ScriptPath = (
+            Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_scripts' '0008_Install-OpenTofu.ps1')
+        ).Path
+    }
 
     It 'calls OpenTofuInstaller when enabled' {
         $cfg = [pscustomobject]@{
@@ -9,7 +13,11 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
             CosignPath      = 'C:\\temp'
             OpenTofuVersion = '1.2.3'
         }
-        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $installerPath = (
+            Resolve-Path (
+                Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+            )
+        ).Path
         Mock $installerPath {}
         Mock Write-CustomLog {}
         & $script:ScriptPath -Config $cfg
@@ -22,7 +30,11 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
 
     It 'skips install when flag is false' {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
-        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $installerPath = (
+            Resolve-Path (
+                Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+            )
+        ).Path
         Mock $installerPath {}
         Mock Write-CustomLog {}
         & $script:ScriptPath -Config $cfg


### PR DESCRIPTION
## Summary
- resolve OpenTofuInstaller path using `Resolve-Path` in `Install-OpenTofu.Tests.ps1`
- ensure script under test is also resolved
- verify tests with `Invoke-Pester`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_6848495ccd6c8331bf3c3781aff15c7f