### PR TITLE
Fix runner verbosity flag

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -21,11 +21,11 @@ Supply a comma-separated list of 4-digit script prefixes via `-Scripts` to run w
 ./runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto
 ```
 
-To suppress informational output, append the `-Quiet` switch. For
-example, to run scripts `0006` and `0007` silently and non-interactively:
+To suppress informational output, pass `-Verbosity silent`. For example,
+to run scripts `0006` and `0007` silently and non-interactively:
 
 ```powershell
-./runner.ps1 -Scripts '0006,0007' -Auto -Quiet
+./runner.ps1 -Scripts '0006,0007' -Auto -Verbosity silent
 ```
 
 The default configuration path (`./config_files/default-config.json`) and the `-Auto` switch are defined on lines 1-6. The logic that runs scripts directly when `-Scripts` is provided lives at lines 259-264. Prompts for editing the configuration or confirming cleanup only occur when `-Auto` is not specified, as shown on lines 135-168.

--- a/runner.ps1
+++ b/runner.ps1
@@ -209,7 +209,7 @@ function Invoke-Scripts {
             }
 
 
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Quiet.IsPresent 2>&1
+            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -244,7 +244,7 @@ Param([PSCustomObject]`$Config)
         finally { Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue }
     }
 
-    It 'suppresses informational logs when -Quiet is used' {
+    It 'suppresses informational logs when Verbosity is silent' {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $tempDir
         try {
@@ -268,7 +268,7 @@ Write-Error 'err message'
                       [Parameter(Position=1)][string]$ForegroundColor)
                 $script:logLines += $Object
             }
-            $output = & "$tempDir/runner.ps1" -Scripts '0001' -Auto -Quiet *>&1
+            $output = & "$tempDir/runner.ps1" -Scripts '0001' -Auto -Verbosity silent *>&1
             Remove-Item Function:\Write-Host -ErrorAction SilentlyContinue
             Pop-Location
 


### PR DESCRIPTION
## Summary
- remove unused `$Quiet.IsPresent` usage and rely on `-Verbosity`
- document silent logging with `-Verbosity silent`
- update tests for new flag mapping

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path . -Recurse`
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_684849da221083318a63383e58d5b12a