### PR TITLE
Update runner docs and help

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -1,7 +1,6 @@
 # runner.ps1 guide
 
-`runner.ps1` orchestrates the numbered scripts under `runner_scripts/`.
-It loads `config_files/default-config.json` by default and then prompts for script selection unless told otherwise.
+`runner.ps1` orchestrates the numbered scripts under `runner_scripts/`. It loads `config_files/default-config.json` by default and then prompts for script selection unless told otherwise.
 
 ## Interactive mode
 
@@ -21,12 +20,10 @@ Supply a comma-separated list of 4-digit script prefixes via `-Scripts` to run w
 ./runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto
 ```
 
-To suppress informational output, append the `-Quiet` switch. For
-example, to run scripts `0006` and `0007` silently and non-interactively:
+To suppress informational output, pass `-Verbosity silent`:
 
 ```powershell
-./runner.ps1 -Scripts '0006,0007' -Auto -Quiet
+./runner.ps1 -Scripts '0006,0007' -Auto -Verbosity silent
 ```
 
-The default configuration path (`./config_files/default-config.json`) and the `-Auto` switch are defined on lines 1-6. The logic that runs scripts directly when `-Scripts` is provided lives at lines 259-264. Prompts for editing the configuration or confirming cleanup only occur when `-Auto` is not specified, as shown on lines 135-168.
-
+Use `-Force` to enable configuration flags detected in a script even when the current config sets them to `false`. The updated value is written back to the configuration file after the script completes.

--- a/runner.ps1
+++ b/runner.ps1
@@ -1,3 +1,25 @@
+<#
+.SYNOPSIS
+  Runs numbered scripts under runner_scripts.
+.DESCRIPTION
+  Loads config_files/default-config.json and prompts for scripts to execute.
+  Provide -Scripts to run non-interactively. Use -Auto to skip confirmation
+  prompts. -Force enables any configuration flags detected in a script and
+  persists the change back to the config file. Control console output with
+  -Verbosity silent|normal|detailed.
+.PARAMETER ConfigFile
+  JSON configuration file path.
+.PARAMETER Auto
+  Skip configuration and cleanup prompts.
+.PARAMETER Scripts
+  Comma-separated list of script prefixes or 'all'.
+.PARAMETER Force
+  Enable script flags even when disabled in config and persist the update.
+.PARAMETER Verbosity
+  Set the logging verbosity level.
+.EXAMPLE
+  ./runner.ps1 -Scripts '0006,0007' -Auto -Verbosity silent
+#>
 param(
     [string]$ConfigFile = "./config_files/default-config.json",
     [switch]$Auto,
@@ -12,7 +34,7 @@ if ($PSVersionTable.PSVersion.Major -lt 7) {
     exit 1
 }
 
-# expose quiet flag to logger
+# map verbosity to numeric logging level
 $script:VerbosityLevels = @{ silent = 0; normal = 1; detailed = 2 }
 $script:ConsoleLevel    = $script:VerbosityLevels[$Verbosity]
 
@@ -209,7 +231,7 @@ function Invoke-Scripts {
             }
 
 
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Quiet.IsPresent 2>&1
+            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## Summary
- refresh runner docs for new `-Verbosity` option
- add `-Force` usage details
- embed comment-based help in `runner.ps1`
- replace old `$Quiet` variable with `$Verbosity`

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684849da646883318a3a78c0676a195c