### PR TITLE
Add Quiet switch alias in runner.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@
   4) Clones this repository from config.json -> RepoUrl to config.json -> LocalPath (or a default path).
   5) Invokes runner.ps1 from this repo. Runner can be ran with optional parameters to automatically run, but it will prompt you to manually select which scripts to run by default. After a selection completes, the menu is shown again so you can run more scripts or type `exit` to quit.
      - Use `-ConfigFile <path>` to specify an alternative configuration file. If omitted, `runner.ps1` loads `config_files/default-config.json`.
-     - Use `-Quiet` to hide most informational output.
-     - See [docs/runner.md](docs/runner.md) for detailed usage including non-interactive mode.
+    - Use `-Quiet` to hide most informational output (alias for `-Verbosity silent`).
+    - Use `-Verbosity <silent|normal|detailed>` for granular log control.
+    - See [docs/runner.md](docs/runner.md) for detailed usage including non-interactive mode.
 
 ```
 
@@ -81,7 +82,8 @@ See [docs/python-cli.md](docs/python-cli.md) for further details.
   4) Clones this repository from config.json -> RepoUrl to config.json -> LocalPath (or a default path).
   5) Invokes runner.ps1 from this repo. Runner can be ran with optional parameters to automatically run, but it will prompt you to manually select which scripts to run by default. After a selection completes, the menu is shown again so you can run more scripts or type `exit` to quit.
      - Use `-ConfigFile <path>` to specify an alternative configuration file. If omitted, `runner.ps1` loads `config_files/default-config.json`.
-     - Use `-Quiet` to hide most informational output.
+     - Use `-Quiet` to hide most informational output (alias for `-Verbosity silent`).
+     - Use `-Verbosity <silent|normal|detailed>` for granular log control.
      - See [docs/runner.md](docs/runner.md) for detailed usage including non-interactive mode.
 
 ```
@@ -159,6 +161,8 @@ Scripts `0006`–`0010` form the minimal path to a working Hyper‑V provider. O
 ```powershell
 ./runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto -Quiet
 ```
+You can also pass `-Verbosity` with `silent`, `normal`, or `detailed` to control
+the amount of console logging.
 
 Completely optional scripts I use for other tasks:
 -a----          3/7/2025   7:08 AM            616 0100_Enable-WinRM.ps1

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -21,12 +21,16 @@ Supply a comma-separated list of 4-digit script prefixes via `-Scripts` to run w
 ./runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto
 ```
 
-To suppress informational output, append the `-Quiet` switch. For
-example, to run scripts `0006` and `0007` silently and non-interactively:
+To suppress informational output, use the `-Quiet` switch (equivalent to
+`-Verbosity silent`). For example, to run scripts `0006` and `0007`
+silently and non-interactively:
 
 ```powershell
 ./runner.ps1 -Scripts '0006,0007' -Auto -Quiet
 ```
+
+You can also specify the output level directly with the `-Verbosity`
+parameter (`silent`, `normal`, or `detailed`).
 
 The default configuration path (`./config_files/default-config.json`) and the `-Auto` switch are defined on lines 1-6. The logic that runs scripts directly when `-Scripts` is provided lives at lines 259-264. Prompts for editing the configuration or confirming cleanup only occur when `-Auto` is not specified, as shown on lines 135-168.
 

--- a/runner.ps1
+++ b/runner.ps1
@@ -3,6 +3,7 @@ param(
     [switch]$Auto,
     [string]$Scripts,
     [switch]$Force,
+    [switch]$Quiet,
     [ValidateSet('silent','normal','detailed')]
     [string]$Verbosity = 'normal'
 )
@@ -13,6 +14,7 @@ if ($PSVersionTable.PSVersion.Major -lt 7) {
 }
 
 # expose quiet flag to logger
+if ($Quiet) { $Verbosity = 'silent' }
 $script:VerbosityLevels = @{ silent = 0; normal = 1; detailed = 2 }
 $script:ConsoleLevel    = $script:VerbosityLevels[$Verbosity]
 

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -272,6 +272,41 @@ Write-Error 'err message'
             Remove-Item Function:\Write-Host -ErrorAction SilentlyContinue
             Pop-Location
 
+        $script:logLines | Should -Not -Contain '==== Loading configuration ===='
+        ($output | Out-String) | Should -Match 'warn message'
+        ($output | Out-String) | Should -Match 'err message'
+    }
+    finally { Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue }
+}
+
+    It 'suppresses informational logs when -Verbosity silent is used' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+        $null = New-Item -ItemType Directory -Path $tempDir
+        try {
+            Copy-Item $script:runnerPath -Destination $tempDir
+            Copy-Item (Join-Path $PSScriptRoot '..' 'runner_utility_scripts') -Destination $tempDir -Recurse
+            Copy-Item (Join-Path $PSScriptRoot '..' 'lab_utils') -Destination $tempDir -Recurse
+            Copy-Item (Join-Path $PSScriptRoot '..' 'config_files') -Destination (Join-Path $tempDir 'config_files') -Recurse
+            $scriptsDir = Join-Path $tempDir 'runner_scripts'
+            $null = New-Item -ItemType Directory -Path $scriptsDir
+            $scriptFile = Join-Path $scriptsDir '0001_Log.ps1'
+            @"
+Param([PSCustomObject]`$Config)
+Write-Warning 'warn message'
+Write-Error 'err message'
+"@ | Set-Content -Path $scriptFile
+
+            Push-Location $tempDir
+            $script:logLines = @()
+            function global:Write-Host {
+                param([Parameter(Mandatory=$true,Position=0)][string]$Object,
+                      [Parameter(Position=1)][string]$ForegroundColor)
+                $script:logLines += $Object
+            }
+            $output = & "$tempDir/runner.ps1" -Scripts '0001' -Auto -Verbosity silent *>&1
+            Remove-Item Function:\Write-Host -ErrorAction SilentlyContinue
+            Pop-Location
+
             $script:logLines | Should -Not -Contain '==== Loading configuration ===='
             ($output | Out-String) | Should -Match 'warn message'
             ($output | Out-String) | Should -Match 'err message'


### PR DESCRIPTION
## Summary
- add `-Quiet` switch to `runner.ps1`
- make `-Quiet` set `-Verbosity silent`
- document the new behaviour in README and docs
- support `-Verbosity silent` in tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_684849e9e1688331aa48933f0f3e22aa