### PR TITLE
Prevent auto-execution when dot-sourcing Prepare-HyperVProvider

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -74,6 +74,7 @@ function Get-HyperVProviderVersion {
 }
 
 . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+if ($MyInvocation.InvocationName -ne '.') {
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0010_Prepare-HyperVProvider.ps1'
 

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -48,7 +48,7 @@ Describe 'Prepare-HyperVProvider path restoration' -Skip:($IsLinux -or $IsMacOS)
         }
         Mock Resolve-Path { param([string]$Path) @{ Path = $Path } }
 
-        . $script:scriptPath -Config $config
+        & $script:scriptPath -Config $config
 
         $location | Should -Be 'C:\\Start'
     }
@@ -128,7 +128,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
         ) | Set-Content -Path $providerFile
 
         $cmdBefore = Get-Command Convert-PfxToPem
-        . $script:scriptPath -Config $config
+        & $script:scriptPath -Config $config
         $cmdAfter  = Get-Command Convert-PfxToPem
         $cmdAfter | Should -Be $cmdBefore
         Assert-MockCalled New-SelfSignedCertificate -Times 2


### PR DESCRIPTION
## Summary
- avoid running Prepare-HyperVProvider.ps1 when the script is dot-sourced
- adjust tests to call the script directly when execution is required

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_684849eb668883318a9ca7f27275799f