### PR TITLE
Add Quiet switch support in runner

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -28,5 +28,5 @@ example, to run scripts `0006` and `0007` silently and non-interactively:
 ./runner.ps1 -Scripts '0006,0007' -Auto -Quiet
 ```
 
-The default configuration path (`./config_files/default-config.json`) and the `-Auto` switch are defined on lines 1-6. The logic that runs scripts directly when `-Scripts` is provided lives at lines 259-264. Prompts for editing the configuration or confirming cleanup only occur when `-Auto` is not specified, as shown on lines 135-168.
+The default configuration path (`./config_files/default-config.json`) and the `-Auto` switch are defined on lines 1-9. The logic that runs scripts directly when `-Scripts` is provided lives at lines 267-272. Prompts for editing the configuration or confirming cleanup only occur when `-Auto` is not specified, as shown on lines 138-171.
 

--- a/runner.ps1
+++ b/runner.ps1
@@ -4,7 +4,8 @@ param(
     [string]$Scripts,
     [switch]$Force,
     [ValidateSet('silent','normal','detailed')]
-    [string]$Verbosity = 'normal'
+    [string]$Verbosity = 'normal',
+    [switch]$Quiet
 )
 
 if ($PSVersionTable.PSVersion.Major -lt 7) {
@@ -12,9 +13,11 @@ if ($PSVersionTable.PSVersion.Major -lt 7) {
     exit 1
 }
 
-# expose quiet flag to logger
 $script:VerbosityLevels = @{ silent = 0; normal = 1; detailed = 2 }
+# honor -Quiet before calculating console level
+if ($Quiet) { $Verbosity = 'silent' }
 $script:ConsoleLevel    = $script:VerbosityLevels[$Verbosity]
+
 
 # ─── Load helpers ──────────────────────────────────────────────────────────────
 . (Join-Path $PSScriptRoot 'runner_utility_scripts' 'Logger.ps1')
@@ -209,7 +212,7 @@ function Invoke-Scripts {
             }
 
 
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Quiet.IsPresent 2>&1
+            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity *>&1
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## Summary
- add `-Quiet` switch to `runner.ps1`
- default to `Verbosity = 'silent'` when `-Quiet` is used
- forward verbosity setting to child processes
- update docs with new line numbers

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_684849f3d24c8331b1e623958ffcad6a