### PR TITLE
Fix duplicate Quiet parameter

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -5,24 +5,19 @@ param(
     [switch]$Force,
     [switch]$Quiet,
     [ValidateSet('silent','normal','detailed')]
-    [string]$Verbosity = 'normal',
-    [switch]$Quiet
+    [string]$Verbosity = 'normal'
 )
 
-
-if ($Quiet.IsPresent) { $Verbosity = 'silent' }
 
 if ($PSVersionTable.PSVersion.Major -lt 7) {
     Write-Error "PowerShell 7 or later is required. Current version: $($PSVersionTable.PSVersion)"
     exit 1
 }
 
-# expose quiet flag to logger
+# expose quiet flag to logger and apply before console level calculation
 if ($Quiet) { $Verbosity = 'silent' }
 
 $script:VerbosityLevels = @{ silent = 0; normal = 1; detailed = 2 }
-# honor -Quiet before calculating console level
-if ($Quiet) { $Verbosity = 'silent' }
 $script:ConsoleLevel    = $script:VerbosityLevels[$Verbosity]
 
 


### PR DESCRIPTION
## Summary
- dedupe `$Quiet` param in `runner.ps1`
- simplify Quiet logic

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684857a9d5048331aa2ca759ace85dd7