### PR TITLE
Fix installer path in OpenTofu tests

### DIFF
--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -14,11 +14,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
             CosignPath      = 'C:\\temp'
             OpenTofuVersion = '1.2.3'
         }
-        $installerPath = (
-            Resolve-Path (
-                Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
-            )
-        ).Path
+        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
 
         Mock $installerPath {}
         Mock Write-CustomLog {}
@@ -32,11 +28,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
 
     It 'skips install when flag is false' {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
-        $installerPath = (
-            Resolve-Path (
-                Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
-            )
-        ).Path
+        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
 
         Mock $installerPath {}
         Mock Write-CustomLog {}


### PR DESCRIPTION
## Summary
- make Install-OpenTofu.Tests construct `$installerPath` just like the script
- ensure the mock intercepts the call

## Testing
- `Invoke-ScriptAnalyzer -EnableExit -Severity Warning`
- `ruff check .`
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_68485859fa5c8331a4b9408a2f255a12