### PR TITLE
Update Reset-Machine script for RDP

### DIFF
--- a/runner_scripts/9999_Reset-Machine.ps1
+++ b/runner_scripts/9999_Reset-Machine.ps1
@@ -8,6 +8,13 @@ Invoke-LabStep -Config $Config -Body {
     $platform = Get-Platform
     Write-CustomLog "Detected platform: $platform"
     if ($platform -eq 'Windows') {
+        $Config.AllowRemoteDesktop = $true
+        if (-not $Config.FirewallPorts) { $Config.FirewallPorts = @() }
+        if ($Config.FirewallPorts -notcontains 3389) { $Config.FirewallPorts += 3389 }
+
+        & "$PSScriptRoot/0101_Enable-RemoteDesktop.ps1" -Config $Config
+        & "$PSScriptRoot/0102_Configure-Firewall.ps1" -Config $Config
+
         $sysprep = 'C:\\Windows\\System32\\Sysprep\\Sysprep.exe'
         if (Test-Path $sysprep) {
             Write-CustomLog "Invoking sysprep at $sysprep"

--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -9,15 +9,19 @@ Describe 'Reset-Machine script' {
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
     }
 
-    It 'invokes sysprep on Windows' {
+    It 'invokes sysprep and configures Remote Desktop on Windows' {
         Mock Get-Platform { 'Windows' }
         $sysprep = 'C:\\Windows\\System32\\Sysprep\\Sysprep.exe'
         Mock Test-Path { $true } -ParameterFilter { $Path -eq $sysprep }
         Mock Start-Process {}
+        Mock Set-ItemProperty {}
+        Mock New-NetFirewallRule {}
         . $script:ScriptPath -Config ([pscustomobject]@{})
         Assert-MockCalled Start-Process -Times 1 -ParameterFilter {
             $FilePath -eq $sysprep -and $ArgumentList -eq '/generalize /oobe /shutdown /quiet' -and $Wait
         }
+        Assert-MockCalled Set-ItemProperty -Times 1
+        Assert-MockCalled New-NetFirewallRule -Times 1
     }
 
     It 'calls Restart-Computer on Linux' {


### PR DESCRIPTION
## Summary
- enable remote desktop and firewall during Reset-Machine
- test that RDP enabling logic is invoked when running on Windows

## Testing
- `Invoke-ScriptAnalyzer .` *(fails: `pwsh` not found)*
- `Invoke-Pester` *(fails: `pwsh` not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485c5f48988331822e8e52ec66b144