### PR TITLE
Fix bootstrap path resolution for nonexistent repo path

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -379,7 +379,8 @@ if (-not $repoPath) {
 }
 
 # Configure git safe.directory to avoid dubious ownership errors
-$resolvedRepoPath = (Resolve-Path $repoPath).ProviderPath
+# Use GetFullPath so path need not exist yet
+$resolvedRepoPath = [System.IO.Path]::GetFullPath($repoPath)
 & "$gitPath" config --global --add safe.directory $resolvedRepoPath 2>$null
 
 if (!(Test-Path $repoPath)) {


### PR DESCRIPTION
## Summary
- handle missing repo path when configuring git safe directory

## Testing
- `ruff check .`
- `pytest -q`
- ❌ `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485db1a5f88331b05c1a868b138b85