### PR TITLE
default clone to C:\temp

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
      - Updates PATH if installed but not found in PATH.
      - Prompts for authentication if not already authenticated.
      - Run `gh auth login` before using `0001_Reset-Git.ps1` or `0009_Initialize-OpenTofu.ps1`.
-  4) Clones this repository from config.json -> RepoUrl to config.json -> LocalPath (or a default path).
+  4) Clones this repository from config.json -> RepoUrl to config.json -> LocalPath. If `LocalPath` is empty, the repo is cloned to `C:\temp` by default (configurable in `default-config.json`).
   5) Invokes runner.ps1 from this repo. Runner can be ran with optional parameters to automatically run, but it will prompt you to manually select which scripts to run by default. After a selection completes, the menu is shown again so you can run more scripts or type `exit` to quit.
      - Use `-ConfigFile <path>` to specify an alternative configuration file. If omitted, `runner.ps1` loads `config_files/default-config.json`.
     - Use `-Quiet` to hide most informational output. This is shorthand for

--- a/config_files/default-config.json
+++ b/config_files/default-config.json
@@ -50,7 +50,7 @@
   },
   "GitHubCLIInstallerUrl": "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_windows_amd64.msi",
   "RepoUrl": "https://github.com/wizzense/opentofu-lab-automation.git",
-  "LocalPath": "",
+  "LocalPath": "C:\\temp",
   "RunnerScriptName": "runner.ps1",
   "ConfigFile": "./config_files/default-config.json",
   "Go": {

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -358,7 +358,7 @@ if (-not $config.RepoUrl) {
 # Define local path (fallback if not in config)
 $localPath = $config.LocalPath
 if (-not $localPath -or [string]::IsNullOrWhiteSpace($localPath)) {
-    $localPath = Join-Path $env:USERPROFILE 'Documents\ServerSetup'
+    $localPath = 'C:\\temp'
 }
 $localPath = [System.Environment]::ExpandEnvironmentVariables($localPath)
 

--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -18,7 +18,7 @@ try {
     $localBase = if ($Config.LocalPath) {
         $Config.LocalPath
     } else {
-        Join-Path $env:USERPROFILE 'Documents\ServerSetup'
+        'C:\\temp'
     }
     $localBase = [System.Environment]::ExpandEnvironmentVariables($localBase)
     $repoName  = ($Config.RepoUrl -split '/')[-1] -replace '\.git$',''


### PR DESCRIPTION
## Summary
- set the default clone directory to `C:\temp`
- update cleanup script to match
- document the default path in README
- adjust `default-config.json` accordingly

## Testing
- `Invoke-Pester` *(fails: `pwsh: command not found`)*
- `mkdocs build` *(fails: `mkdocs: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68485de66c5c8331930cdeeb9f7ac1c4