### PR TITLE
Add Directories output in Get-LabConfig

### DIFF
--- a/lab_utils/Get-LabConfig.ps1
+++ b/lab_utils/Get-LabConfig.ps1
@@ -21,11 +21,22 @@ function Get-LabConfig {
                     throw "YAML support requires the 'powershell-yaml' module. Install it with 'Install-Module powershell-yaml'."
                 }
             }
-            return $content | ConvertFrom-Yaml
+            $config = $content | ConvertFrom-Yaml
         }
         else {
-            return $content | ConvertFrom-Json
+            $config = $content | ConvertFrom-Json
         }
+
+        $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+        $dirs = [pscustomobject]@{
+            RepoRoot       = $repoRoot.Path
+            RunnerScripts  = Join-Path $repoRoot 'runner_scripts'
+            UtilityScripts = Join-Path $repoRoot 'runner_utility_scripts'
+            ConfigFiles    = Join-Path $repoRoot 'config_files'
+            InfraRepo      = if ($config.InfraRepoPath) { $config.InfraRepoPath } else { 'C:\\Temp\\base-infra' }
+        }
+        Add-Member -InputObject $config -MemberType NoteProperty -Name Directories -Value $dirs -Force
+        return $config
     }
     catch {
         throw "Failed to parse config file $Path. $_"

--- a/tests/Get-LabConfig.Tests.ps1
+++ b/tests/Get-LabConfig.Tests.ps1
@@ -1,12 +1,22 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 Describe 'Get-LabConfig' {
 
-    It 'returns PSCustomObject for valid JSON' {
+    It 'returns PSCustomObject for valid JSON and populates Directories' {
         $modulePath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-LabConfig.ps1'
         . $modulePath
-        $configPath = Join-Path $PSScriptRoot '..' 'config_files' 'default-config.json'
-        $result = Get-LabConfig -Path $configPath
-        $result | Should -BeOfType 'System.Management.Automation.PSCustomObject'
+        $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString() + '.json')
+        @{
+            InfraRepoPath = 'C:\\Infra'
+        } | ConvertTo-Json | Set-Content -Path $tempFile
+        try {
+            $result = Get-LabConfig -Path $tempFile
+            $result | Should -BeOfType 'System.Management.Automation.PSCustomObject'
+            $result | Get-Member -Name Directories | Should -Not -BeNullOrEmpty
+            $result.Directories.InfraRepo | Should -Be 'C:\\Infra'
+            $result.Directories.RunnerScripts | Should -Match 'runner_scripts$'
+        } finally {
+            Remove-Item $tempFile
+        }
     }
 
     It 'throws when file does not exist' {


### PR DESCRIPTION
## Summary
- compute repo-related directories when loading lab config
- verify Directories object in Get-LabConfig tests using a temp config file

## Testing
- `Invoke-Pester -CI` *(fails: Could not find Command New-NetFirewallRule)*

------
https://chatgpt.com/codex/tasks/task_e_68485d81b0148331ac5b3553a0688738