### PR TITLE
Update bootstrap fallback path

### DIFF
--- a/config_files/default-config.json
+++ b/config_files/default-config.json
@@ -50,7 +50,7 @@
   },
   "GitHubCLIInstallerUrl": "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_windows_amd64.msi",
   "RepoUrl": "https://github.com/wizzense/opentofu-lab-automation.git",
-  "LocalPath": "",
+  "LocalPath": "C:\\temp",
   "RunnerScriptName": "runner.ps1",
   "ConfigFile": "./config_files/default-config.json",
   "Go": {

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -357,8 +357,14 @@ if (-not $config.RepoUrl) {
 
 # Define local path (fallback if not in config)
 $localPath = $config.LocalPath
-if (-not $localPath -or [string]::IsNullOrWhiteSpace($localPath)) {
-    $localPath = Join-Path $env:USERPROFILE 'Documents\ServerSetup'
+$localPath = if (-not $localPath -or [string]::IsNullOrWhiteSpace($localPath)) {
+    if ($isWindowsOS) {
+        if ($env:TEMP) { $env:TEMP } else { 'C:\\temp' }
+    } else {
+        [System.IO.Path]::GetTempPath()
+    }
+} else {
+    $localPath
 }
 $localPath = [System.Environment]::ExpandEnvironmentVariables($localPath)
 

--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -18,7 +18,11 @@ try {
     $localBase = if ($Config.LocalPath) {
         $Config.LocalPath
     } else {
-        Join-Path $env:USERPROFILE 'Documents\ServerSetup'
+        if ($IsWindows) {
+            if ($env:TEMP) { $env:TEMP } else { 'C:\\temp' }
+        } else {
+            [System.IO.Path]::GetTempPath()
+        }
     }
     $localBase = [System.Environment]::ExpandEnvironmentVariables($localBase)
     $repoName  = ($Config.RepoUrl -split '/')[-1] -replace '\.git$',''


### PR DESCRIPTION
## Summary
- default clone directory uses temp folder
- cleanup script follows same convention
- reflect change in sample config

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485e61bb988331bfd350203bfbd88a