### PR TITLE
Fix runner prompts to show config values

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -114,12 +114,12 @@ function Set-LabConfig {
         if ($ans) { $ConfigObject[$k] = $ans -match '^(?i)y' }
     }
 
-    $localPath = Read-Host "Local repo path [`$($ConfigObject.LocalPath)`]"
+    $localPath = Read-Host "Local repo path [$($ConfigObject.LocalPath)]"
     if ($localPath) { $ConfigObject.LocalPath = $localPath }
 
-    $npmPath = Read-Host "Path to Node project [`$($ConfigObject.Node_Dependencies.NpmPath)`]"
+    $npmPath = Read-Host "Path to Node project [$($ConfigObject.Node_Dependencies.NpmPath)]"
     if ($npmPath) { $ConfigObject.Node_Dependencies.NpmPath = $npmPath }
-    $createPath = Read-Host "Create NpmPath if missing? (Y/N) [`$($ConfigObject.Node_Dependencies.CreateNpmPath)`]"
+    $createPath = Read-Host "Create NpmPath if missing? (Y/N) [$($ConfigObject.Node_Dependencies.CreateNpmPath)]"
     if ($createPath) { $ConfigObject.Node_Dependencies.CreateNpmPath = $createPath -match '^(?i)y' }
 
     return $ConfigObject

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -435,12 +435,12 @@ Describe 'Set-LabConfig' {
             if ($answer) { $ConfigObject[$key] = $answer -match '^(?i)y' }
         }
 
-        $localPath = Read-Host "Local repo path [`$($ConfigObject['LocalPath'])`]"
+        $localPath = Read-Host "Local repo path [$($ConfigObject['LocalPath'])]"
         if ($localPath) { $ConfigObject['LocalPath'] = $localPath }
 
-        $npmPath = Read-Host "Path to Node project [`$($ConfigObject.Node_Dependencies.NpmPath)`]"
+        $npmPath = Read-Host "Path to Node project [$($ConfigObject.Node_Dependencies.NpmPath)]"
         if ($npmPath) { $ConfigObject.Node_Dependencies.NpmPath = $npmPath }
-        $createPath = Read-Host "Create NpmPath if missing? (Y/N) [`$($ConfigObject.Node_Dependencies.CreateNpmPath)`]"
+        $createPath = Read-Host "Create NpmPath if missing? (Y/N) [$($ConfigObject.Node_Dependencies.CreateNpmPath)]"
         if ($createPath) { $ConfigObject.Node_Dependencies.CreateNpmPath = $createPath -match '^(?i)y' }
 
         return $ConfigObject


### PR DESCRIPTION
## Summary
- fix backtick-escaped `$` variables in `runner.ps1`
- update Pester tests accordingly

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684860cfb93483319f33b883d8aeb900