### PR TITLE
Fix runner config saving

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [string]$ConfigFile = "./config_files/default-config.json",
     [switch]$Auto,


### PR DESCRIPTION
## Summary
- declare `runner.ps1` as an advanced script

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `bash: pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848613f5a7483319dd8893ded6e52a1