### PR TITLE
Fix Node project prompt in config setup

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -114,12 +114,12 @@ function Set-LabConfig {
         if ($ans) { $ConfigObject[$k] = $ans -match '^(?i)y' }
     }
 
-    $localPath = Read-Host "Local repo path [`$($ConfigObject.LocalPath)`]"
+    $localPath = Read-Host "Local repo path [$($ConfigObject.LocalPath)]"
     if ($localPath) { $ConfigObject.LocalPath = $localPath }
 
-    $npmPath = Read-Host "Path to Node project [`$($ConfigObject.Node_Dependencies.NpmPath)`]"
+    $npmPath = Read-Host "Path to Node project [$($ConfigObject.Node_Dependencies.NpmPath)]"
     if ($npmPath) { $ConfigObject.Node_Dependencies.NpmPath = $npmPath }
-    $createPath = Read-Host "Create NpmPath if missing? (Y/N) [`$($ConfigObject.Node_Dependencies.CreateNpmPath)`]"
+    $createPath = Read-Host "Create NpmPath if missing? (Y/N) [$($ConfigObject.Node_Dependencies.CreateNpmPath)]"
     if ($createPath) { $ConfigObject.Node_Dependencies.CreateNpmPath = $createPath -match '^(?i)y' }
 
     return $ConfigObject

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -435,12 +435,12 @@ Describe 'Set-LabConfig' {
             if ($answer) { $ConfigObject[$key] = $answer -match '^(?i)y' }
         }
 
-        $localPath = Read-Host "Local repo path [`$($ConfigObject['LocalPath'])`]"
+        $localPath = Read-Host "Local repo path [$($ConfigObject['LocalPath'])]"
         if ($localPath) { $ConfigObject['LocalPath'] = $localPath }
 
-        $npmPath = Read-Host "Path to Node project [`$($ConfigObject.Node_Dependencies.NpmPath)`]"
+        $npmPath = Read-Host "Path to Node project [$($ConfigObject.Node_Dependencies.NpmPath)]"
         if ($npmPath) { $ConfigObject.Node_Dependencies.NpmPath = $npmPath }
-        $createPath = Read-Host "Create NpmPath if missing? (Y/N) [`$($ConfigObject.Node_Dependencies.CreateNpmPath)`]"
+        $createPath = Read-Host "Create NpmPath if missing? (Y/N) [$($ConfigObject.Node_Dependencies.CreateNpmPath)]"
         if ($createPath) { $ConfigObject.Node_Dependencies.CreateNpmPath = $createPath -match '^(?i)y' }
 
         return $ConfigObject


### PR DESCRIPTION
## Summary
- correct variable interpolation for Node path prompts in `runner.ps1`
- update tests to match new prompt strings

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684861296f24833196c4c220357af66d