### PR TITLE
Revamp config editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ The repo expects the latest stable code on the `main` branch. When running
 `iso_tools/bootstrap.ps1`, you can override the branch with the `-Branch`
 parameter if needed.
 
-It will prompt print the current config and prompt you to customize it interactively. 
+The bootstrap script shows your current configuration and opens a simple menu
+based editor so you can tweak only the settings you care about. A menu option
+lets you apply the recommended defaults from `config_files/recommended-config.json`
+for a quick start.
 
 
 Example opentofu-infra repo: https://github.com/wizzense/tofu-base-lab.git

--- a/config_files/recommended-config.json
+++ b/config_files/recommended-config.json
@@ -1,0 +1,10 @@
+{
+  "InstallGo": true,
+  "InstallOpenTofu": true,
+  "InitializeOpenTofu": true,
+  "PrepareHyperVHost": true,
+  "InstallHyperV": true,
+  "InstallCA": true,
+  "InstallCosign": true,
+  "InstallGPG": true
+}

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -13,6 +13,10 @@ Simply invoke the script with no parameters:
 
 You will be shown a menu to choose which scripts to run. After the selected scripts complete, the menu will appear again so you can run additional scripts without restarting the runner. Type `exit` at the prompt when you are finished.
 
+When prompted to customize the configuration, a menu lists all available
+settings. Select one or more entries to edit or choose **Apply recommended
+defaults** to merge values from `config_files/recommended-config.json`.
+
 ## Non-interactive mode
 
 Supply a comma-separated list of 4-digit script prefixes via `-Scripts` to run without prompts. Combine this with `-Auto` to skip configuration customization and cleanup confirmations.


### PR DESCRIPTION
## Summary
- add recommended defaults json
- provide menu-driven Set-LabConfig with optional recommended defaults
- document new config editor behaviour
- update Pester tests for menu workflow

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path .` *(fails: command not found)*
- `Invoke-Pester` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684862f3abc883319ae22e9759cdcc7f