### PR TITLE
Add Kickstart bootstrap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ The repo expects the latest stable code on the `main` branch. When running
 `iso_tools/bootstrap.ps1`, you can override the branch with the `-Branch`
 parameter if needed.
 
+Linux users can run `./kickstart-bootstrap.sh` to download the example
+`kickstart.cfg` and launch a Kickstart-based install via `virt-install`.
+
 It will prompt print the current config and prompt you to customize it interactively. 
 
 

--- a/docs/iso_tools.md
+++ b/docs/iso_tools.md
@@ -6,5 +6,7 @@ The `iso_tools` directory contains scripts for building automated installation m
 - **bootstrap.ps1** – Downloads `kicker-bootstrap.ps1` from this repository and runs it. Used inside customized ISOs.
 - **autounattend - generic.xml** – Example unattended installation file for Windows Server.
 - **headlessunattend.xml** – Sample answer file for fully headless deployments.
+- **kickstart.cfg** – Example Kickstart file for automating Linux installations.
+- **kickstart-bootstrap.sh** – Shell helper that downloads `kickstart.cfg` and launches a sample `virt-install` command.
 
 These resources can be adapted to streamline automated lab setups.

--- a/iso_tools/kickstart.cfg
+++ b/iso_tools/kickstart.cfg
@@ -1,0 +1,21 @@
+#version=RHEL9
+install
+url --url="http://mirror.centos.org/centos/9-stream/BaseOS/x86_64/os/"
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp --hostname=tofu-lab
+rootpw --plaintext labpass
+firewall --disabled
+selinux --disabled
+timezone UTC
+reboot --eject
+
+%packages
+@^minimal-environment
+%end
+
+%post --log=/root/bootstrap.log
+curl -fsSL https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/kickstart-bootstrap.sh -o /root/kickstart-bootstrap.sh
+chmod +x /root/kickstart-bootstrap.sh
+/root/kickstart-bootstrap.sh
+%end

--- a/kickstart-bootstrap.sh
+++ b/kickstart-bootstrap.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Simple bootstrap helper for automated Linux installs
+# Downloads kickstart.cfg from this repo and demonstrates applying it
+
+set -euo pipefail
+BRANCH="main"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -b|--branch)
+      BRANCH="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+
+KS_URL="https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/${BRANCH}/iso_tools/kickstart.cfg"
+KS_FILE="/tmp/kickstart.cfg"
+
+curl -fsSL "$KS_URL" -o "$KS_FILE"
+
+if [[ ! -f "$KS_FILE" ]]; then
+  echo "Failed to download kickstart.cfg" >&2
+  exit 1
+fi
+
+echo "Kickstart file saved to $KS_FILE"
+
+if command -v virt-install >/dev/null 2>&1; then
+  echo "Launching virt-install using the downloaded kickstart file..."
+  virt-install \
+    --name tofu-lab-vm \
+    --ram 2048 \
+    --disk size=20 \
+    --location 'http://mirror.centos.org/centos/9-stream/BaseOS/x86_64/os/' \
+    --initrd-inject="$KS_FILE" \
+    --extra-args "inst.ks=file:/kickstart.cfg console=ttyS0" \
+    --noreboot
+else
+  echo "virt-install not found. Use the kickstart file manually with your installer."
+fi

--- a/py/tests/test_kickstart_bootstrap.py
+++ b/py/tests/test_kickstart_bootstrap.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_kickstart_bootstrap_exists():
+    script = Path(__file__).resolve().parents[2] / 'kickstart-bootstrap.sh'
+    assert script.exists()
+    content = script.read_text()
+    assert 'kickstart.cfg' in content

--- a/tests/Kickstart-Bootstrap.Tests.ps1
+++ b/tests/Kickstart-Bootstrap.Tests.ps1
@@ -1,0 +1,12 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+Describe 'kickstart-bootstrap script' {
+    It 'exists at repo root' {
+        $path = Join-Path $PSScriptRoot '..' 'kickstart-bootstrap.sh'
+        (Test-Path $path) | Should -BeTrue
+    }
+    It 'references kickstart.cfg' {
+        $path = Join-Path $PSScriptRoot '..' 'kickstart-bootstrap.sh'
+        $content = Get-Content $path -Raw
+        $content | Should -Match 'kickstart.cfg'
+    }
+}


### PR DESCRIPTION
## Summary
- provide a Kickstart config for Linux installs
- add kickstart-bootstrap.sh helper
- document both in docs and README
- test that the new script exists

## Testing
- `poetry run pytest -q`
- `Invoke-Pester` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486428b03c8331922d460c2764d872