### PR TITLE
Fix OpenTofu installer test mocking

### DIFF
--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -6,7 +6,9 @@ Invoke-LabStep -Config $Config -Body {
 if ($Config.InstallOpenTofu -eq $true) {
     
     $Cosign = Join-Path $Config.CosignPath "cosign-windows-amd64.exe"
-    $installer = Join-Path $PSScriptRoot "..\runner_utility_scripts\OpenTofuInstaller.ps1"
+    $installer = (
+        Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1')
+    ).Path
     $openTofuVersion = if ($Config.OpenTofuVersion) { $Config.OpenTofuVersion } else { 'latest' }
     & $installer -installMethod standalone -cosignPath $Cosign -opentofuVersion $openTofuVersion
 } else {

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -14,7 +14,9 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
             CosignPath      = 'C:\\temp'
             OpenTofuVersion = '1.2.3'
         }
-        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $installerPath = (
+            Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1')
+        ).Path
 
         Mock $installerPath {}
         Mock Write-CustomLog {}
@@ -28,7 +30,9 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
 
     It 'skips install when flag is false' {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
-        $installerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
+        $installerPath = (
+            Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1')
+        ).Path
 
         Mock $installerPath {}
         Mock Write-CustomLog {}


### PR DESCRIPTION
## Summary
- resolve the path to `OpenTofuInstaller.ps1` in the install script
- canonicalize the installer path in `Install-OpenTofu.Tests.ps1`

## Testing
- `Invoke-Pester` *(fails: Could not find Command New-NetFirewallRule)*

------
https://chatgpt.com/codex/tasks/task_e_6848638ecd98833198f04c163ce39df3