### PR TITLE
Add OpenTofu validation workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Example Infrastructure
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: opentofu/setup-opentofu@v1
+      - name: Init and validate
+        working-directory: example-infrastructure
+        run: |
+          tofu init -input=false
+          tofu validate
+

--- a/example-infrastructure/README.md
+++ b/example-infrastructure/README.md
@@ -34,8 +34,7 @@ git pull
 
 ## Automated testing
 
-A GitHub Actions workflow located at `.github/workflows/test.yml` installs
-OpenTofu using the `wizzense/opentofu-lab-automation` action. The workflow
-runs `tofu init` and `tofu validate` whenever the repository is pushed to or a
-pull request is opened.
+The [test.yml](../.github/workflows/test.yml) workflow installs OpenTofu and
+executes `tofu init` and `tofu validate` in this directory. It runs whenever you
+push changes or open a pull request, ensuring the examples remain valid.
 


### PR DESCRIPTION
## Summary
- add workflow to init & validate example-infrastructure
- link to workflow from example README

## Testing
- `mkdocs build -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848651edecc83319337f4171d9e9364