### PR TITLE
Update Get-HyperVProviderVersion fallback

### DIFF
--- a/tests/Get-HyperVProviderVersion.Tests.ps1
+++ b/tests/Get-HyperVProviderVersion.Tests.ps1
@@ -26,4 +26,11 @@ terraform {
             Remove-Item $tf -ErrorAction SilentlyContinue
         }
     }
+
+    It 'falls back to repository paths when missing' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        . $scriptPath
+        $tf = Join-Path $env:TEMP ([guid]::NewGuid()).ToString() + '.tf'
+        Get-HyperVProviderVersion -MainTfPath $tf | Should -Be '1.2.1'
+    }
 }


### PR DESCRIPTION
## Summary
- improve `Get-HyperVProviderVersion` by searching default paths and warning on failure
- verify fallback logic in Pester tests

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486519d4008331a3dd2b16d41965d2