### PR TITLE
Fix OpenTofu workflow for Hyper-V modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,12 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: opentofu/setup-opentofu@v1
       - name: Init and validate
+        shell: pwsh
         working-directory: example-infrastructure
         run: |
           tofu init -input=false

--- a/modules/network_switch/README.md
+++ b/modules/network_switch/README.md
@@ -2,6 +2,21 @@
 
 This module creates a Hyper-V virtual switch. It wraps the `hyperv_network_switch` resource so the switch can be reused by other modules.
 
+## Provider Requirements
+
+The module depends on the `hyperv` provider from the `taliesins` namespace. Include the following in your configuration:
+
+```hcl
+terraform {
+  required_providers {
+    hyperv = {
+      source  = "taliesins/hyperv"
+      version = ">=1.2.1"
+    }
+  }
+}
+```
+
 ## Inputs
 - `name` - name of the switch
 - `net_adapter_names` - list of adapters

--- a/modules/network_switch/main.tf
+++ b/modules/network_switch/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    hyperv = {
+      source  = "taliesins/hyperv"
+      version = ">=1.2.1"
+    }
+  }
+}
+
 resource "hyperv_network_switch" "this" {
   name                = var.name
   allow_management_os = var.allow_management_os

--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -24,7 +24,8 @@ looks like the following:
 terraform {
   required_providers {
     hyperv = {
-      source = "taliesins/hyperv"
+      source  = "taliesins/hyperv"
+      version = ">=1.2.1"
     }
   }
 }

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -1,6 +1,15 @@
 # Module to provision a Hyper-V VM with an attached VHD
 # and optional dvd drive for installation media.
 
+terraform {
+  required_providers {
+    hyperv = {
+      source  = "taliesins/hyperv"
+      version = ">=1.2.1"
+    }
+  }
+}
+
 resource "hyperv_vhd" "this" {
   count = var.vm_count
   depends_on = [var.switch_dependency]


### PR DESCRIPTION
## Summary
- run workflow on Windows with pwsh
- require the Hyper-V provider in network and VM modules
- document provider version requirement in README files

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848665d057883319f48065083090f8a