### PR TITLE
Fix installer cleanup and update tofu version

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -610,13 +610,14 @@ function installStandalone() {
     } finally {
         for ($i = 0; $i -le ($dlFiles.Length - 1); $i++) {
             $target = Join-Path $tempPath $dlFiles[$i]
-            try
-            {
-                Remove-Item -force -recurse $target
-            } catch {
-                $msg = $_.ToString()
-                logError $msg
-                throw
+            if (Test-Path $target) {
+                try {
+                    Remove-Item -Force -Recurse $target
+                } catch {
+                    $msg = $_.ToString()
+                    logError $msg
+                    throw
+                }
             }
         }
         if ($logDir -and (Test-Path $logDir)) {

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -12,7 +12,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
         $cfg = [pscustomobject]@{
             InstallOpenTofu = $true
             CosignPath      = 'C:\\temp'
-            OpenTofuVersion = '1.2.3'
+            OpenTofuVersion = '1.9.1'
         }
         $installerPath = (
             Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1')


### PR DESCRIPTION
## Summary
- avoid failures if downloaded archive is missing in OpenTofuInstaller
- use a current OpenTofu release in tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration @{Run=@{Exit=$false}}"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486967d70c833192a8b1f7bf9074ec