### PR TITLE
Fix runner output logging

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -263,17 +263,11 @@ function Invoke-Scripts {
                 exit $LASTEXITCODE
             }
 
-          try {
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
+            $output = & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity *>&1
 
-          }
-          catch {
-
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity *>&1
-
-          }
-
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
+            foreach ($line in $output) {
+                if ($line) { Write-CustomLog $line.ToString() }
+            }
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## Summary
- drop redundant pwsh calls in runner
- capture script output and log it once
- test for duplicate output in runner

## Testing
- `Invoke-ScriptAnalyzer -Path .`
- `ruff check .`
- `Invoke-Pester` *(fails: `Reset-Machine` test requires Windows cmdlets)*

------
https://chatgpt.com/codex/tasks/task_e_684869c92b588331953c4c10593eec41