### PR TITLE
Add runner output capture & system info test

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -263,19 +263,14 @@ function Invoke-Scripts {
                 exit $LASTEXITCODE
             }
 
-          try {
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
-
-          }
-          catch {
-
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity *>&1
-
-          }
-
-            & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
-
-            Remove-Item $tempCfg -ErrorAction SilentlyContinue
+        try {
+            $scriptOutput = & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
+        }
+        catch {
+            $scriptOutput = & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity *>&1
+        }
+        Write-Output $scriptOutput
+        Remove-Item $tempCfg -ErrorAction SilentlyContinue
 
             $results[$s.Name] = $LASTEXITCODE
             if ($LASTEXITCODE) {


### PR DESCRIPTION
## Summary
- capture output from scripts executed by `runner.ps1`
- test runner with `0200_Get-SystemInfo.ps1` to confirm info keys present

## Testing
- `Invoke-Pester` *(fails: `Reset-Machine script.invokes sysprep and configures Remote Desktop on Windows`)*

------
https://chatgpt.com/codex/tasks/task_e_684869d8577c8331bba19d899b840fb3