### PR TITLE
Fix Pester mocking for OpenTofu installer

### DIFF
--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -1,17 +1,26 @@
 Param([pscustomobject]$Config)
 . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
-Invoke-LabStep -Config $Config -Body {
-    Write-CustomLog 'Running 0008_Install-OpenTofu.ps1'
 
-if ($Config.InstallOpenTofu -eq $true) {
-    
-    $Cosign = Join-Path $Config.CosignPath "cosign-windows-amd64.exe"
+function Invoke-OpenTofuInstaller {
+    param(
+        [string]$CosignPath,
+        [string]$OpenTofuVersion
+    )
     $installer = (
         Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1')
     ).Path
-    $openTofuVersion = if ($Config.OpenTofuVersion) { $Config.OpenTofuVersion } else { 'latest' }
-    & $installer -installMethod standalone -cosignPath $Cosign -opentofuVersion $openTofuVersion
-} else {
-    Write-CustomLog "InstallOpenTofu flag is disabled. Skipping OpenTofu installation."
+    & $installer -installMethod standalone -cosignPath $CosignPath -opentofuVersion $OpenTofuVersion
 }
+
+Invoke-LabStep -Config $Config -Body {
+    Write-CustomLog 'Running 0008_Install-OpenTofu.ps1'
+
+    if ($Config.InstallOpenTofu -eq $true) {
+
+        $Cosign = Join-Path $Config.CosignPath "cosign-windows-amd64.exe"
+        $openTofuVersion = if ($Config.OpenTofuVersion) { $Config.OpenTofuVersion } else { 'latest' }
+        Invoke-OpenTofuInstaller -CosignPath $Cosign -OpenTofuVersion $openTofuVersion
+    } else {
+        Write-CustomLog "InstallOpenTofu flag is disabled. Skipping OpenTofu installation."
+    }
 }

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -14,29 +14,21 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
             CosignPath      = 'C:\\temp'
             OpenTofuVersion = '1.9.1'
         }
-        $installerPath = (
-            Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1')
-        ).Path
 
-        Mock $installerPath {}
+        Mock Invoke-OpenTofuInstaller {}
         Mock Write-CustomLog {}
         & $script:ScriptPath -Config $cfg
-        Assert-MockCalled $installerPath -Times 1 -ParameterFilter {
-            $installMethod -eq 'standalone' -and
-            $cosignPath -eq (Join-Path $cfg.CosignPath 'cosign-windows-amd64.exe') -and
-            $opentofuVersion -eq $cfg.OpenTofuVersion
+        Assert-MockCalled Invoke-OpenTofuInstaller -Times 1 -ParameterFilter {
+            $CosignPath -eq (Join-Path $cfg.CosignPath 'cosign-windows-amd64.exe') -and
+            $OpenTofuVersion -eq $cfg.OpenTofuVersion
         }
     }
 
     It 'skips install when flag is false' {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
-        $installerPath = (
-            Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1')
-        ).Path
-
-        Mock $installerPath {}
+        Mock Invoke-OpenTofuInstaller {}
         Mock Write-CustomLog {}
         & $script:ScriptPath -Config $cfg
-        Assert-MockCalled $installerPath -Times 0
+        Assert-MockCalled Invoke-OpenTofuInstaller -Times 0
     }
 }


### PR DESCRIPTION
## Summary
- expose `Invoke-OpenTofuInstaller` helper in the install script
- adjust tests to mock `Invoke-OpenTofuInstaller`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486bc3d9008331ab9ca60fdfe9baad