### PR TITLE
Add Pester tests for WinRM, RDP and Firewall scripts

### DIFF
--- a/tests/Configure-Firewall.Tests.ps1
+++ b/tests/Configure-Firewall.Tests.ps1
@@ -1,0 +1,21 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+if ($IsLinux -or $IsMacOS) { return }
+Describe '0102_Configure-Firewall' -Skip:($IsLinux -or $IsMacOS) {
+    BeforeAll {
+        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0102_Configure-Firewall.ps1'
+    }
+
+    It 'creates firewall rules for each port when ports are specified' {
+        $cfg = [pscustomobject]@{ FirewallPorts = @(80, 443) }
+        Mock New-NetFirewallRule {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled New-NetFirewallRule -Times 2
+    }
+
+    It 'skips when no FirewallPorts are provided' {
+        $cfg = [pscustomobject]@{ FirewallPorts = $null }
+        Mock New-NetFirewallRule {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled New-NetFirewallRule -Times 0
+    }
+}

--- a/tests/Enable-RemoteDesktop.Tests.ps1
+++ b/tests/Enable-RemoteDesktop.Tests.ps1
@@ -1,0 +1,31 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+if ($IsLinux -or $IsMacOS) { return }
+Describe '0101_Enable-RemoteDesktop' -Skip:($IsLinux -or $IsMacOS) {
+    BeforeAll {
+        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0101_Enable-RemoteDesktop.ps1'
+    }
+
+    It 'enables RDP when allowed and currently disabled' {
+        $cfg = [pscustomobject]@{ AllowRemoteDesktop = $true }
+        Mock Get-ItemProperty { [pscustomobject]@{ fDenyTSConnections = 1 } }
+        Mock Set-ItemProperty {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Set-ItemProperty -Times 1
+    }
+
+    It 'skips registry change when already enabled' {
+        $cfg = [pscustomobject]@{ AllowRemoteDesktop = $true }
+        Mock Get-ItemProperty { [pscustomobject]@{ fDenyTSConnections = 0 } }
+        Mock Set-ItemProperty {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Set-ItemProperty -Times 0
+    }
+
+    It 'does nothing when AllowRemoteDesktop is false' {
+        $cfg = [pscustomobject]@{ AllowRemoteDesktop = $false }
+        Mock Get-ItemProperty { [pscustomobject]@{ fDenyTSConnections = 1 } }
+        Mock Set-ItemProperty {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Set-ItemProperty -Times 0
+    }
+}

--- a/tests/Enable-WinRM.Tests.ps1
+++ b/tests/Enable-WinRM.Tests.ps1
@@ -1,0 +1,23 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+if ($IsLinux -or $IsMacOS) { return }
+Describe '0100_Enable-WinRM' -Skip:($IsLinux -or $IsMacOS) {
+    BeforeAll {
+        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0100_Enable-WinRM.ps1'
+    }
+
+    It 'enables WinRM when service is not running' {
+        $cfg = [pscustomobject]@{}
+        Mock Get-Service { [pscustomobject]@{ Status = 'Stopped' } } -ParameterFilter { $Name -eq 'WinRM' }
+        Mock Enable-PSRemoting {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Enable-PSRemoting -ParameterFilter { $Force } -Times 1
+    }
+
+    It 'skips enabling when WinRM already running' {
+        $cfg = [pscustomobject]@{}
+        Mock Get-Service { [pscustomobject]@{ Status = 'Running' } } -ParameterFilter { $Name -eq 'WinRM' }
+        Mock Enable-PSRemoting {}
+        & $script:ScriptPath -Config $cfg
+        Assert-MockCalled Enable-PSRemoting -Times 0
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `0100_Enable-WinRM.ps1`
- add tests for `0101_Enable-RemoteDesktop.ps1`
- add tests for `0102_Configure-Firewall.ps1`
- fix Reset-Machine tests on non‑Windows hosts

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_684869cbabd483318d02d7d72558e1fd