### PR TITLE
Use Write-CustomLog in OpenTofu installer

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -117,6 +117,8 @@ param(
     [string]$internalZipFile = ""
 )
 
+. $PSScriptRoot/Logger.ps1
+
 $scriptCommand = $MyInvocation.MyCommand.Source
 $InformationPreference = 'continue'
 $WarningPreference = 'continue'
@@ -704,11 +706,11 @@ ${bold}${blue}Exit codes:${normal}
   ${bold}${exitCodeInvalidArgument}${normal}                             Invalid configuration options.
 
 "@
-    Write-Output $usageText
+    Write-CustomLog $usageText
 }
 
-Write-Output "${blue}${bold}OpenTofu Installer${normal}"
-Write-Output ""
+Write-CustomLog "${blue}${bold}OpenTofu Installer${normal}"
+Write-CustomLog ""
 if ($help) {
     usage
     exit $exitCodeOK


### PR DESCRIPTION
## Summary
- load Logger.ps1 for OpenTofuInstaller
- emit usage and heading via Write-CustomLog

## Testing
- `Invoke-Pester` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68486d4720608331965e962bcb118338