### PR TITLE
Expand load_config tests

### DIFF
--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 import sys
 from typer.testing import CliRunner
+import json
+import yaml
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from labctl.cli import app, default_config_path
+from labctl.cli import app, default_config_path, load_config
 
 
 def test_default_config_packaged():
@@ -23,3 +26,29 @@ def test_hv_deploy():
     result = runner.invoke(app, ["hv", "deploy"])
     assert result.exit_code == 0
     assert "Deploying Hyper-V host" in result.output
+
+
+def test_load_config_json(tmp_path):
+    conf = tmp_path / "conf.json"
+    conf.write_text(json.dumps({"foo": "bar"}))
+    assert load_config(conf) == {"foo": "bar"}
+
+
+def test_load_config_yaml(tmp_path):
+    conf = tmp_path / "conf.yaml"
+    conf.write_text("foo: bar")
+    assert load_config(conf) == {"foo": "bar"}
+
+
+def test_load_config_invalid_json(tmp_path):
+    conf = tmp_path / "bad.json"
+    conf.write_text("{bad json}")
+    with pytest.raises(json.JSONDecodeError):
+        load_config(conf)
+
+
+def test_load_config_invalid_yaml(tmp_path):
+    conf = tmp_path / "bad.yaml"
+    conf.write_text("foo: [unclosed")
+    with pytest.raises(yaml.YAMLError):
+        load_config(conf)


### PR DESCRIPTION
## Summary
- cover `load_config` in test_cli

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486fdda19c8331ba03dac08080f78d