### PR TITLE
Fix mocking in Install-OpenTofu test

### DIFF
--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -17,7 +17,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
 
         Mock Invoke-OpenTofuInstaller {}
         Mock Write-CustomLog {}
-        & $script:ScriptPath -Config $cfg
+        . $script:ScriptPath -Config $cfg
         Assert-MockCalled Invoke-OpenTofuInstaller -Times 1 -ParameterFilter {
             $CosignPath -eq (Join-Path $cfg.CosignPath 'cosign-windows-amd64.exe') -and
             $OpenTofuVersion -eq $cfg.OpenTofuVersion
@@ -28,7 +28,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
         Mock Invoke-OpenTofuInstaller {}
         Mock Write-CustomLog {}
-        & $script:ScriptPath -Config $cfg
+        . $script:ScriptPath -Config $cfg
         Assert-MockCalled Invoke-OpenTofuInstaller -Times 0
     }
 }


### PR DESCRIPTION
## Summary
- ensure `Invoke-OpenTofuInstaller` can be mocked by dot-sourcing the script

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI -ErrorAction Stop"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848703439548331a0c58060e5e8caf5