### PR TITLE
Update Get-SystemInfo runner test

### DIFF
--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -36,13 +36,14 @@ Describe 'runner.ps1 executing 0200_Get-SystemInfo' -Skip:($IsLinux -or $IsMacOS
             $output = & "$tempDir/runner.ps1" -Scripts '0200' -Auto
             Pop-Location
 
-            $text = $output | Out-String
-            $text | Should -Match 'ComputerName'
-            $text | Should -Match 'IPAddresses'
-            $text | Should -Match 'OSVersion'
-            $text | Should -Match 'DiskInfo'
-            $text | Should -Match 'RolesFeatures'
-            $text | Should -Match 'LatestHotfix'
+            $obj = $output | ConvertFrom-Json
+            $obj | Should -Not -BeNullOrEmpty
+            $obj.PSObject.Properties.Name | Should -Contain 'ComputerName'
+            $obj.PSObject.Properties.Name | Should -Contain 'IPAddresses'
+            $obj.PSObject.Properties.Name | Should -Contain 'OSVersion'
+            $obj.PSObject.Properties.Name | Should -Contain 'DiskInfo'
+            $obj.PSObject.Properties.Name | Should -Contain 'RolesFeatures'
+            $obj.PSObject.Properties.Name | Should -Contain 'LatestHotfix'
         }
         finally {
             Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- parse `runner.ps1` output with `ConvertFrom-Json`
- assert that the resulting object exposes expected properties

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487104dd1883318aca39f4165ce247