### PR TITLE
Fix 0008_Install-OpenTofu test

### DIFF
--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -1,6 +1,3 @@
-Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
-
 function Invoke-OpenTofuInstaller {
     param(
         [string]$CosignPath,
@@ -14,15 +11,22 @@ function Invoke-OpenTofuInstaller {
     Write-CustomLog 'OpenTofu installer completed'
 }
 
-Invoke-LabStep -Config $Config -Body {
-    Write-CustomLog 'Running 0008_Install-OpenTofu.ps1'
+function Install-OpenTofu {
+    [CmdletBinding()]
+    param([pscustomobject]$Config)
 
-    if ($Config.InstallOpenTofu -eq $true) {
+    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+    Invoke-LabStep -Config $Config -Body {
+        Write-CustomLog 'Running 0008_Install-OpenTofu.ps1'
 
-        $Cosign = Join-Path $Config.CosignPath "cosign-windows-amd64.exe"
-        $openTofuVersion = if ($Config.OpenTofuVersion) { $Config.OpenTofuVersion } else { 'latest' }
-        Invoke-OpenTofuInstaller -CosignPath $Cosign -OpenTofuVersion $openTofuVersion
-    } else {
-        Write-CustomLog "InstallOpenTofu flag is disabled. Skipping OpenTofu installation."
+        if ($Config.InstallOpenTofu -eq $true) {
+            $Cosign = Join-Path $Config.CosignPath "cosign-windows-amd64.exe"
+            $openTofuVersion = if ($Config.OpenTofuVersion) { $Config.OpenTofuVersion } else { 'latest' }
+            Invoke-OpenTofuInstaller -CosignPath $Cosign -OpenTofuVersion $openTofuVersion
+        } else {
+            Write-CustomLog "InstallOpenTofu flag is disabled. Skipping OpenTofu installation."
+        }
     }
 }
+
+if ($MyInvocation.InvocationName -ne '.') { Install-OpenTofu @PSBoundParameters }

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -6,6 +6,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
             Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_scripts' '0008_Install-OpenTofu.ps1')
 
         ).Path
+        . $script:ScriptPath
     }
 
     It 'calls OpenTofuInstaller when enabled' {
@@ -17,7 +18,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
 
         Mock Invoke-OpenTofuInstaller {}
         Mock Write-CustomLog {}
-        & $script:ScriptPath -Config $cfg
+        Install-OpenTofu -Config $cfg
         Assert-MockCalled Invoke-OpenTofuInstaller -Times 1 -ParameterFilter {
             $CosignPath -eq (Join-Path $cfg.CosignPath 'cosign-windows-amd64.exe') -and
             $OpenTofuVersion -eq $cfg.OpenTofuVersion
@@ -28,7 +29,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
         Mock Invoke-OpenTofuInstaller {}
         Mock Write-CustomLog {}
-        & $script:ScriptPath -Config $cfg
+        Install-OpenTofu -Config $cfg
         Assert-MockCalled Invoke-OpenTofuInstaller -Times 0
     }
 }


### PR DESCRIPTION
## Summary
- wrap Install-OpenTofu script in a function so it can be dot-sourced
- load the script in the test and call the new function

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848701e9a608331b82b81d1dd289fff