### PR TITLE
Add logging to labctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ Or type 'exit' to quit this script.
 All scripts output to the console using `Write-CustomLog`. If no log file is
 specified, a file named `lab.log` is created in `C:\temp` on Windows (or the
 system temporary directory on other platforms). Set the `LAB_LOG_DIR`
-environment variable or `$script:LogFilePath` to override the location.
+environment variable or `$script:LogFilePath` to override the location. The
+`labctl` Python CLI uses the same variable and writes to `lab.log` within that
+directory.
 
 Make sure to modify the 'main.tf' so it uses your admin credentials and hostname/IP of the host machine if you don't have a customized config.json or choose not to customize.
 

--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -11,15 +11,21 @@ def test_default_config_packaged():
     assert default_config_path().exists()
 
 
-def test_hv_facts():
+def test_hv_facts(tmp_path):
     runner = CliRunner()
-    result = runner.invoke(app, ["hv", "facts"])
+    env = {"LAB_LOG_DIR": str(tmp_path)}
+    result = runner.invoke(app, ["hv", "facts"], env=env)
     assert result.exit_code == 0
-    assert "\"Host\"" in result.output
+    log_file = tmp_path / "lab.log"
+    assert log_file.exists()
+    assert "\"Host\"" in log_file.read_text()
 
 
-def test_hv_deploy():
+def test_hv_deploy(tmp_path):
     runner = CliRunner()
-    result = runner.invoke(app, ["hv", "deploy"])
+    env = {"LAB_LOG_DIR": str(tmp_path)}
+    result = runner.invoke(app, ["hv", "deploy"], env=env)
     assert result.exit_code == 0
-    assert "Deploying Hyper-V host" in result.output
+    log_file = tmp_path / "lab.log"
+    assert log_file.exists()
+    assert "Deploying Hyper-V host" in log_file.read_text()


### PR DESCRIPTION
## Summary
- configure logging for the Python CLI
- log hv facts and deploy actions
- write logs when `LAB_LOG_DIR` is set
- document `labctl` logging in README
- update tests to verify log output

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester" | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487124e7648331af8a6d84db341bfe