### PR TITLE
Fix Reset-Machine test

### DIFF
--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -20,6 +20,7 @@ Describe 'Reset-Machine script' {
         }
         Mock New-NetFirewallRule {}
         $cfg = [pscustomobject]@{ AllowRemoteDesktop = $false; FirewallPorts = @() }
+        Mock Get-ItemProperty { [pscustomobject]@{ fDenyTSConnections = 1 } }
         . $script:ScriptPath -Config $cfg
         Assert-MockCalled Start-Process -Times 1 -ParameterFilter {
             $FilePath -eq $sysprep -and $ArgumentList -eq '/generalize /oobe /shutdown /quiet' -and $Wait


### PR DESCRIPTION
## Summary
- mock Get-ItemProperty when running Reset-Machine on Windows

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684871768e5c8331bda6194099882c9b