### PR TITLE
Fix script runner exit code handling

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -264,6 +264,7 @@ function Invoke-Scripts {
             }
 
             $output = & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity *>&1
+            $exitCode = $LASTEXITCODE
 
             foreach ($line in $output) {
                 if ($line) { Write-CustomLog $line.ToString() }
@@ -271,19 +272,9 @@ function Invoke-Scripts {
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 
-        try {
-            $scriptOutput = & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity 2>&1
-        }
-        catch {
-            $scriptOutput = & pwsh -NoLogo -NoProfile -Command $sb -Args $tempCfg, $scriptPath, $Verbosity *>&1
-        }
-        Write-Output $scriptOutput
-        Remove-Item $tempCfg -ErrorAction SilentlyContinue
-
-
-            $results[$s.Name] = $LASTEXITCODE
-            if ($LASTEXITCODE) {
-                Write-CustomLog "ERROR: $($s.Name) exited with code $LASTEXITCODE."
+            $results[$s.Name] = $exitCode
+            if ($exitCode -ne 0) {
+                Write-CustomLog "ERROR: $($s.Name) exited with code $exitCode."
                 $failed += $s.Name
             } else {
                 Write-CustomLog "$($s.Name) completed successfully."


### PR DESCRIPTION
## Summary
- streamline `Invoke-Scripts` to only run scripts once
- capture `$LASTEXITCODE` immediately and use it for per-script results

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_6848718e507c8331b7f79ee8419ef3ed