### PR TITLE
Add cleanup for stubbed firewall function

### DIFF
--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -47,4 +47,11 @@ Describe 'Reset-Machine script' {
         $code | Should -Be 1
         Assert-MockCalled Restart-Computer -Times 0
     }
+
+    AfterAll {
+        $cmd = Get-Command New-NetFirewallRule -ErrorAction SilentlyContinue
+        if ($cmd -and $cmd.CommandType -eq 'Function') {
+            Remove-Item Function:\New-NetFirewallRule -ErrorAction SilentlyContinue
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `New-NetFirewallRule` stub is removed after `Reset-Machine` tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_684871d0ad1083319d96da61d36463b9