### PR TITLE
Use Write-CustomLog across node scripts

### DIFF
--- a/iso_tools/Customize-ISO.ps1
+++ b/iso_tools/Customize-ISO.ps1
@@ -6,10 +6,10 @@ $adkInstaller    = Join-Path $PSScriptRoot "adksetup.exe"
 $peAddonInstaller = Join-Path $PSScriptRoot "adkwinpesetup.exe"
 
 # Install Windows ADK silently.
-Write-Output "Installing Windows ADK for Server 2025..."
+Write-CustomLog "Installing Windows ADK for Server 2025..."
 try {
     Start-Process -FilePath $adkInstaller -ArgumentList "/quiet", "/norestart", "/features optionid.deploymenttools optionid.userstatemigrationtool" -Wait -ErrorAction Stop
-    Write-Output "Windows ADK installation complete."
+    Write-CustomLog "Windows ADK installation complete."
 }
 catch {
     Write-Error "Installation of Windows ADK failed: $_"
@@ -17,10 +17,10 @@ catch {
 }
 
 # Install Windows PE Add-on silently.
-Write-Output "Installing Windows PE Add-on for Windows ADK..."
+Write-CustomLog "Installing Windows PE Add-on for Windows ADK..."
 try {
     Start-Process -FilePath $peAddonInstaller -ArgumentList "/quiet", "/norestart" -Wait -ErrorAction Stop
-    Write-Output "Windows PE Add-on installation complete."
+    Write-CustomLog "Windows PE Add-on installation complete."
 }
 catch {
     Write-Error "Installation of Windows PE Add-on failed: $_"

--- a/iso_tools/bootstrap.ps1
+++ b/iso_tools/bootstrap.ps1
@@ -8,7 +8,7 @@ $bootstrapUrl = "https://raw.githubusercontent.com/wizzense/opentofu-lab-automat
 Invoke-WebRequest -Uri $bootstrapUrl -OutFile '.\kicker-bootstrap.ps1'
 
 if (Test-Path '.\kicker-bootstrap.ps1') {
-  Write-Output "Downloaded kicker-bootstrap.ps1 to $(Resolve-Path '.\kicker-bootstrap.ps1')"
+  Write-CustomLog "Downloaded kicker-bootstrap.ps1 to $(Resolve-Path '.\kicker-bootstrap.ps1')"
   & .\kicker-bootstrap.ps1
 } else {
   Write-Error 'kicker-bootstrap.ps1 was not found after download.'

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -22,7 +22,7 @@ function Install-NodeCore {
     .\0201_Install-NodeCore.ps1 -Config $Config
 #>
 
-Write-Output "Config parameter is: $Config"
+Write-CustomLog "Config parameter is: $Config"
 
 
 Write-CustomLog "==== [0201] Installing Node.js Core ===="

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -52,7 +52,7 @@ function Install-NodeGlobalPackages {
     .\0202_Install-NodeGlobalPackages.ps1 -Config $Config
 #>
 
-Write-Output "Config parameter is: $Config"
+Write-CustomLog "Config parameter is: $Config"
 
 Write-CustomLog "==== [0202] Installing Global npm Packages ===="
 

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -84,6 +84,20 @@ Describe 'Node installation scripts' {
         Should -Invoke -CommandName npm -Times 0 -ParameterFilter { ($testArgs -join ' ') -eq 'install -g vite' }
     }
 
+    It 'logs start message when running Install-NodeCore' {
+        . $core
+        Mock Write-CustomLog {}
+        Install-NodeCore -Config $script:config
+        Assert-MockCalled Write-CustomLog -ParameterFilter { $Message -eq 'Running 0201_Install-NodeCore.ps1' } -Times 1
+    }
+
+    It 'logs start message when running Install-NodeGlobalPackages' {
+        . $global
+        Mock Write-CustomLog {}
+        Install-NodeGlobalPackages -Config $script:config
+        Assert-MockCalled Write-CustomLog -ParameterFilter { $Message -eq 'Running 0202_Install-NodeGlobalPackages.ps1' } -Times 1
+    }
+
     It 'honours -WhatIf for Install-GlobalPackage' {
     
         $global = (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' 'runner_scripts' '0202_Install-NodeGlobalPackages.ps1')).Path


### PR DESCRIPTION
## Summary
- update node install scripts to log with `Write-CustomLog`
- convert ISO tooling scripts to the same logger
- add Pester tests verifying start log messages

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68487154bc248331a4beb3053c9145db