### PR TITLE
Fix Write-CustomLog mocking

### DIFF
--- a/runner_utility_scripts/ScriptTemplate.ps1
+++ b/runner_utility_scripts/ScriptTemplate.ps1
@@ -1,6 +1,8 @@
 function Invoke-LabStep {
     param([scriptblock]$Body, [pscustomobject]$Config)
-    . $PSScriptRoot/Logger.ps1
+    if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
+        . $PSScriptRoot/Logger.ps1
+    }
 
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Summary
- make the logger import in ScriptTemplate.ps1 conditional so Pester can mock `Write-CustomLog`

## Testing
- `Invoke-Pester` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684875efbefc83319283b5a8b03a528b