### PR TITLE
Fix Install-OpenTofu tests

### DIFF
--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -19,7 +19,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
         Mock Invoke-OpenTofuInstaller {}
         Mock Write-CustomLog {}
         
-        . $script:ScriptPath -Config $cfg
+        & $script:ScriptPath -Config $cfg
 
         Assert-MockCalled Invoke-OpenTofuInstaller -Times 1 -ParameterFilter {
             $CosignPath -eq (Join-Path $cfg.CosignPath 'cosign-windows-amd64.exe') -and
@@ -32,7 +32,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
         Mock Invoke-OpenTofuInstaller {}
         Mock Write-CustomLog {}
 
-        . $script:ScriptPath -Config $cfg
+        & $script:ScriptPath -Config $cfg
 
         Assert-MockCalled Invoke-OpenTofuInstaller -Times 0
     }


### PR DESCRIPTION
## Summary
- fix tests so script is invoked with the call operator

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/Install-OpenTofu.Tests.ps1 -Output Detailed"`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Minimal"` *(fails: Tests Passed: 41, Failed: 5, Skipped: 4)*

------
https://chatgpt.com/codex/tasks/task_e_684875ded2d88331bc688c7247b790cc