### PR TITLE
Fix runner and system info scripts

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -294,33 +294,11 @@ function Invoke-Scripts {
 
 
         } catch {
-            Try {
-
-                  $results[$s.Name] = $exitCode
-                  if ($exitCode -ne 0) {
-                  Write-CustomLog "ERROR: $($s.Name) exited with code $exitCode."
-}
-
-            Catch {
-                  $results[$s.Name] = $LASTEXITCODE
-                   if ($LASTEXITCODE) {
-                      Write-CustomLog "ERROR: $($s.Name) exited with code $LASTEXITCODE."
-
-                      $failed += $s.Name
-            } else {
-                Write-CustomLog "$($s.Name) completed successfully."
-            }
-        } 
-        
-        catch {
-
             Write-CustomLog "ERROR: Exception in $($s.Name): $_"
             $global:LASTEXITCODE = 1
             $failed += $s.Name
         }
     }
-    
- }
 
     $Config | ConvertTo-Json -Depth 5 | Out-File $ConfigFile -Encoding utf8
     $summary = $results.GetEnumerator() | ForEach-Object { "${($_.Key)}=$($_.Value)" } | Sort-Object | Join-String -Separator ', '


### PR DESCRIPTION
## Summary
- handle Pester execution when loading Get-Platform
- remove stray braces in `runner.ps1`

## Testing
- `Invoke-Pester` *(fails: Tests Passed: 42, Failed: 4)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684875c6b150833198d9378eba158478