### PR TITLE
Fix runner invocation parsing

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -294,28 +294,9 @@ function Invoke-Scripts {
 
 
         } catch {
-            Try {
-
-                  $results[$s.Name] = $exitCode
-                  if ($exitCode -ne 0) {
-                  Write-CustomLog "ERROR: $($s.Name) exited with code $exitCode."
-}
-
-            Catch {
-                  $results[$s.Name] = $LASTEXITCODE
-                   if ($LASTEXITCODE) {
-                      Write-CustomLog "ERROR: $($s.Name) exited with code $LASTEXITCODE."
-
-                      $failed += $s.Name
-            } else {
-                Write-CustomLog "$($s.Name) completed successfully."
-            }
-        } 
-        
-        catch {
-
             Write-CustomLog "ERROR: Exception in $($s.Name): $_"
             $global:LASTEXITCODE = 1
+            $results[$s.Name] = $LASTEXITCODE
             $failed += $s.Name
         }
     }

--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -50,7 +50,38 @@ function Get-SystemInfo {
                     LatestHotfix   = $hotfix.HotFixID
                 }
             }
-            'Linux' | 'MacOS' {
+            'Linux' {
+                $computer = (hostname)
+                $addresses = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces() |
+                    Where-Object { $_.OperationalStatus -eq 'Up' } |
+                    ForEach-Object { $_.GetIPProperties().UnicastAddresses } |
+                    Where-Object { $_.Address.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } |
+                    ForEach-Object { $_.Address.ToString() } | Sort-Object -Unique
+                $gateway = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces() |
+                    ForEach-Object { $_.GetIPProperties().GatewayAddresses } |
+                    Where-Object { $_.Address.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } |
+                    Select-Object -First 1 -ExpandProperty Address |
+                    ForEach-Object { $_.ToString() }
+                $osVersion = (uname -sr)
+                $disks = [System.IO.DriveInfo]::GetDrives() |
+                    Where-Object { $_.IsReady } |
+                    ForEach-Object {
+                        [pscustomobject]@{
+                            Partition   = $_.Name
+                            DriveLetter = $_.Name
+                            SizeGB      = [math]::Round(($_.TotalSize/1GB),2)
+                            MediaType   = $_.DriveType
+                        }
+                    }
+                $info = [pscustomobject]@{
+                    ComputerName   = $computer
+                    IPAddresses    = $addresses
+                    DefaultGateway = $gateway
+                    OSVersion      = $osVersion
+                    DiskInfo       = $disks
+                }
+            }
+            'MacOS' {
                 $computer = (hostname)
                 $addresses = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces() |
                     Where-Object { $_.OperationalStatus -eq 'Up' } |


### PR DESCRIPTION
## Summary
- fix missing catch blocks in `runner.ps1`
- update system info script switch statement for Linux/MacOS

## Testing
- `Invoke-Pester` *(fails: Tests Passed: 42, Failed: 4)*

------
https://chatgpt.com/codex/tasks/task_e_6848765a7d008331a73588e4ca9f2ed6