### PR TITLE
Update CI matrix for pytest job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,11 @@ jobs:
 
   pytest:
     needs: pester
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Authenticate gh
@@ -142,8 +146,6 @@ jobs:
         with:
           python-version: '3.x'
           cache: 'pip'
-          
-          
       - name: Install Poetry
         run: pip install --user poetry
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- run pytest on Windows, Ubuntu, and macOS runners
- keep pytest job dependent on Pester

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path ."` *(fails: pwsh not found)*
- `poetry run pytest` *(fails: ModuleNotFoundError: 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684878661bb8833195f07355add7bfb7