### PR TITLE
Switch to Should-Invoke in tests

### DIFF
--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -20,7 +20,9 @@ Describe '0104_Install-CA script' {
 
         & $scriptPath -Config $config -Confirm:$false
 
-        Assert-MockCalled Install-AdcsCertificationAuthority -Times 1
+        Should -Invoke -CommandName Install-AdcsCertificationAuthority -Times 1 -ParameterFilter {
+            $CACommonName -eq 'TestCA' -and $CAType -eq 'StandaloneRootCA'
+        }
     }
 
     It 'skips CA installation when InstallCA is false' -Skip:($IsLinux -or $IsMacOS) {

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -21,7 +21,7 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
         
         & $script:ScriptPath -Config $cfg
 
-        Assert-MockCalled Invoke-OpenTofuInstaller -Times 1 -ParameterFilter {
+        Should -Invoke -CommandName Invoke-OpenTofuInstaller -Times 1 -ParameterFilter {
             $CosignPath -eq (Join-Path $cfg.CosignPath 'cosign-windows-amd64.exe') -and
             $OpenTofuVersion -eq $cfg.OpenTofuVersion
         }
@@ -34,6 +34,6 @@ Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
 
         & $script:ScriptPath -Config $cfg
 
-        Assert-MockCalled Invoke-OpenTofuInstaller -Times 0
+        Should -Invoke -CommandName Invoke-OpenTofuInstaller -Times 0
     }
 }


### PR DESCRIPTION
## Summary
- replace `Assert-MockCalled` with `Should -Invoke` in CA installer tests
- switch OpenTofu installer tests to `Should -Invoke` syntax

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848786d70208331b06860a41a237996