### PR TITLE
Add error checks to Format-Config and tests

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -3,6 +3,10 @@ function Format-Config {
         [pscustomobject]$Config
     )
 
+    if ($null -eq $Config) {
+        throw [System.ArgumentNullException]::new('Config')
+    }
+
     # Serialize the configuration object to indented JSON so nested
     # properties are easier to read in the console output.  Depth 10
     # should be sufficient for our current config structure.

--- a/tests/EscapePathArgument.Tests.ps1
+++ b/tests/EscapePathArgument.Tests.ps1
@@ -14,5 +14,7 @@ Describe 'escapePathArgument' {
     It 'accepts pipeline input' {
         'C:\Temp' | escapePathArgument | Should -Be '"C:\Temp"'
     }
-
+    It 'throws when path contains quotes' {
+        { escapePathArgument -Path 'C:\Bad"Path' } | Should -Throw
+    }
 }

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -9,4 +9,8 @@ Describe 'Format-Config' {
         $result | Should -Match '"Foo"\s*:\s*"bar"'
         $result | Should -Match '"Baz"\s*:\s*1'
     }
+
+    It 'throws when Config is null' {
+        { Format-Config -Config $null } | Should -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `Format-Config` throws when Config is `$null`
- test `Format-Config -Config $null` throws
- test `escapePathArgument` errors on paths containing quotes

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `ruff .` *(fails: unrecognized subcommand)*

------
https://chatgpt.com/codex/tasks/task_e_68487890b8d08331b81c4c9cb29ed9db