### PR TITLE
Centralize test OS skips

### DIFF
--- a/tests/Config-DNS.Tests.ps1
+++ b/tests/Config-DNS.Tests.ps1
@@ -1,7 +1,8 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe '0113_Config-DNS' {
-    It 'calls Set-DnsClientServerAddress with value from config' -Skip:($IsLinux -or $IsMacOS) {
+    It 'calls Set-DnsClientServerAddress with value from config' -Skip:($SkipNonWindows) {
         $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0113_Config-DNS.ps1'
         $config = [pscustomobject]@{
             SetDNSServers = $true

--- a/tests/Config-TrustedHosts.Tests.ps1
+++ b/tests/Config-TrustedHosts.Tests.ps1
@@ -1,7 +1,8 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 
-Describe '0114_Config-TrustedHosts' -Skip:($IsLinux -or $IsMacOS) {
+Describe '0114_Config-TrustedHosts' -Skip:($SkipNonWindows) {
     It 'calls Start-Process with winrm arguments using config value' {
 
         $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0114_Config-TrustedHosts.ps1'

--- a/tests/Configure-Firewall.Tests.ps1
+++ b/tests/Configure-Firewall.Tests.ps1
@@ -1,6 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
-Describe '0102_Configure-Firewall' -Skip:($IsLinux -or $IsMacOS) {
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
+Describe '0102_Configure-Firewall' -Skip:($SkipNonWindows) {
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0102_Configure-Firewall.ps1'
     }

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe '0112_Enable-PXE' {
     BeforeAll {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0112_Enable-PXE.ps1'
@@ -7,7 +8,7 @@ Describe '0112_Enable-PXE' {
         . $loggerPath
     }
 
-    It 'logs firewall rules when ConfigPXE is true' -Skip:($IsLinux -or $IsMacOS) {
+    It 'logs firewall rules when ConfigPXE is true' -Skip:($SkipNonWindows) {
         $Config = [pscustomobject]@{ ConfigPXE = $true }
         $logPath = Join-Path $env:TEMP ('pxe-log-' + [System.Guid]::NewGuid().ToString() + '.txt')
         $script:LogFilePath = $logPath

--- a/tests/Enable-RemoteDesktop.Tests.ps1
+++ b/tests/Enable-RemoteDesktop.Tests.ps1
@@ -1,6 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
-Describe '0101_Enable-RemoteDesktop' -Skip:($IsLinux -or $IsMacOS) {
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
+Describe '0101_Enable-RemoteDesktop' -Skip:($SkipNonWindows) {
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0101_Enable-RemoteDesktop.ps1'
     }

--- a/tests/Enable-WinRM.Tests.ps1
+++ b/tests/Enable-WinRM.Tests.ps1
@@ -1,6 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
-Describe '0100_Enable-WinRM' -Skip:($IsLinux -or $IsMacOS) {
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
+Describe '0100_Enable-WinRM' -Skip:($SkipNonWindows) {
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0100_Enable-WinRM.ps1'
     }

--- a/tests/Get-HyperVProviderVersion.Tests.ps1
+++ b/tests/Get-HyperVProviderVersion.Tests.ps1
@@ -1,7 +1,8 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 
-Describe 'Get-HyperVProviderVersion' -Skip:($IsLinux -or $IsMacOS) {
+Describe 'Get-HyperVProviderVersion' -Skip:($SkipNonWindows) {
     It 'parses version from main.tf' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath

--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -1,11 +1,12 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe '0104_Install-CA script' {
     BeforeAll {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0104_Install-CA.ps1'
     }
 
-    It 'invokes CA installation when InstallCA is true' -Skip:($IsLinux -or $IsMacOS) {
+    It 'invokes CA installation when InstallCA is true' -Skip:($SkipNonWindows) {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $config = [pscustomobject]@{
             InstallCA = $true
@@ -23,7 +24,7 @@ Describe '0104_Install-CA script' {
         Assert-MockCalled Install-AdcsCertificationAuthority -Times 1
     }
 
-    It 'skips CA installation when InstallCA is false' -Skip:($IsLinux -or $IsMacOS) {
+    It 'skips CA installation when InstallCA is false' -Skip:($SkipNonWindows) {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $config = [pscustomobject]@{
             InstallCA = $false

--- a/tests/Install-Go.Tests.ps1
+++ b/tests/Install-Go.Tests.ps1
@@ -1,6 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
-Describe '0007_Install-Go' -Skip:($IsLinux -or $IsMacOS) {
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
+Describe '0007_Install-Go' -Skip:($SkipNonWindows) {
     BeforeAll { $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0007_Install-Go.ps1' }
 
     It 'installs Go when enabled' {

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -1,6 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
-Describe '0008_Install-OpenTofu' -Skip:($IsLinux -or $IsMacOS) {
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
+Describe '0008_Install-OpenTofu' -Skip:($SkipNonWindows) {
     BeforeAll {
         $script:ScriptPath = (
             Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_scripts' '0008_Install-OpenTofu.ps1')

--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -1,6 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
-Describe '0006_Install-ValidationTools' -Skip:($IsLinux -or $IsMacOS) {
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
+Describe '0006_Install-ValidationTools' -Skip:($SkipNonWindows) {
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0006_Install-ValidationTools.ps1'
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -1,6 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
-Describe 'kicker-bootstrap utilities' -Skip:($IsLinux -or $IsMacOS) {
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
+Describe 'kicker-bootstrap utilities' -Skip:($SkipNonWindows) {
     It 'defines Write-CustomLog fallback' {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:scriptPath, [ref]$null, [ref]$null)

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,5 +1,6 @@
 Describe 'OpenTofuInstaller' {
-if ($IsLinux -or $IsMacOS) { return }
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 
     BeforeAll {
         # Ensure no lingering TestDrive from previous test runs
@@ -20,7 +21,7 @@ if ($IsLinux -or $IsMacOS) { return }
     }
 
 
-    Describe 'logging' -Skip:($IsLinux -or $IsMacOS) {
+    Describe 'logging' -Skip:($SkipNonWindows) {
         It 'creates log files and removes them for elevated unpack' {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'
         $temp = $script:temp

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 
 BeforeAll {
     $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
@@ -8,7 +9,7 @@ BeforeAll {
     $global:origConvertPfxToPem = (Get-Command Convert-PfxToPem).ScriptBlock
     Mock Convert-PfxToPem {}
 }
-Describe 'Prepare-HyperVProvider path restoration' -Skip:($IsLinux -or $IsMacOS) {
+Describe 'Prepare-HyperVProvider path restoration' -Skip:($SkipNonWindows) {
     It 'restores location after execution' {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
@@ -63,7 +64,7 @@ Describe 'Prepare-HyperVProvider path restoration' -Skip:($IsLinux -or $IsMacOS)
     }
 }
 
-Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMacOS) {
+Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
     It 'creates PEM files and updates providers.tf' {
 
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
@@ -170,7 +171,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($IsLinux -or $IsMa
 }
 
 
-Describe 'Convert certificate helpers honour -WhatIf' -Skip:($IsLinux -or $IsMacOS) {
+Describe 'Convert certificate helpers honour -WhatIf' -Skip:($SkipNonWindows) {
     It 'skips writing files when WhatIf is used' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
@@ -183,7 +184,7 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($IsLinux -or $IsMac
         Remove-Item $cer -ErrorAction SilentlyContinue
     }
 
-    It 'skips writing PFX outputs when WhatIf is used' -Skip:($IsLinux -or $IsMacOS) {
+    It 'skips writing PFX outputs when WhatIf is used' -Skip:($SkipNonWindows) {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
         $pfx = Join-Path $TestDrive (([guid]::NewGuid()).ToString() + '.pfx')
@@ -206,7 +207,7 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($IsLinux -or $IsMac
     }
 }
 
-Describe 'Convert certificate helpers validate paths' -Skip:($IsLinux -or $IsMacOS) {
+Describe 'Convert certificate helpers validate paths' -Skip:($SkipNonWindows) {
     BeforeAll {
         Unmock Convert-CerToPem -ErrorAction SilentlyContinue
         Unmock Convert-PfxToPem -ErrorAction SilentlyContinue

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 <#
 .SYNOPSIS
     Tests for runner_scripts\0001_Reset-Git.ps1
@@ -9,7 +10,7 @@ if ($IsLinux -or $IsMacOS) { return }
     - Verifies that it exits with a non-zero code (or throws) when the clone fails.
 #>
 
-Describe '0001_Reset-Git' -Skip:($IsLinux -or $IsMacOS) {
+Describe '0001_Reset-Git' -Skip:($SkipNonWindows) {
 
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0001_Reset-Git.ps1'

--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Reset-Machine script' {
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '9999_Reset-Machine.ps1'
@@ -9,7 +10,7 @@ Describe 'Reset-Machine script' {
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
     }
 
-    It 'invokes sysprep and configures Remote Desktop on Windows' -Skip:($IsLinux -or $IsMacOS) {
+    It 'invokes sysprep and configures Remote Desktop on Windows' -Skip:($SkipNonWindows) {
         Mock Get-Platform { 'Windows' }
         $sysprep = 'C:\\Windows\\System32\\Sysprep\\Sysprep.exe'
         Mock Test-Path { $true } -ParameterFilter { $Path -eq $sysprep }

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'runner.ps1 configuration' {
     It 'loads default configuration without errors' {
         $modulePath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-LabConfig.ps1'
@@ -9,7 +10,7 @@ Describe 'runner.ps1 configuration' {
     }
 }
 
-Describe 'runner.ps1 script selection' -Skip:($IsLinux -or $IsMacOS) {
+Describe 'runner.ps1 script selection' -Skip:($SkipNonWindows) {
     BeforeAll {
         # Use script-scoped variable so PSScriptAnalyzer recognizes cross-block usage
         $script:runnerPath = Join-Path $PSScriptRoot '..' 'runner.ps1'
@@ -346,7 +347,7 @@ Write-Error 'err message'
         finally { Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue }
     }
 
-    It 'prompts for script selection when no -Scripts argument is supplied' -Skip:($IsLinux -or $IsMacOS) {
+    It 'prompts for script selection when no -Scripts argument is supplied' -Skip:($SkipNonWindows) {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $tempDir
         try {
@@ -379,7 +380,7 @@ exit 0' | Set-Content -Path $dummy
         }
     }
 
-    It 'handles empty or invalid selection by logging and doing nothing' -Skip:($IsLinux -or $IsMacOS) {
+    It 'handles empty or invalid selection by logging and doing nothing' -Skip:($SkipNonWindows) {
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $tempDir
         try {
@@ -486,7 +487,7 @@ Describe 'Set-LabConfig' {
         }
     }
 
-    It 'updates selections and saves to JSON' -Skip:($IsLinux -or $IsMacOS) {
+    It 'updates selections and saves to JSON' -Skip:($SkipNonWindows) {
         $config = @{
             InstallGit = $false
             InstallGo  = $false

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -5,13 +5,14 @@ if (-not (Test-Path $helperPath)) {
 }
 
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 
-if ($IsLinux -or $IsMacOS) { return }
+if ($SkipNonWindows) { return }
 
 $scriptDir = Join-Path $PSScriptRoot '..' 'runner_scripts'
 $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 
-Describe 'Runner scripts parameter and command checks' -Skip:($IsLinux -or $IsMacOS) {
+Describe 'Runner scripts parameter and command checks' -Skip:($SkipNonWindows) {
 
     BeforeAll {
         . (Join-Path $PSScriptRoot 'helpers' 'Get-ScriptAst.ps1')

--- a/tests/Setup-Directories.Tests.ps1
+++ b/tests/Setup-Directories.Tests.ps1
@@ -1,6 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
-if ($IsLinux -or $IsMacOS) { return }
-Describe '0002_Setup-Directories' -Skip:($IsLinux -or $IsMacOS) {
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
+Describe '0002_Setup-Directories' -Skip:($SkipNonWindows) {
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0002_Setup-Directories.ps1'
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')

--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -1,0 +1,1 @@
+$SkipNonWindows = $IsLinux -or $IsMacOS


### PR DESCRIPTION
## Summary
- add `TestHelpers.ps1` defining `$SkipNonWindows`
- update PowerShell tests to import TestHelpers and skip via `$SkipNonWindows`

## Testing
- `ruff check .`
- `Invoke-Pester` *(fails: `pwsh` not found)*
- `Invoke-ScriptAnalyzer -Path .` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848784d26a88331b5e1997eebe11dd7