### PR TITLE
Add cleanup for global function mocks

### DIFF
--- a/tests/Expand-All.Tests.ps1
+++ b/tests/Expand-All.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Expand-All' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Expand-All.ps1')
@@ -6,6 +7,9 @@ Describe 'Expand-All' {
     BeforeEach {
         function global:Write-CustomLog {}
         Mock Write-CustomLog {}
+    }
+    AfterEach {
+        Remove-Item Function:Write-CustomLog -ErrorAction SilentlyContinue
     }
 
     It 'expands a specific ZIP file when provided' {

--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -1,7 +1,12 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Initialize-OpenTofu script' {
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0009_Initialize-OpenTofu.ps1'
+    }
+    AfterEach {
+        Remove-Item Function:gh -ErrorAction SilentlyContinue
+        Remove-Item Function:tofu -ErrorAction SilentlyContinue
     }
 
     It 'clones repo when InfraRepoUrl is provided' {

--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -1,8 +1,12 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 if ($IsLinux -or $IsMacOS) { return }
 Describe '0104_Install-CA script' {
     BeforeAll {
         $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0104_Install-CA.ps1'
+    }
+    AfterEach {
+        Remove-Item Function:Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
     }
 
     It 'invokes CA installation when InstallCA is true' -Skip:($IsLinux -or $IsMacOS) {

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -1,5 +1,9 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe '0203_Install-npm' {
+    AfterEach {
+        Remove-Item Function:npm -ErrorAction SilentlyContinue
+    }
     It 'runs npm install in configured NpmPath' {
         $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0203_Install-npm.ps1'
         $npmDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
@@ -21,7 +25,6 @@ Describe '0203_Install-npm' {
         $script:calledPath | Should -Be (Get-Item $npmDir).FullName
 
         Remove-Item -Recurse -Force $npmDir
-        Remove-Item function:npm -ErrorAction SilentlyContinue
     }
 
     It 'succeeds when NpmPath exists' {
@@ -43,7 +46,6 @@ Describe '0203_Install-npm' {
         $success | Should -BeTrue
 
         Remove-Item -Recurse -Force $npmDir
-        Remove-Item function:npm -ErrorAction SilentlyContinue
     }
 
     It 'errors when NpmPath is missing and CreateNpmPath is false' {
@@ -57,7 +59,6 @@ Describe '0203_Install-npm' {
         . $script -Config $cfg
         { Install-NpmDependencies -Config $cfg } | Should -Throw
         $script:called | Should -BeFalse
-        Remove-Item function:npm -ErrorAction SilentlyContinue
     }
 
     It 'errors when NpmPath is empty string' {
@@ -70,7 +71,6 @@ Describe '0203_Install-npm' {
         . $script -Config $cfg
         { Install-NpmDependencies -Config $cfg } | Should -Throw
         $script:called | Should -BeFalse
-        Remove-Item function:npm -ErrorAction SilentlyContinue
     }
 
     It 'creates NpmPath when CreateNpmPath is true' {

--- a/tests/Menu.Tests.ps1
+++ b/tests/Menu.Tests.ps1
@@ -1,8 +1,12 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Get-MenuSelection' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Menu.ps1')
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+    }
+    AfterEach {
+        Remove-Item Function:Read-Host -ErrorAction SilentlyContinue
     }
     It 'returns all items when user types all' {
         $items = @('0001_Test.ps1','0002_Other.ps1')

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,4 +1,5 @@
 Describe 'OpenTofuInstaller' {
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 if ($IsLinux -or $IsMacOS) { return }
 
     BeforeAll {
@@ -16,6 +17,7 @@ if ($IsLinux -or $IsMacOS) { return }
     AfterEach {
         Remove-Item -Recurse -Force $script:temp -ErrorAction SilentlyContinue
         Remove-Item Function:Test-IsAdmin -ErrorAction SilentlyContinue
+        Remove-Item Function:Start-Process -ErrorAction SilentlyContinue
         Remove-Variable -Name OpenTofuInstallerLogDir -Scope Global -ErrorAction SilentlyContinue
     }
 
@@ -64,7 +66,6 @@ if ($IsLinux -or $IsMacOS) { return }
         }
 
         (Test-Path $global:OpenTofuInstallerLogDir) | Should -BeFalse
-        Remove-Item Function:Start-Process -ErrorAction SilentlyContinue
         }
 
         It 'gracefully handles missing log directory' {
@@ -103,7 +104,6 @@ if ($IsLinux -or $IsMacOS) { return }
         & $script:scriptPath -installMethod standalone -opentofuVersion '0.0.0' -installPath $temp -allUsers -skipVerify -skipChangePath | Out-Null
         $global:startProcessCalled | Should -BeTrue
         $LASTEXITCODE | Should -Be 0
-        Remove-Item Function:Start-Process -ErrorAction SilentlyContinue
         }
     }
 

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 if ($IsLinux -or $IsMacOS) { return }
 <#
 .SYNOPSIS
@@ -13,6 +14,9 @@ Describe '0001_Reset-Git' -Skip:($IsLinux -or $IsMacOS) {
 
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0001_Reset-Git.ps1'
+    }
+    AfterEach {
+        Remove-Item Function:gh -ErrorAction SilentlyContinue
     }
 
     Context 'Clone command selection' {

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 if ($IsLinux -or $IsMacOS) { return }
 Describe 'runner.ps1 configuration' {
     It 'loads default configuration without errors' {
@@ -17,6 +18,10 @@ Describe 'runner.ps1 script selection' -Skip:($IsLinux -or $IsMacOS) {
         . $modulePath
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Menu.ps1')
+    }
+    AfterEach {
+        Remove-Item Function:Write-Host -ErrorAction SilentlyContinue
+        Remove-Item Function:Read-Host -ErrorAction SilentlyContinue
     }
 
     It 'runs non-interactively when -Scripts is supplied' {
@@ -301,7 +306,6 @@ Write-Error 'err message'
                 $script:logLines += $Object
             }
             $output = & "$tempDir/runner.ps1" -Scripts '0001' -Auto -Verbosity 'silent' *>&1
-            Remove-Item Function:\Write-Host -ErrorAction SilentlyContinue
             Pop-Location
 
         $script:logLines | Should -Not -Contain '==== Loading configuration ===='
@@ -336,7 +340,6 @@ Write-Error 'err message'
                 $script:logLines += $Object
             }
             $output = & "$tempDir/runner.ps1" -Scripts '0001' -Auto -Verbosity silent *>&1
-            Remove-Item Function:\Write-Host -ErrorAction SilentlyContinue
             Pop-Location
 
             $script:logLines | Should -Not -Contain '==== Loading configuration ===='

--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -1,0 +1,4 @@
+# Helper utilities for Pester tests.
+# To avoid cross-test pollution, remove any mocked global functions in an AfterEach block.
+# Example:
+#     AfterEach { Remove-Item Function:npm -ErrorAction SilentlyContinue }


### PR DESCRIPTION
## Summary
- ensure global function mocks are cleared in tests via `AfterEach`
- explain the pattern in new `tests/helpers/TestHelpers.ps1`

## Testing
- `Invoke-Pester` *(fails: CommandNotFoundException for Get-Platform)*

------
https://chatgpt.com/codex/tasks/task_e_684878540f30833180dcc793e3c3faad