### PR TITLE
Add coverage config and artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,14 @@ jobs:
         continue-on-error: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
-          pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests -CI -ErrorAction Stop"
+          pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration tests/PesterConfiguration.psd1 -ErrorAction Stop"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pester-coverage-${{ matrix.os }}
+          path: coverage/coverage.xml
 
   pytest:
     needs: pester

--- a/tests/PesterConfiguration.psd1
+++ b/tests/PesterConfiguration.psd1
@@ -1,0 +1,9 @@
+@{
+    Run = @{ Path = 'tests' }
+    CodeCoverage = @{ 
+        Path = @('runner_scripts','lab_utils')
+        OutputFormat = 'JaCoCo'
+        Enabled = $true
+        OutputPath = 'coverage/coverage.xml'
+    }
+}


### PR DESCRIPTION
## Summary
- create `tests/PesterConfiguration.psd1` to collect coverage
- run Pester with the new config
- upload coverage report after tests

## Testing
- `pwsh -NoLogo -NoProfile -Command '$h=Import-PowerShellDataFile -Path "tests/PesterConfiguration.psd1"; $config=New-PesterConfiguration -Hashtable $h; Invoke-Pester -Configuration $config'`

------
https://chatgpt.com/codex/tasks/task_e_684878612dac833183025c8ac5aa3cb9