### PR TITLE
Fix script parsing

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -260,8 +260,9 @@ function Invoke-Scripts {
                 $script:ConsoleLevel = $vl[$verbosity]
                 $cfg = Get-Content -Raw -Path $cfgPath | ConvertFrom-Json
                 try {
-                    & $scr -Config $cfg
+                    $result = & $scr -Config $cfg
                     $exit = if ($LASTEXITCODE) { $LASTEXITCODE } elseif (-not $?) { 1 } else { 0 }
+                    Write-Output $result
                     exit $exit
                 } catch {
                     $_ | Out-String | Write-Error
@@ -294,33 +295,12 @@ function Invoke-Scripts {
 
 
         } catch {
-            Try {
-
-                  $results[$s.Name] = $exitCode
-                  if ($exitCode -ne 0) {
-                  Write-CustomLog "ERROR: $($s.Name) exited with code $exitCode."
-}
-
-            Catch {
-                  $results[$s.Name] = $LASTEXITCODE
-                   if ($LASTEXITCODE) {
-                      Write-CustomLog "ERROR: $($s.Name) exited with code $LASTEXITCODE."
-
-                      $failed += $s.Name
-            } else {
-                Write-CustomLog "$($s.Name) completed successfully."
-            }
-        } 
-        
-        catch {
-
             Write-CustomLog "ERROR: Exception in $($s.Name): $_"
+            $results[$s.Name] = 1
             $global:LASTEXITCODE = 1
             $failed += $s.Name
         }
-    }
-    
- }
+        }
 
     $Config | ConvertTo-Json -Depth 5 | Out-File $ConfigFile -Encoding utf8
     $summary = $results.GetEnumerator() | ForEach-Object { "${($_.Key)}=$($_.Value)" } | Sort-Object | Join-String -Separator ', '

--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -50,7 +50,38 @@ function Get-SystemInfo {
                     LatestHotfix   = $hotfix.HotFixID
                 }
             }
-            'Linux' | 'MacOS' {
+            'Linux' {
+                $computer = (hostname)
+                $addresses = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces() |
+                    Where-Object { $_.OperationalStatus -eq 'Up' } |
+                    ForEach-Object { $_.GetIPProperties().UnicastAddresses } |
+                    Where-Object { $_.Address.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } |
+                    ForEach-Object { $_.Address.ToString() } | Sort-Object -Unique
+                $gateway = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces() |
+                    ForEach-Object { $_.GetIPProperties().GatewayAddresses } |
+                    Where-Object { $_.Address.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } |
+                    Select-Object -First 1 -ExpandProperty Address |
+                    ForEach-Object { $_.ToString() }
+                $osVersion = (uname -sr)
+                $disks = [System.IO.DriveInfo]::GetDrives() |
+                    Where-Object { $_.IsReady } |
+                    ForEach-Object {
+                        [pscustomobject]@{
+                            Partition   = $_.Name
+                            DriveLetter = $_.Name
+                            SizeGB      = [math]::Round(($_.TotalSize/1GB),2)
+                            MediaType   = $_.DriveType
+                        }
+                    }
+                $info = [pscustomobject]@{
+                    ComputerName   = $computer
+                    IPAddresses    = $addresses
+                    DefaultGateway = $gateway
+                    OSVersion      = $osVersion
+                    DiskInfo       = $disks
+                }
+            }
+            'MacOS' {
                 $computer = (hostname)
                 $addresses = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces() |
                     Where-Object { $_.OperationalStatus -eq 'Up' } |

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -1,5 +1,14 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 if ($IsLinux -or $IsMacOS) { return }
+
+Describe 'runner.ps1 syntax' {
+    It 'parses without errors' {
+        $path = Join-Path $PSScriptRoot '..' 'runner.ps1'
+        $errs = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$null, [ref]$errs) | Out-Null
+        ($errs ? $errs.Count : 0) | Should -Be 0
+    }
+}
 Describe 'runner.ps1 configuration' {
     It 'loads default configuration without errors' {
         $modulePath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-LabConfig.ps1'

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -22,6 +22,13 @@ Describe 'Runner scripts parameter and command checks' -Skip:($IsLinux -or $IsMa
         @{ Name = $_.Name; File = $_ }
     }
 
+    It 'parses without errors' -TestCases $testCases {
+        param($File)
+        $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($File.FullName, [ref]$null, [ref]$errors) | Out-Null
+        ($errors ? $errors.Count : 0) | Should -Be 0
+    }
+
     It 'declares a Config parameter when required' -TestCases $testCases {
         param($File)
         $ast = Get-ScriptAst $File.FullName


### PR DESCRIPTION
## Summary
- fix unbalanced catch block in `runner.ps1`
- print script results from inner PowerShell invocation
- split Linux and MacOS cases in `0200_Get-SystemInfo.ps1`
- check syntax of runner and runner scripts in tests

## Testing
- `Invoke-Pester -Path tests -CI -ErrorAction Stop` *(fails: Tests Passed: 42, Failed: 4)*

------
https://chatgpt.com/codex/tasks/task_e_6848758ba9d88331b960a085709911cd