### PR TITLE
Fix Pester config invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         continue-on-error: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
-          pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration tests/PesterConfiguration.psd1 -ErrorAction Stop"
+          pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration (Import-PowerShellDataFile -Path 'tests/PesterConfiguration.psd1') -ErrorAction Stop"
 
       - name: Upload coverage
         if: always()


### PR DESCRIPTION
## Summary
- import the Pester configuration file when calling Invoke-Pester

## Testing
- `pwsh` was not available so tests couldn't be run

------
https://chatgpt.com/codex/tasks/task_e_68487db558748331b7cb527c17e4c3e9