### PR TITLE
Refactor Pester tests with new helper

### DIFF
--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -1,7 +1,8 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Cleanup-Files script' {
     BeforeAll {
-        $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0000_Cleanup-Files.ps1'
+        $script:scriptPath = Get-RunnerScriptPath '0000_Cleanup-Files.ps1'
     }
 
     BeforeEach {

--- a/tests/Config-DNS.Tests.ps1
+++ b/tests/Config-DNS.Tests.ps1
@@ -3,7 +3,7 @@
 if ($SkipNonWindows) { return }
 Describe '0113_Config-DNS' {
     It 'calls Set-DnsClientServerAddress with value from config' -Skip:($SkipNonWindows) {
-        $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0113_Config-DNS.ps1'
+        $script = Get-RunnerScriptPath '0113_Config-DNS.ps1'
         $config = [pscustomobject]@{
             SetDNSServers = $true
             DNSServers    = '1.2.3.4'

--- a/tests/Config-TrustedHosts.Tests.ps1
+++ b/tests/Config-TrustedHosts.Tests.ps1
@@ -5,7 +5,7 @@ if ($SkipNonWindows) { return }
 Describe '0114_Config-TrustedHosts' -Skip:($SkipNonWindows) {
     It 'calls Start-Process with winrm arguments using config value' {
 
-        $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0114_Config-TrustedHosts.ps1'
+        $script = Get-RunnerScriptPath '0114_Config-TrustedHosts.ps1'
         $config = [pscustomobject]@{
             SetTrustedHosts = $true
             TrustedHosts    = 'host1'

--- a/tests/Configure-Firewall.Tests.ps1
+++ b/tests/Configure-Firewall.Tests.ps1
@@ -3,7 +3,7 @@
 if ($SkipNonWindows) { return }
 Describe '0102_Configure-Firewall' -Skip:($SkipNonWindows) {
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0102_Configure-Firewall.ps1'
+        $script:ScriptPath = Get-RunnerScriptPath '0102_Configure-Firewall.ps1'
     }
 
     It 'creates firewall rules for each port when ports are specified' {

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -3,7 +3,7 @@
 if ($SkipNonWindows) { return }
 Describe '0112_Enable-PXE' {
     BeforeAll {
-        $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0112_Enable-PXE.ps1'
+        $script:scriptPath = Get-RunnerScriptPath '0112_Enable-PXE.ps1'
         $loggerPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1'
         . $loggerPath
     }

--- a/tests/Enable-RemoteDesktop.Tests.ps1
+++ b/tests/Enable-RemoteDesktop.Tests.ps1
@@ -3,7 +3,7 @@
 if ($SkipNonWindows) { return }
 Describe '0101_Enable-RemoteDesktop' -Skip:($SkipNonWindows) {
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0101_Enable-RemoteDesktop.ps1'
+        $script:ScriptPath = Get-RunnerScriptPath '0101_Enable-RemoteDesktop.ps1'
     }
 
     It 'enables RDP when allowed and currently disabled' {

--- a/tests/Enable-WinRM.Tests.ps1
+++ b/tests/Enable-WinRM.Tests.ps1
@@ -3,7 +3,7 @@
 if ($SkipNonWindows) { return }
 Describe '0100_Enable-WinRM' -Skip:($SkipNonWindows) {
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0100_Enable-WinRM.ps1'
+        $script:ScriptPath = Get-RunnerScriptPath '0100_Enable-WinRM.ps1'
     }
 
     It 'enables WinRM when service is not running' {

--- a/tests/EscapePathArgument.Tests.ps1
+++ b/tests/EscapePathArgument.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'escapePathArgument' {
     BeforeAll {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'

--- a/tests/Expand-All.Tests.ps1
+++ b/tests/Expand-All.Tests.ps1
@@ -5,8 +5,7 @@ Describe 'Expand-All' {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Expand-All.ps1')
     }
     BeforeEach {
-        function global:Write-CustomLog {}
-        Mock Write-CustomLog {}
+        Mock-WriteLog
     }
     AfterEach {
         Remove-Item Function:Write-CustomLog -ErrorAction SilentlyContinue

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Format-Config' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Format-Config.ps1')

--- a/tests/Get-HyperVProviderVersion.Tests.ps1
+++ b/tests/Get-HyperVProviderVersion.Tests.ps1
@@ -4,7 +4,7 @@ if ($SkipNonWindows) { return }
 
 Describe 'Get-HyperVProviderVersion' -Skip:($SkipNonWindows) {
     It 'parses version from main.tf' {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
         $tf = [System.IO.Path]::ChangeExtension(
             [System.IO.Path]::Combine(
@@ -29,7 +29,7 @@ terraform {
     }
 
     It 'falls back to repository paths when missing' {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
         $tf = Join-Path $env:TEMP ([guid]::NewGuid()).ToString() + '.tf'
         Get-HyperVProviderVersion -MainTfPath $tf | Should -Be '1.2.1'

--- a/tests/Get-LabConfig.Tests.ps1
+++ b/tests/Get-LabConfig.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Get-LabConfig' {
 
     It 'returns PSCustomObject for valid JSON and populates Directories' {

--- a/tests/Get-Platform.Tests.ps1
+++ b/tests/Get-Platform.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Get-Platform' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')

--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -1,11 +1,12 @@
 
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')
 
 
 Describe '0200_Get-SystemInfo' {
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0200_Get-SystemInfo.ps1'
+        $script:ScriptPath = Get-RunnerScriptPath '0200_Get-SystemInfo.ps1'
     }
 
     It 'runs without throwing and returns expected keys' {

--- a/tests/Hypervisor.Tests.ps1
+++ b/tests/Hypervisor.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Hypervisor module' {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'Hypervisor.psm1') -Force

--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -2,7 +2,7 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Initialize-OpenTofu script' {
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0009_Initialize-OpenTofu.ps1'
+        $script:ScriptPath = Get-RunnerScriptPath '0009_Initialize-OpenTofu.ps1'
     }
     AfterEach {
         Remove-Item Function:gh -ErrorAction SilentlyContinue

--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -5,7 +5,7 @@ if ($IsLinux -or $IsMacOS) { return }
 
 Describe '0104_Install-CA script' {
     BeforeAll {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0104_Install-CA.ps1'
+        $scriptPath = Get-RunnerScriptPath '0104_Install-CA.ps1'
     }
     AfterEach {
         Remove-Item Function:Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
@@ -17,7 +17,7 @@ Describe '0104_Install-CA script' {
             InstallCA = $true
             CertificateAuthority = @{ CommonName = 'TestCA'; ValidityYears = 1 }
         }
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         Mock Get-WindowsFeature { @{ Installed = $false } } -ParameterFilter { $Name -eq 'Adcs-Cert-Authority' }
         Mock Install-WindowsFeature {}
         Mock Get-Item { $null }
@@ -37,7 +37,7 @@ Describe '0104_Install-CA script' {
             InstallCA = $false
             CertificateAuthority = @{ CommonName = 'TestCA'; ValidityYears = 1 }
         }
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         function global:Install-AdcsCertificationAuthority {}
         Mock Install-AdcsCertificationAuthority {}
 

--- a/tests/Install-Go.Tests.ps1
+++ b/tests/Install-Go.Tests.ps1
@@ -2,14 +2,14 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 if ($SkipNonWindows) { return }
 Describe '0007_Install-Go' -Skip:($SkipNonWindows) {
-    BeforeAll { $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0007_Install-Go.ps1' }
+    BeforeAll { $script:ScriptPath = Get-RunnerScriptPath '0007_Install-Go.ps1' }
 
     It 'installs Go when enabled' {
         $cfg = [pscustomobject]@{ InstallGo = $true; Go = @{ InstallerUrl = 'http://example.com/go1.21.0.windows-amd64.msi' } }
         Mock Get-Command {} -ParameterFilter { $Name -eq 'go' }
         Mock Invoke-WebRequest {}
         Mock Start-Process {}
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         & $script:ScriptPath -Config $cfg
         Assert-MockCalled Invoke-WebRequest -ParameterFilter { $Uri -eq $cfg.Go.InstallerUrl } -Times 1
         Assert-MockCalled Start-Process -ParameterFilter { $FilePath -eq 'msiexec.exe' } -Times 1
@@ -19,7 +19,7 @@ Describe '0007_Install-Go' -Skip:($SkipNonWindows) {
         $cfg = [pscustomobject]@{ InstallGo = $false; Go = @{ InstallerUrl = 'http://example.com/go1.21.0.windows-amd64.msi' } }
         Mock Invoke-WebRequest {}
         Mock Start-Process {}
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         & $script:ScriptPath -Config $cfg
         Assert-MockCalled Invoke-WebRequest -Times 0
         Assert-MockCalled Start-Process -Times 0
@@ -30,7 +30,7 @@ Describe '0007_Install-Go' -Skip:($SkipNonWindows) {
         Mock Get-Command { @{ Name = 'go' } } -ParameterFilter { $Name -eq 'go' }
         Mock Invoke-WebRequest {}
         Mock Start-Process {}
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         & $script:ScriptPath -Config $cfg
         Assert-MockCalled Invoke-WebRequest -Times 0
         Assert-MockCalled Start-Process -Times 0

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -3,10 +3,7 @@
 if ($SkipNonWindows) { return }
 Describe '0008_Install-OpenTofu' -Skip:($SkipNonWindows) {
     BeforeAll {
-        $script:ScriptPath = (
-            Resolve-Path (Join-Path $PSScriptRoot '..' 'runner_scripts' '0008_Install-OpenTofu.ps1')
-
-        ).Path
+        $script:ScriptPath = Get-RunnerScriptPath '0008_Install-OpenTofu.ps1'
         . $script:ScriptPath
     }
 
@@ -18,7 +15,7 @@ Describe '0008_Install-OpenTofu' -Skip:($SkipNonWindows) {
         }
 
         Mock Invoke-OpenTofuInstaller {}
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         
         & $script:ScriptPath -Config $cfg
 
@@ -31,7 +28,7 @@ Describe '0008_Install-OpenTofu' -Skip:($SkipNonWindows) {
     It 'skips install when flag is false' {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
         Mock Invoke-OpenTofuInstaller {}
-        Mock Write-CustomLog {}
+        Mock-WriteLog
 
         & $script:ScriptPath -Config $cfg
 

--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -3,7 +3,7 @@
 if ($SkipNonWindows) { return }
 Describe '0006_Install-ValidationTools' -Skip:($SkipNonWindows) {
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0006_Install-ValidationTools.ps1'
+        $script:ScriptPath = Get-RunnerScriptPath '0006_Install-ValidationTools.ps1'
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
     }
 
@@ -16,7 +16,7 @@ Describe '0006_Install-ValidationTools' -Skip:($SkipNonWindows) {
         Mock Invoke-WebRequest {}
         Mock New-Item {}
         Mock Test-Path { $false }
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         & $script:ScriptPath -Config $cfg
         Assert-MockCalled Invoke-WebRequest -Times 1 -ParameterFilter { $Uri -eq $cfg.CosignURL }
     }
@@ -24,14 +24,14 @@ Describe '0006_Install-ValidationTools' -Skip:($SkipNonWindows) {
     It 'checks for gpg when InstallGpg is true' {
         $cfg = [pscustomobject]@{ InstallGpg = $true }
         Mock Get-Command {} -ParameterFilter { $Name -eq 'gpg' }
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         & $script:ScriptPath -Config $cfg
         Assert-MockCalled Get-Command -ParameterFilter { $Name -eq 'gpg' } -Times 1
     }
 
     It 'logs a message when no option specified' {
         $cfg = [pscustomobject]@{ InstallCosign = $false; InstallGpg = $false }
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         & $script:ScriptPath -Config $cfg
         Assert-MockCalled Write-CustomLog -ParameterFilter { $Message -like 'No installation option*' } -Times 1
     }

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -5,7 +5,7 @@ Describe '0203_Install-npm' {
         Remove-Item Function:npm -ErrorAction SilentlyContinue
     }
     It 'runs npm install in configured NpmPath' {
-        $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0203_Install-npm.ps1'
+        $script = Get-RunnerScriptPath '0203_Install-npm.ps1'
         $npmDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $npmDir
         '{}' | Set-Content -Path (Join-Path $npmDir 'package.json')
@@ -28,7 +28,7 @@ Describe '0203_Install-npm' {
     }
 
     It 'succeeds when NpmPath exists' {
-        $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0203_Install-npm.ps1'
+        $script = Get-RunnerScriptPath '0203_Install-npm.ps1'
         $npmDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $null = New-Item -ItemType Directory -Path $npmDir
         '{}' | Set-Content -Path (Join-Path $npmDir 'package.json')
@@ -49,7 +49,7 @@ Describe '0203_Install-npm' {
     }
 
     It 'errors when NpmPath is missing and CreateNpmPath is false' {
-        $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0203_Install-npm.ps1'
+        $script = Get-RunnerScriptPath '0203_Install-npm.ps1'
         $npmDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $cfg = @{ Node_Dependencies = @{ NpmPath = $npmDir; CreateNpmPath = $false } }
 
@@ -62,7 +62,7 @@ Describe '0203_Install-npm' {
     }
 
     It 'errors when NpmPath is empty string' {
-        $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0203_Install-npm.ps1'
+        $script = Get-RunnerScriptPath '0203_Install-npm.ps1'
         $cfg = @{ Node_Dependencies = @{ NpmPath = ''; CreateNpmPath = $false } }
 
         $script:called = $false
@@ -74,7 +74,7 @@ Describe '0203_Install-npm' {
     }
 
     It 'creates NpmPath when CreateNpmPath is true' {
-        $script = Join-Path $PSScriptRoot '..' 'runner_scripts' '0203_Install-npm.ps1'
+        $script = Get-RunnerScriptPath '0203_Install-npm.ps1'
         $npmDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
         $cfg = @{ Node_Dependencies = @{ NpmPath = $npmDir; CreateNpmPath = $true } }
 

--- a/tests/Kickstart-Bootstrap.Tests.ps1
+++ b/tests/Kickstart-Bootstrap.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'kickstart-bootstrap script' {
     It 'exists at repo root' {
         $path = Join-Path $PSScriptRoot '..' 'kickstart-bootstrap.sh'

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Write-CustomLog' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,5 +1,5 @@
-Describe 'OpenTofuInstaller' {
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+Describe 'OpenTofuInstaller' {
 
 if ($IsLinux -or $IsMacOS) { return }
 

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -3,7 +3,7 @@
 if ($SkipNonWindows) { return }
 
 BeforeAll {
-    $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+    $script:scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
     . $script:scriptPath
     $global:origConvertCerToPem = (Get-Command Convert-CerToPem).ScriptBlock
     $global:origConvertPfxToPem = (Get-Command Convert-PfxToPem).ScriptBlock
@@ -12,7 +12,7 @@ BeforeAll {
 Describe 'Prepare-HyperVProvider path restoration' -Skip:($SkipNonWindows) {
     It 'restores location after execution' {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
-        $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        $script:scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         $config = [pscustomobject]@{
             PrepareHyperVHost = $true
             InfraRepoPath = 'C:\\Infra'
@@ -37,7 +37,7 @@ Describe 'Prepare-HyperVProvider path restoration' -Skip:($SkipNonWindows) {
             }
         }
 
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         Mock Get-WindowsOptionalFeature { @{State='Enabled'} }
         Mock Enable-WindowsOptionalFeature {}
         Mock Test-WSMan {}
@@ -68,7 +68,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
     It 'creates PEM files and updates providers.tf' {
 
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
-        $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        $script:scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
 
         $null = New-Item -ItemType Directory -Path $tempDir
@@ -78,7 +78,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
             CertificateAuthority = @{ CommonName = 'TestCA' }
         }
 
-        Mock Write-CustomLog {}
+        Mock-WriteLog
         Mock Get-WindowsOptionalFeature { @{State='Enabled'} }
         Mock Enable-WindowsOptionalFeature {}
         Mock Test-WSMan {}
@@ -173,7 +173,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
 
 Describe 'Convert certificate helpers honour -WhatIf' -Skip:($SkipNonWindows) {
     It 'skips writing files when WhatIf is used' {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
         $cer = Join-Path $TestDrive (([guid]::NewGuid()).ToString() + '.cer')
         $pem = Join-Path $TestDrive (([guid]::NewGuid()).ToString() + '.pem')
@@ -185,7 +185,7 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($SkipNonWindows) {
     }
 
     It 'skips writing PFX outputs when WhatIf is used' -Skip:($SkipNonWindows) {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
         $pfx = Join-Path $TestDrive (([guid]::NewGuid()).ToString() + '.pfx')
         $cert = Join-Path $TestDrive (([guid]::NewGuid()).ToString() + '.pem')
@@ -211,18 +211,18 @@ Describe 'Convert certificate helpers validate paths' -Skip:($SkipNonWindows) {
     BeforeAll {
         Remove-Mock Convert-CerToPem -ErrorAction SilentlyContinue
         Remove-Mock Convert-PfxToPem -ErrorAction SilentlyContinue
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
     }
     It 'errors when CerPath or PemPath is missing' {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
         { Convert-CerToPem -CerPath '' -PemPath 'x' } | Should -Throw 'Convert-CerToPem: CerPath is required'
         { Convert-CerToPem -CerPath 'x' -PemPath '' } | Should -Throw 'Convert-CerToPem: PemPath is required'
     }
 
     It 'errors when PfxPath, CertPath, or KeyPath is missing' {
-        $scriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0010_Prepare-HyperVProvider.ps1'
+        $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
         $pwd = New-Object System.Security.SecureString
         foreach ($c in 'pw'.ToCharArray()) { $pwd.AppendChar($c) }

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -15,7 +15,7 @@ if ($IsLinux -or $IsMacOS) { return }
 Describe '0001_Reset-Git' -Skip:($SkipNonWindows) {
 
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0001_Reset-Git.ps1'
+        $script:ScriptPath = Get-RunnerScriptPath '0001_Reset-Git.ps1'
     }
     AfterEach {
         Remove-Item Function:gh -ErrorAction SilentlyContinue
@@ -145,7 +145,7 @@ Describe '0001_Reset-Git' -Skip:($SkipNonWindows) {
                 $global:LASTEXITCODE = 0
                 New-Item -ItemType Directory -Path (Join-Path $tempDir '.git') -Force | Out-Null
             }
-            Mock Write-CustomLog {}
+            Mock-WriteLog
 
             & $script:ScriptPath -Config $config
 

--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -2,7 +2,7 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Reset-Machine script' {
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '9999_Reset-Machine.ps1'
+        $script:ScriptPath = Get-RunnerScriptPath '9999_Reset-Machine.ps1'
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')
     }
 

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -61,7 +61,7 @@ exit 0' | Set-Content -Path $dummy
             $null = New-Item -ItemType Directory -Path $scriptsDir
 
             Push-Location $tempDir
-            Mock Write-CustomLog {}
+            Mock-WriteLog
             & "$tempDir/runner.ps1" -Scripts '9999' -Auto | Out-Null
             $code = $LASTEXITCODE
             Pop-Location
@@ -403,7 +403,7 @@ exit 0
 "@ | Set-Content -Path $scriptFile
 
             Mock Get-MenuSelection { @() }
-            Mock Write-CustomLog {}
+            Mock-WriteLog
 
             Push-Location $tempDir
             & "$tempDir/runner.ps1" -Auto | Out-Null
@@ -436,7 +436,8 @@ Write-Output 'hello world'
 
             Push-Location $tempDir
             $script:messages = @()
-            Mock Write-CustomLog { param($Message,$Level) $script:messages += $Message }
+            Mock-WriteLog
+            Set-Item -Path Function:Write-CustomLog -Value { param($Message,$Level) $script:messages += $Message }
             & "$tempDir/runner.ps1" -Scripts '0001' -Auto | Out-Null
             Pop-Location
 

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -9,7 +9,7 @@ if (-not (Test-Path $helperPath)) {
 
 if ($SkipNonWindows) { return }
 
-$scriptDir = Join-Path $PSScriptRoot '..' 'runner_scripts'
+$scriptDir = Split-Path (Get-RunnerScriptPath '0001_Reset-Git.ps1')
 $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 
 Describe 'Runner scripts parameter and command checks' -Skip:($SkipNonWindows) {

--- a/tests/Setup-Directories.Tests.ps1
+++ b/tests/Setup-Directories.Tests.ps1
@@ -3,7 +3,7 @@
 if ($SkipNonWindows) { return }
 Describe '0002_Setup-Directories' -Skip:($SkipNonWindows) {
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'runner_scripts' '0002_Setup-Directories.ps1'
+        $script:ScriptPath = Get-RunnerScriptPath '0002_Setup-Directories.ps1'
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
     }
 

--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -6,3 +6,17 @@
 
 $SkipNonWindows = $IsLinux -or $IsMacOS
 
+function Get-RunnerScriptPath {
+    param(
+        [Parameter(Mandatory=$true)][string]$Name
+    )
+    (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' '..' 'runner_scripts' $Name)).Path
+}
+
+function Mock-WriteLog {
+    if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
+        function global:Write-CustomLog { param([string]$Message,[string]$Level) }
+    }
+    Mock Write-CustomLog {}
+}
+


### PR DESCRIPTION
## Summary
- add helper functions for tests
- replace repeated runner path logic with `Get-RunnerScriptPath`
- simplify mocking of `Write-CustomLog` via `Mock-WriteLog`
- import `TestHelpers.ps1` consistently across test files

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848797f81788331ac66316d038405ca