### PR TITLE
Fix ruff lint issues

### DIFF
--- a/py/labctl/cli.py
+++ b/py/labctl/cli.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import subprocess
 from pathlib import Path
 from importlib.resources import files
 import typer

--- a/py/labctl/github_utils.py
+++ b/py/labctl/github_utils.py
@@ -1,6 +1,5 @@
 import subprocess
 from datetime import datetime
-from collections import defaultdict
 from typing import List
 
 
@@ -23,7 +22,7 @@ def cleanup_branches(remote: str = "origin") -> List[str]:
         [
             "git",
             "for-each-ref",
-            f"--format=%(committerdate:iso8601)%09%(refname)",
+            "--format=%(committerdate:iso8601)%09%(refname)",
             f"refs/remotes/{remote}"
         ]
     )


### PR DESCRIPTION
## Summary
- remove unused imports in labctl modules
- clean up git branch cleanup command

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488703eb348331a5666ff932d9a1c0