### PR TITLE
Fix Pester config loading

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -71,7 +71,7 @@ jobs:
         continue-on-error: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
-          pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration tests/PesterConfiguration.psd1 -ErrorAction Stop"
+          pwsh -NoLogo -NoProfile -Command '$cfg = New-PesterConfiguration -Hashtable (Import-PowerShellDataFile "tests/PesterConfiguration.psd1"); Invoke-Pester -Configuration $cfg -ErrorAction Stop'
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- update Pester workflow step to build configuration from .psd1

## Testing
- `pwsh -NoLogo -NoProfile -Command '$cfg = New-PesterConfiguration -Hashtable (Import-PowerShellDataFile "tests/PesterConfiguration.psd1"); Invoke-Pester -Configuration $cfg -ErrorAction Stop'` *(fails: Get-RunnerScriptPath not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488bf2e04c8331bfa4bc26ab500ec5