### PR TITLE
Implement basic Textual UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ poetry install
 poetry run labctl hv facts
 ```
 
+Launch the experimental Textual interface:
+
+```bash
+poetry run labctl ui
+```
+
 See [docs/python-cli.md](docs/python-cli.md) for further details.
 
 

--- a/docs/python-cli.md
+++ b/docs/python-cli.md
@@ -46,3 +46,11 @@ poetry run labctl repo cleanup
 `cleanup` removes merged remote branches while keeping the most recent branch
 per hour.
 
+### `ui`
+Launch a simple Textual interface showing runner scripts, log output and
+configuration files:
+
+```bash
+poetry run labctl ui
+```
+

--- a/py/labctl/cli.py
+++ b/py/labctl/cli.py
@@ -42,6 +42,14 @@ app.add_typer(hv_app, name="hv")
 app.add_typer(repo_app, name="repo")
 
 
+@app.command()
+def ui() -> None:
+    """Launch the Textual user interface."""
+    from .ui import run_ui
+
+    run_ui()
+
+
 @app.callback(invoke_without_command=True)
 def main(ctx: typer.Context):
     """Initialize logging before executing commands."""

--- a/py/labctl/ui.py
+++ b/py/labctl/ui.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.widgets import Header, Footer, DataTable, TextLog, TabPane, TabbedContent, Markdown
+
+
+class LabUI(App):
+    """Simple Textual interface for labctl."""
+
+    CSS_PATH = None
+    TITLE = "labctl UI"
+
+    def __init__(self, scripts: list[str], log_path: Path, default_config: Path, recommended_config: Path) -> None:
+        super().__init__()
+        self.scripts = scripts
+        self.log_path = log_path
+        self.default_config = default_config
+        self.recommended_config = recommended_config
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield TabbedContent(
+            TabPane(self.build_scripts_table(), title="Scripts"),
+            TabPane(self.build_log_view(), title="Log"),
+            TabPane(self.build_config_view(self.default_config), title="Default Config"),
+            TabPane(self.build_config_view(self.recommended_config), title="Recommended Config"),
+        )
+        yield Footer()
+
+    # --- Widget builders -------------------------------------------------
+
+    def build_scripts_table(self) -> DataTable:
+        table = DataTable(zebra_stripes=True)
+        table.add_columns("Prefix", "Script")
+        for name in self.scripts:
+            table.add_row(name[:4], name)
+        return table
+
+    def build_log_view(self) -> TextLog:
+        log = TextLog(highlight=False, wrap=False)
+        if self.log_path.exists():
+            log.write(self.log_path.read_text())
+        return log
+
+    def build_config_view(self, path: Path) -> Markdown:
+        text = path.read_text() if path.exists() else ""
+        if path.suffix.lower() == ".json":
+            try:
+                text = json.dumps(json.loads(text), indent=2)
+            except json.JSONDecodeError:
+                pass
+        return Markdown(text)
+
+
+def run_ui() -> None:
+    """Launch the Textual UI."""
+    repo_root = Path(__file__).resolve().parents[2]
+    script_dir = repo_root / "runner_scripts"
+    scripts = sorted(p.name for p in script_dir.glob("????_*.ps1"))
+    log_dir = Path(os.environ.get("LAB_LOG_DIR", Path.cwd()))
+    log_path = log_dir / "lab.log"
+    default_cfg = repo_root / "config_files" / "default-config.json"
+    recommended_cfg = repo_root / "config_files" / "recommended-config.json"
+    LabUI(scripts, log_path, default_cfg, recommended_cfg).run()

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
   "typer>=0.12",
   "pyyaml>=6.0",
+  "textual>=0.58",
 ]
 
 [project.scripts]
@@ -26,6 +27,7 @@ pytest = "^8.4.0"
 [tool.poetry.dev-dependencies]
 typer = "^0.12"
 PyYAML = "^6.0"
+textual = "^0.58"
 
 [tool.poetry]
 packages = [

--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -58,3 +58,9 @@ def test_load_config_invalid_yaml(tmp_path):
     conf.write_text("foo: [unclosed")
     with pytest.raises(yaml.YAMLError):
         load_config(conf)
+
+
+def test_ui_help():
+    runner = CliRunner()
+    result = runner.invoke(app, ["ui", "--help"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add new `labctl ui` command
- implement minimal Textual interface listing scripts, log and config files
- document the new command in README and CLI docs
- test `labctl ui --help`
- wire in `textual` to Python project

## Testing
- `ruff check .`
- `pytest -q`
- `mkdocs build -q`
- `pwsh -NoLogo -NoProfile -Command Invoke-ScriptAnalyzer` *(fails: `pwsh` not found)*
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488b9ca8488331aecb5de80c3cc1d7