### PR TITLE
Fix Runner tests by loading helpers

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -25,6 +25,7 @@ Describe 'runner.ps1 script selection' -Skip:($SkipNonWindows) {
     BeforeAll {
         # Use script-scoped variable so PSScriptAnalyzer recognizes cross-block usage
         $script:runnerPath = Join-Path $PSScriptRoot '..' 'runner.ps1'
+        . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
         $modulePath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-LabConfig.ps1'
         . $modulePath
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')


### PR DESCRIPTION
## Summary
- load `TestHelpers.ps1` within the `BeforeAll` block of `Runner.Tests.ps1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488edd8cc08331951646f2ec833330