### PR TITLE
Fix global helper scope

### DIFF
--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -6,7 +6,7 @@
 
 $SkipNonWindows = $IsLinux -or $IsMacOS
 
-function Get-RunnerScriptPath {
+function global:Get-RunnerScriptPath {
     param(
         [Parameter(Mandatory=$true)][string]$Name
     )


### PR DESCRIPTION
## Summary
- expose `Get-RunnerScriptPath` as a global function so it's available inside Pester blocks

## Testing
- `pytest --maxfail=1 -q`
- `Invoke-Pester -Path tests -PassThru` *(fails: `Result : Failed`)*


------
https://chatgpt.com/codex/tasks/task_e_68488ee836ec8331bfafd039eb20e123