### PR TITLE
Fix Pester coverage upload

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -67,6 +67,12 @@ jobs:
               Write-Error 'Get-ScriptAst helper not loaded'
               exit 1
           }
+      - name: Ensure coverage directory
+        shell: pwsh
+        run: |
+          if (-not (Test-Path coverage)) {
+              New-Item -ItemType Directory -Path coverage | Out-Null
+          }
       - name: Run Pester
         continue-on-error: ${{ runner.os != 'Windows' }}
         shell: bash


### PR DESCRIPTION
## Summary
- create coverage directory before running Pester so coverage.xml is produced

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "echo hi"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488fe00fc08331b58712ea3a889197