### PR TITLE
Update TestHelpers with global function

### DIFF
--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -6,7 +6,7 @@
 
 $SkipNonWindows = $IsLinux -or $IsMacOS
 
-function Get-RunnerScriptPath {
+function global:Get-RunnerScriptPath {
     param(
         [Parameter(Mandatory=$true)][string]$Name
     )


### PR DESCRIPTION
## Summary
- change `Get-RunnerScriptPath` to global scope so Pester tests can import it

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488fe3fb4083319beec9fcb920bb90