### PR TITLE
Fix Poetry install for macOS in tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: '3.x'
           cache: 'pip'
       - name: Install Poetry
-        run: pip install --user poetry
+        uses: snok/install-poetry@v1
       - name: Install dependencies
         run: |
           cd py


### PR DESCRIPTION
## Summary
- install Poetry via snok/install-poetry action

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684890137e208331a653b20e689ef4dd