### PR TITLE
Fix runner exit status

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -282,7 +282,6 @@ function Invoke-Scripts {
                 if ($line) { Write-CustomLog $line.ToString() }
             }
 
-            Write-Output $output
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 
             $results[$s.Name] = $exitCode
@@ -305,7 +304,10 @@ function Invoke-Scripts {
 
 
     $Config | ConvertTo-Json -Depth 5 | Out-File $ConfigFile -Encoding utf8
-    $summary = $results.GetEnumerator() | ForEach-Object { "${($_.Key)}=$($_.Value)" } | Sort-Object | Join-String -Separator ', '
+    $summary = $results.GetEnumerator() |
+        ForEach-Object { "$(($_.Key))=$($_.Value)" } |
+        Sort-Object |
+        Join-String -Separator ', '
     Write-CustomLog "Results: $summary"
     Write-CustomLog "`n==== Script run complete ===="
     if ($failed) { Write-CustomLog "Failures: $($failed -join ', ')"; return $false }


### PR DESCRIPTION
## Summary
- ensure runner exit code propagates failures
- clean up summary output

## Testing
- `Invoke-Pester tests/Runner.Tests.ps1 -Output Detailed` *(no tests run on Linux)*
- `pwsh -NoLogo -NoProfile -File ./runner.ps1 -Scripts '0001,0002' -Auto`

------
https://chatgpt.com/codex/tasks/task_e_68488ecf492483318aa6eb8bf9f5f573