### PR TITLE
Fix NodeScripts test helper visibility

### DIFF
--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -6,7 +6,7 @@
 
 $SkipNonWindows = $IsLinux -or $IsMacOS
 
-function Get-RunnerScriptPath {
+function global:Get-RunnerScriptPath {
     param(
         [Parameter(Mandatory=$true)][string]$Name
     )


### PR DESCRIPTION
## Summary
- expose `Get-RunnerScriptPath` globally for all Pester tests

## Testing
- `Invoke-Pester`
- `pytest -q`
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path .`


------
https://chatgpt.com/codex/tasks/task_e_68488efc70a08331aa52a9a07103fd13