### PR TITLE
Add cross-platform skip in tests

### DIFF
--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Cleanup-Files script' {
     BeforeAll {
         $script:scriptPath = Get-RunnerScriptPath '0000_Cleanup-Files.ps1'

--- a/tests/EscapePathArgument.Tests.ps1
+++ b/tests/EscapePathArgument.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'escapePathArgument' {
     BeforeAll {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'

--- a/tests/Expand-All.Tests.ps1
+++ b/tests/Expand-All.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Expand-All' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Expand-All.ps1')

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Format-Config' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Format-Config.ps1')

--- a/tests/Get-LabConfig.Tests.ps1
+++ b/tests/Get-LabConfig.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Get-LabConfig' {
 
     It 'returns PSCustomObject for valid JSON and populates Directories' {

--- a/tests/Get-Platform.Tests.ps1
+++ b/tests/Get-Platform.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Get-Platform' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')

--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -1,6 +1,7 @@
 
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')
 
 

--- a/tests/Hypervisor.Tests.ps1
+++ b/tests/Hypervisor.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Hypervisor module' {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'Hypervisor.psm1') -Force

--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Initialize-OpenTofu script' {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0009_Initialize-OpenTofu.ps1'

--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 
 if ($IsLinux -or $IsMacOS) { return }
 

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe '0203_Install-npm' {
     AfterEach {
         Remove-Item Function:npm -ErrorAction SilentlyContinue

--- a/tests/Kickstart-Bootstrap.Tests.ps1
+++ b/tests/Kickstart-Bootstrap.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'kickstart-bootstrap script' {
     It 'exists at repo root' {
         $path = Join-Path $PSScriptRoot '..' 'kickstart-bootstrap.sh'

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Write-CustomLog' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')

--- a/tests/Menu.Tests.ps1
+++ b/tests/Menu.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Get-MenuSelection' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Menu.ps1')

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Node installation scripts' {
     BeforeAll {
 

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -1,4 +1,5 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'OpenTofuInstaller' {
 
 if ($IsLinux -or $IsMacOS) { return }

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 
 if ($IsLinux -or $IsMacOS) { return }
 

--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe 'Reset-Machine script' {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '9999_Reset-Machine.ps1'

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 
 if ($IsLinux -or $IsMacOS) { return }
 


### PR DESCRIPTION
## Summary
- skip non-Windows hosts in a bunch of Pester test files

## Testing
- `Invoke-Pester tests/NodeScripts.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68488fa7ea6c8331aa497e328fb7d43e