### PR TITLE
Fix Pester workflow on Windows

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -71,7 +71,7 @@ jobs:
         continue-on-error: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
-          pwsh -NoLogo -NoProfile -Command '$cfg = New-PesterConfiguration -Hashtable (Import-PowerShellDataFile "tests/PesterConfiguration.psd1"); Invoke-Pester -Configuration $cfg -ErrorAction Stop'
+          pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command '$cfg = New-PesterConfiguration -Hashtable (Import-PowerShellDataFile "tests/PesterConfiguration.psd1"); Invoke-Pester -Configuration $cfg -ErrorAction Stop'
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- bypass execution policy when running Pester tests

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path .`
- `pytest -q`
- `Invoke-Pester` *(fails: Get-RunnerScriptPath not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848902ae1ec8331ada59414898e10b4