### PR TITLE
Fix TestHelpers scope for RunnerScriptPath

### DIFF
--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -6,11 +6,12 @@
 
 $SkipNonWindows = $IsLinux -or $IsMacOS
 
-function Get-RunnerScriptPath {
+function global:Get-RunnerScriptPath {
     param(
         [Parameter(Mandatory=$true)][string]$Name
     )
-    (Resolve-Path -ErrorAction Stop (Join-Path $PSScriptRoot '..' '..' 'runner_scripts' $Name)).Path
+    $root = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+    (Resolve-Path -ErrorAction Stop (Join-Path $root '..' '..' 'runner_scripts' $Name)).Path
 }
 
 function Mock-WriteLog {


### PR DESCRIPTION
## Summary
- define `Get-RunnerScriptPath` in the global scope
- handle missing `$PSScriptRoot` when resolving paths

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path . -EnableExit`
- `Invoke-Pester -Path tests -ErrorAction Stop` *(fails: 8 tests failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68488ef167fc83319767bb31db8d7720