### PR TITLE
Fix Mock-WriteLog scoping in tests

### DIFF
--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -14,7 +14,7 @@ function global:Get-RunnerScriptPath {
     (Resolve-Path -ErrorAction Stop (Join-Path $root '..' '..' 'runner_scripts' $Name)).Path
 }
 
-function Mock-WriteLog {
+function global:Mock-WriteLog {
     if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
         function global:Write-CustomLog { param([string]$Message,[string]$Level) }
     }


### PR DESCRIPTION
## Summary
- ensure Mock-WriteLog is available across Pester scopes

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `Invoke-ScriptAnalyzer` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489397f4e883318e6d81e8f1ee567b