### PR TITLE
Fix runner log passthrough

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -275,7 +275,14 @@ function Invoke-Scripts {
             $exitCode = $LASTEXITCODE
 
             foreach ($line in $output) {
-                if ($line) { Write-CustomLog $line.ToString() }
+                if (-not $line) { continue }
+                if ($line -is [System.Management.Automation.ErrorRecord]) {
+                    Write-Error $line.ToString()
+                } elseif ($line -is [System.Management.Automation.WarningRecord]) {
+                    Write-Warning $line.ToString()
+                } else {
+                    Write-CustomLog $line.ToString()
+                }
             }
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- ensure `runner.ps1` forwards warning and error records to the console

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for `typer`)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684893c0e31483318c767999a86ee5db