### PR TITLE
Fix warnings hidden in silent mode

### DIFF
--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -3,7 +3,7 @@ function Write-CustomLog {
         [string]$Message,
         [ValidateSet('INFO','WARN','ERROR')] [string]$Level = 'INFO'
     )
-    $levelIdx = @{ INFO = 1; WARN = 1; ERROR = 0 }[$Level]
+    $levelIdx = @{ INFO = 1; WARN = 0; ERROR = 0 }[$Level]
 
     if (-not (Get-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue)) {
         $logDir = $env:LAB_LOG_DIR


### PR DESCRIPTION
## Summary
- ensure Write-CustomLog emits warnings even when `-Verbosity silent`

## Testing
- `Invoke-Pester -Path tests` *(0 tests found as expected on linux)*

------
https://chatgpt.com/codex/tasks/task_e_684893c9b95c8331881cb83ee7b8226e