### PR TITLE
Fix Get-SystemInfo test on Windows

### DIFF
--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -12,7 +12,8 @@ function Get-SystemInfo {
 
     . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
     Invoke-LabStep -Config $Config -Body {
-        if (-not (Get-Variable -Name PesterState -ErrorAction SilentlyContinue)) {
+        if (-not (Get-Variable -Name PesterState -ErrorAction SilentlyContinue) -and
+            -not (Get-Variable -Name '____Pester' -ErrorAction SilentlyContinue)) {
             if (-not (Get-Command Get-Platform -ErrorAction SilentlyContinue)) {
                 . "$PSScriptRoot/../lab_utils/Get-Platform.ps1"
             }


### PR DESCRIPTION
## Summary
- ensure `0200_Get-SystemInfo.ps1` detects Pester v5

## Testing
- `ruff check .`
- `pwsh -NoLogo -NoProfile -File run_pester.ps1` *(0 tests ran due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6848936bc3808331ba5b8930f2dc3e29