### PR TITLE
Fix path validation in installer

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -643,8 +643,8 @@ function escapePathArgument {
     )
 
     process {
-        if ($Path -contains '"') {
-            throw [InvalidArgumentException]::new("Invalid path: ${Path}")
+        if ($Path -match '"') {
+            throw [InvalidArgumentException]::new("Invalid path: $Path")
         }
 
         "`"${Path}`""


### PR DESCRIPTION
## Summary
- validate input paths with -match in `escapePathArgument`

## Testing
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path .`
- `Invoke-Pester` *(no tests run on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68489407cb5483319378e1c9a33e5af9