### PR TITLE
Fix binding in Format-Config function

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -1,6 +1,7 @@
 function Format-Config {
+    [CmdletBinding()]
     param(
-        [pscustomobject]$Config
+        [psobject]$Config
     )
 
     if ($null -eq $Config) {


### PR DESCRIPTION
## Summary
- allow `$null` to bind to the `Config` parameter in `Format-Config`
- adjust parameter type to `[psobject]`

## Testing
- `Invoke-Pester -Path 'tests/Format-Config.Tests.ps1' -Output Detailed` *(shows 0 tests because `$SkipNonWindows` skips on Linux)*
- `Invoke-ScriptAnalyzer -Path lab_utils/Format-Config.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6848940ab2088331895214093e7944a5