### PR TITLE
Expose Mock-WriteLog in global scope

### DIFF
--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -14,7 +14,7 @@ function global:Get-RunnerScriptPath {
     (Resolve-Path -ErrorAction Stop (Join-Path $root '..' '..' 'runner_scripts' $Name)).Path
 }
 
-function Mock-WriteLog {
+function global:Mock-WriteLog {
     if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
         function global:Write-CustomLog { param([string]$Message,[string]$Level) }
     }


### PR DESCRIPTION
## Summary
- use global scope for `Mock-WriteLog` to avoid `CommandNotFoundException`

## Testing
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Output Detailed -Script tests/Expand-All.Tests.ps1'`

------
https://chatgpt.com/codex/tasks/task_e_6848944d264083318c85ea3d7027d543