### PR TITLE
Ensure ScriptTemplate is dot-sourced first in runner scripts

### DIFF
--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -1,4 +1,5 @@
 Param([pscustomobject]$Config)
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 
 function Install-Cosign {
     [CmdletBinding(SupportsShouldProcess)]

--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -1,3 +1,4 @@
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 function Invoke-OpenTofuInstaller {
     param(
         [string]$CosignPath,

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -1,4 +1,5 @@
 Param([pscustomobject]$Config)
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 
 if (-not (Get-Command Convert-CerToPem -ErrorAction SilentlyContinue)) {
 function Convert-CerToPem {

--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -1,4 +1,5 @@
 Param([pscustomobject]$Config)
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 function Install-CA {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)

--- a/runner_scripts/0106_Install-WAC.ps1
+++ b/runner_scripts/0106_Install-WAC.ps1
@@ -1,4 +1,5 @@
 Param([pscustomobject]$Config)
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 
 function Get-WacRegistryInstallation {
     param(

--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -3,6 +3,7 @@ Param(
     [switch]$AsJson
 )
 
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 function Get-SystemInfo {
     [CmdletBinding()]
     param(

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -1,4 +1,5 @@
 Param([pscustomobject]$Config)
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 
 function Install-NodeCore {
     [CmdletBinding(SupportsShouldProcess = $true)]

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -1,4 +1,5 @@
 Param([pscustomobject]$Config)
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 
 function Install-GlobalPackage {
     [CmdletBinding(SupportsShouldProcess)]

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -3,6 +3,7 @@ Param(
     [pscustomobject]$Config
 )
 
+. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 function Install-NpmDependencies {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)


### PR DESCRIPTION
## Summary
- import ScriptTemplate.ps1 before any function definitions
- maintain Write-CustomLog and Invoke-LabStep pattern in scripts

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684894fa82708331b71dd442d8305a08