### PR TITLE
Fix Set-LabConfig tests on fresh systems

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -4,6 +4,10 @@ if ($SkipNonWindows) { return }
 
 if ($IsLinux -or $IsMacOS) { return }
 
+if (-not (Get-Command Get-MenuSelection -ErrorAction SilentlyContinue)) {
+    function global:Get-MenuSelection {}
+}
+
 Describe 'runner.ps1 syntax' {
     It 'parses without errors' {
         $path = Join-Path $PSScriptRoot '..' 'runner.ps1'


### PR DESCRIPTION
## Summary
- stub `Get-MenuSelection` in `Runner.Tests.ps1` so Pester can mock it

## Testing
- `Invoke-Pester` *(results show 0 tests on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_684894f681148331b98c87fda3fa0305