### PR TITLE
Enable runner prompt test cross-platform

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -1,8 +1,8 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
-
-if ($IsLinux -or $IsMacOS) { return }
+# These tests exercise logic that works on all platforms. Avoid skipping when
+# running on Linux or macOS so we can verify behaviour in CI.
+$script:SkipNonWindows = $false
 
 Describe 'runner.ps1 syntax' {
     It 'parses without errors' {


### PR DESCRIPTION
## Summary
- ensure `Runner.Tests.ps1` always runs by clearing `SkipNonWindows`

## Testing
- `pwsh -NoLogo -NoProfile -File /tmp/run_pester.ps1`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684894fd88008331b9b134924e37619b