### PR TITLE
Fix Install-OpenTofu test mocking

### DIFF
--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -17,7 +17,7 @@ Describe '0008_Install-OpenTofu' -Skip:($SkipNonWindows) {
         Mock Invoke-OpenTofuInstaller {}
         Mock-WriteLog
         
-        & $script:ScriptPath -Config $cfg
+        Install-OpenTofu -Config $cfg
 
         Should -Invoke -CommandName Invoke-OpenTofuInstaller -Times 1 -ParameterFilter {
             $CosignPath -eq (Join-Path $cfg.CosignPath 'cosign-windows-amd64.exe') -and
@@ -30,7 +30,7 @@ Describe '0008_Install-OpenTofu' -Skip:($SkipNonWindows) {
         Mock Invoke-OpenTofuInstaller {}
         Mock-WriteLog
 
-        & $script:ScriptPath -Config $cfg
+        Install-OpenTofu -Config $cfg
 
         Should -Invoke -CommandName Invoke-OpenTofuInstaller -Times 0
     }


### PR DESCRIPTION
## Summary
- update `Install-OpenTofu.Tests.ps1` to call `Install-OpenTofu` directly

## Testing
- `ruff check .`
- `Invoke-Pester tests/Install-OpenTofu.Tests.ps1` *(fails: 0 tests discovered on non‑Windows)*

------
https://chatgpt.com/codex/tasks/task_e_6848963627e883319939c7e16589b17a