### PR TITLE
Prevent logger override in runner.ps1

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -23,7 +23,9 @@ $script:ConsoleLevel    = $script:VerbosityLevels[$Verbosity]
 
 
 # ─── Load helpers ──────────────────────────────────────────────────────────────
-. (Join-Path $PSScriptRoot 'runner_utility_scripts' 'Logger.ps1')
+if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
+    . (Join-Path $PSScriptRoot 'runner_utility_scripts' 'Logger.ps1')
+}
 . (Join-Path $PSScriptRoot 'lab_utils' 'Get-LabConfig.ps1')
 . (Join-Path $PSScriptRoot 'lab_utils' 'Format-Config.ps1')
 $menuPath = Join-Path $PSScriptRoot 'lab_utils' 'Menu.ps1'


### PR DESCRIPTION
## Summary
- avoid overriding an existing `Write-CustomLog` function when `runner.ps1` loads helpers

## Testing
- `Invoke-Pester` *(no tests found on Linux)*
- `ruff check .`
- `Invoke-ScriptAnalyzer -Path . -Recurse`


------
https://chatgpt.com/codex/tasks/task_e_684896a12cb88331ac5dcaf3a647e53e