### PR TITLE
Fix Format-Config pipeline input

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -1,16 +1,18 @@
 function Format-Config {
     [CmdletBinding()]
     param(
+        [Parameter(Mandatory, ValueFromPipeline = $true)]
         [psobject]$Config
     )
 
-    if ($null -eq $Config) {
-        throw [System.ArgumentNullException]::new('Config')
-    }
+    process {
+        if ($null -eq $Config) {
+            throw [System.ArgumentNullException]::new('Config')
+        }
 
-    # Serialize the configuration object to indented JSON so nested
-    # properties are easier to read in the console output.  Depth 10
-    # should be sufficient for our current config structure.
-    $json = $Config | ConvertTo-Json -Depth 10
-    return $json
+        # Serialize the configuration object to indented JSON so nested
+        # properties are easier to read in the console output.  Depth 10
+        # should be sufficient for our current config structure.
+        $Config | ConvertTo-Json -Depth 10
+    }
 }

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -12,6 +12,12 @@ Describe 'Format-Config' {
         $result | Should -Match '"Baz"\s*:\s*1'
     }
 
+    It 'accepts pipeline input' {
+        $cfg = [pscustomobject]@{ Foo = 'pipe' }
+        $result = $cfg | Format-Config
+        $result | Should -Match '"Foo"\s*:\s*"pipe"'
+    }
+
     It 'throws when Config is null' {
         { Format-Config -Config $null } | Should -Throw
     }
@@ -19,5 +25,9 @@ Describe 'Format-Config' {
     It 'is a terminating error when Config is null' {
         { Format-Config -Config $null } |
             Should -Throw -ErrorType System.ArgumentNullException
+    }
+
+    It 'is a terminating error when piped null' {
+        { $null | Format-Config } | Should -Throw -ErrorType System.ArgumentNullException
     }
 }


### PR DESCRIPTION
## Summary
- allow `Format-Config` to accept pipeline input
- extend tests for pipeline usage

## Testing
- `Invoke-ScriptAnalyzer -Path . -Recurse`
- `ruff check .`
- `pytest -q`
- `Invoke-Pester -Configuration $cfg` *(no tests run: discovery found 0 tests)*

------
https://chatgpt.com/codex/tasks/task_e_684895dbf7788331bc54ce63c588a915