### PR TITLE
Handle JSON-aware runner scripts

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -260,7 +260,9 @@ function Invoke-Scripts {
                 $script:ConsoleLevel = $vl[$verbosity]
                 $cfg = Get-Content -Raw -Path $cfgPath | ConvertFrom-Json
                 try {
-                    $result = & $scr -Config $cfg
+                    $args = @{ Config = $cfg }
+                    if ((Get-Command $scr).Parameters.ContainsKey('AsJson')) { $args.AsJson = $true }
+                    $result = & $scr @args
                     $exit = if ($LASTEXITCODE) { $LASTEXITCODE } elseif (-not $?) { 1 } else { 0 }
                     Write-Output $result
                     exit $exit


### PR DESCRIPTION
## Summary
- enhance `runner.ps1` to detect `-AsJson` support
- forward the flag so JSON-capable runner scripts return JSON properly

## Testing
- `Invoke-Pester -Path tests/Get-SystemInfo.Tests.ps1` *(zero tests executed on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_684896aac72c8331bd3163f5651baec2