### PR TITLE
Fix Get-SystemInfo test helper load

### DIFF
--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -2,11 +2,11 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 if ($SkipNonWindows) { return }
-. (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')
 
 
 Describe '0200_Get-SystemInfo' {
     BeforeAll {
+        . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')
         $script:ScriptPath = Get-RunnerScriptPath '0200_Get-SystemInfo.ps1'
     }
 


### PR DESCRIPTION
## Summary
- ensure `Get-Platform` helper is loaded inside `Get-SystemInfo` tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `Invoke-Pester` *(0 tests on Linux)*
- `Invoke-ScriptAnalyzer` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684895f2da5c8331aab6460c8275e082