### PR TITLE
Fix coverage upload trigger

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -74,13 +74,14 @@ jobs:
               New-Item -ItemType Directory -Path coverage | Out-Null
           }
       - name: Run Pester
+        id: pester
         continue-on-error: ${{ runner.os != 'Windows' }}
         shell: pwsh
         run: |
           $cfg = New-PesterConfiguration -Hashtable (Import-PowerShellDataFile 'tests/PesterConfiguration.psd1')
           Invoke-Pester -Configuration $cfg -ErrorAction Stop
       - name: Upload coverage
-        if: always()
+        if: steps.pester.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: pester-coverage-${{ matrix.os }}


### PR DESCRIPTION
## Summary
- upload Pester coverage only when tests succeed

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Import-Module Pester -MinimumVersion 5.6.1; Invoke-Pester -Configuration (New-PesterConfiguration -Hashtable (Import-PowerShellDataFile 'tests/PesterConfiguration.psd1'))"`


------
https://chatgpt.com/codex/tasks/task_e_684896f0521c833191af70436200f474