### PR TITLE
Enable ShouldProcess on Install-CA script

### DIFF
--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
 Param([pscustomobject]$Config)
 function Install-CA {
     [CmdletBinding(SupportsShouldProcess = $true)]


### PR DESCRIPTION
## Summary
- mark `0104_Install-CA.ps1` as an advanced script so common parameters
  (like `-Confirm`) flow to the internal `Install-CA` function

## Testing
- `Invoke-ScriptAnalyzer -Path .`
- `ruff check .`
- `Invoke-Pester` *(no tests run on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_6848962e04cc8331b71c646d22d6f947