### PR TITLE
Fix Remove-Mock undefined in Pester test

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -213,6 +213,9 @@ Describe 'Convert certificate helpers validate paths' -Skip:($SkipNonWindows) {
         if (Get-Command Remove-Mock -ErrorAction SilentlyContinue) {
             Remove-Mock Convert-CerToPem -ErrorAction SilentlyContinue
             Remove-Mock Convert-PfxToPem -ErrorAction SilentlyContinue
+        } else {
+            Remove-Item Function:Convert-CerToPem -ErrorAction SilentlyContinue
+            Remove-Item Function:Convert-PfxToPem -ErrorAction SilentlyContinue
         }
         $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath


### PR DESCRIPTION
## Summary
- prevent `Remove-Mock` failure when Pester is missing by removing functions manually

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not found)*
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'typer'`)*

------
https://chatgpt.com/codex/tasks/task_e_68489a4fccf88331a04acce6ed4b3773