### PR TITLE
Fix Format-Config null handling

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -2,6 +2,7 @@ function Format-Config {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, ValueFromPipeline = $true)]
+        [AllowNull()]
         [psobject]$Config
     )
 


### PR DESCRIPTION
## Summary
- allow `Format-Config` to receive `$null` input

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_68489a0ef4bc83318453f1686723ce0a