### PR TITLE
Fix ADCS installer lookup

### DIFF
--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -54,8 +54,13 @@ if ($PSCmdlet.ShouldProcess($CAName, 'Configure Standalone Root CA')) {
 
     $installCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
     if (-not $installCmd) {
+        if (Get-Module -ListAvailable -Name ADCSDeployment) {
+            Import-Module ADCSDeployment -ErrorAction SilentlyContinue
+            $installCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
+        }
+    }
+    if (-not $installCmd) {
         Write-CustomLog 'Install-AdcsCertificationAuthority command not found. Ensure AD CS features are available.'
-
         return
     }
     Install-AdcsCertificationAuthority `


### PR DESCRIPTION
## Summary
- retry loading ADCS cmdlets before bailing out

## Testing
- `ruff check .`
- `Invoke-Pester -Configuration tests/PesterConfiguration.psd1` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68489a3d66408331a880ea7681237108