### PR TITLE
Fix ParameterBindingException in runner.ps1 tests

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -322,9 +322,13 @@ Write-Error 'err message'
             $script:warnings  = @()
             $script:errors    = @()
             function global:Write-Host {
-                param([Parameter(Mandatory=$true,Position=0)][string]$Object,
-                      [Parameter(Position=1)][string]$ForegroundColor)
-                $script:logLines += $Object
+                param(
+                    [Parameter(Mandatory=$true,Position=0,ValueFromPipeline=$true)]
+                    [object]$Object,
+                    [Parameter(Position=1)]
+                    [string]$ForegroundColor
+                )
+                process { $script:logLines += "$Object" }
             }
             function global:Write-Warning {
                 param([string]$Message)
@@ -367,9 +371,13 @@ Write-Error 'err message'
             $script:warnings  = @()
             $script:errors    = @()
             function global:Write-Host {
-                param([Parameter(Mandatory=$true,Position=0)][string]$Object,
-                      [Parameter(Position=1)][string]$ForegroundColor)
-                $script:logLines += $Object
+                param(
+                    [Parameter(Mandatory=$true,Position=0,ValueFromPipeline=$true)]
+                    [object]$Object,
+                    [Parameter(Position=1)]
+                    [string]$ForegroundColor
+                )
+                process { $script:logLines += "$Object" }
             }
             function global:Write-Warning {
                 param([string]$Message)


### PR DESCRIPTION
## Summary
- update Write-Host mocks in `Runner.Tests.ps1` to accept pipeline input

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command Invoke-ScriptAnalyzer -Path .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489ac6c67c833180847f0a68e04093