### PR TITLE
Fix test path variable

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -1,6 +1,6 @@
-$testRoot = if ($PSScriptRoot) { $PSScriptRoot } elseif ($PSCommandPath) { Split-Path $PSCommandPath } else { '.' }
-. (Join-Path $testRoot 'TestDriveCleanup.ps1')
-. (Join-Path $testRoot 'helpers' 'TestHelpers.ps1')
+$script:testRoot = if ($PSScriptRoot) { $PSScriptRoot } elseif ($PSCommandPath) { Split-Path $PSCommandPath } else { '.' }
+. (Join-Path $script:testRoot 'TestDriveCleanup.ps1')
+. (Join-Path $script:testRoot 'helpers' 'TestHelpers.ps1')
 if ($SkipNonWindows) { return }
 
 BeforeAll {
@@ -12,7 +12,7 @@ BeforeAll {
 }
 Describe 'Prepare-HyperVProvider path restoration' -Skip:($SkipNonWindows) {
     It 'restores location after execution' {
-        . (Join-Path $testRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+        . (Join-Path $script:testRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $script:scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         $config = [pscustomobject]@{
             PrepareHyperVHost = $true
@@ -68,7 +68,7 @@ Describe 'Prepare-HyperVProvider path restoration' -Skip:($SkipNonWindows) {
 Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
     It 'creates PEM files and updates providers.tf' {
 
-        . (Join-Path $testRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+        . (Join-Path $script:testRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $script:scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
 
@@ -121,7 +121,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
         # prepare certificate files for conversion using static test data
         $rootCaName = $config.CertificateAuthority.CommonName
         $hostName   = [System.Net.Dns]::GetHostName()
-        $sourceCert = Join-Path $testRoot 'data' 'TestCA.cer'
+        $sourceCert = Join-Path $script:testRoot 'data' 'TestCA.cer'
         Copy-Item -Path $sourceCert -Destination (Join-Path $PWD "$rootCaName.cer") -Force
         'dummy' | Set-Content -Path (Join-Path $PWD "$rootCaName.pfx")
         'dummy' | Set-Content -Path (Join-Path $PWD "$hostName.pfx")


### PR DESCRIPTION
## Summary
- ensure `$testRoot` is script-scoped in PrepareHyperVProvider tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68489aa235e883319d4f7b8115876a53