### PR TITLE
Fix runner docs duplication

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -37,9 +37,7 @@ macOS hosts use `uname`, `df` and networking APIs to return similar details.
 If the platform cannot be recognised the script exits with code `1` and logs an
 "unsupported platform" error.
 
-To suppress informational output, append the `-Quiet` switch (equivalent to
 To suppress informational output, use the `-Quiet` switch (equivalent to
- 
 `-Verbosity silent`). For example, to run scripts `0006` and `0007`
 silently and non-interactively:
 


### PR DESCRIPTION
## Summary
- trim repeated explanation of `-Quiet` switch in the runner guide

## Testing
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_68489c1fb9f4833181792d7ad49f0e80