### PR TITLE
Fix providers.tf path mocking

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -138,6 +138,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
           '  key_path        = ""',
           '}'
         ) | Set-Content -Path $providerFile
+        Mock Test-Path { $true } -ParameterFilter { $_ -eq $providerFile }
 
         $cmdBefore = Get-Command Convert-PfxToPem
         & $script:scriptPath -Config $config


### PR DESCRIPTION
## Summary
- ensure PrepareHyperVProvider tests mock the providers.tf path

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_68489bba91ac83319593ddd2c22bc7b4