### PR TITLE
Fix Set-LabConfig test selection

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -549,7 +549,13 @@ Describe 'Set-LabConfig' {
             Node_Dependencies = @{ NpmPath = 'C:\\Old'; CreateNpmPath = $false }
         }
 
-        $answers = @('Y','C:\\Repo','C:\\Node','Y')
+        $answers = @(
+            'Y',      # InstallGit
+            'Y',      # InstallOpenTofu
+            'C:\\Repo',
+            'C:\\Node',
+            'Y'
+        )
         $script:idx = 0
         function global:Read-Host {
             param([string]$Prompt)
@@ -557,7 +563,13 @@ Describe 'Set-LabConfig' {
             $answers[$script:idx++]
         }
 
-        Mock Get-MenuSelection { 'InstallGit','LocalPath','Node_Dependencies','Done' }
+        Mock Get-MenuSelection {
+            'InstallGit',
+            'InstallOpenTofu',
+            'LocalPath',
+            'Node_Dependencies',
+            'Done'
+        }
 
         $updated = Set-LabConfig -ConfigObject $config
 


### PR DESCRIPTION
## Summary
- ensure InstallOpenTofu menu option is part of the mocked selection
- update Read-Host answers accordingly

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_68489c1c6bd4833182a23ddb4caaa45a