### PR TITLE
Fix certificate path copy in Hyper-V tests

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -121,10 +121,13 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
         # prepare certificate files for conversion using static test data
         $rootCaName = $config.CertificateAuthority.CommonName
         $hostName   = [System.Net.Dns]::GetHostName()
+
+        $executionPath = Get-Location
         $sourceCert = Join-Path $testRoot 'data' 'TestCA.cer'
-        Copy-Item -Path $sourceCert -Destination (Join-Path $PWD "$rootCaName.cer") -Force
-        'dummy' | Set-Content -Path (Join-Path $PWD "$rootCaName.pfx")
-        'dummy' | Set-Content -Path (Join-Path $PWD "$hostName.pfx")
+        Copy-Item -Path $sourceCert -Destination (Join-Path $executionPath "$rootCaName.cer") -Force
+        'dummy' | Set-Content -Path (Join-Path $executionPath "$rootCaName.pfx")
+        'dummy' | Set-Content -Path (Join-Path $executionPath "$hostName.pfx")
+        Mock Test-Path { $true } -ParameterFilter { $_ -like "*$rootCaName.cer" }
         Mock Copy-Item {}
 
         $providerFile = Join-Path $tempDir 'providers.tf'
@@ -155,13 +158,13 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
         (Get-Content $providerFile -Raw) | Should -Match 'insecure\s*=\s*false'
 
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
-        Remove-Item (Join-Path $PWD "$rootCaName.cer") -ErrorAction SilentlyContinue
-        Remove-Item (Join-Path $PWD "$rootCaName.pem") -ErrorAction SilentlyContinue
-        Remove-Item (Join-Path $PWD "$rootCaName.pfx") -ErrorAction SilentlyContinue
-        Remove-Item (Join-Path $PWD "$hostName.pfx") -ErrorAction SilentlyContinue
-        Remove-Item (Join-Path $PWD "$hostName.pem") -ErrorAction SilentlyContinue
-        Remove-Item (Join-Path $PWD "$hostName-key.pem") -ErrorAction SilentlyContinue
-    }
+        Remove-Item (Join-Path $executionPath "$rootCaName.cer") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $executionPath "$rootCaName.pem") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $executionPath "$rootCaName.pfx") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $executionPath "$hostName.pfx") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $executionPath "$hostName.pem") -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $executionPath "$hostName-key.pem") -ErrorAction SilentlyContinue
+   }
 
     It 'does not redefine Convert-PfxToPem when sourced twice' {
         $cmdFirst = Get-Command Convert-PfxToPem


### PR DESCRIPTION
## Summary
- fix `PrepareHyperVProvider` tests to copy test certificate into the execution
  directory after mocks
- clean up temporary test artifacts using the resolved path

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command '$cfg=New-PesterConfiguration; $cfg.Run.Path="tests"; Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_68489bb776788331a41ae5110e89b16c