### PR TITLE
Fix Format-Config null handling

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -1,12 +1,15 @@
 function Format-Config {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory, ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline = $true)]
         [AllowNull()]
         [psobject]$Config
     )
 
+    begin { $hasInput = $false }
+
     process {
+        $hasInput = $true
         if ($null -eq $Config) {
             throw [System.ArgumentNullException]::new('Config')
         }
@@ -15,5 +18,11 @@ function Format-Config {
         # properties are easier to read in the console output.  Depth 10
         # should be sufficient for our current config structure.
         $Config | ConvertTo-Json -Depth 10
+    }
+
+    end {
+        if (-not $hasInput) {
+            throw [System.ArgumentNullException]::new('Config')
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make Format-Config detect when no pipeline input is received
- ensure System.ArgumentNullException is thrown when null is piped or passed

## Testing
- `Invoke-Pester`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848a1f08a2c83319b975426e7be7296