### PR TITLE
Fix Poetry path for Windows in pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   pytest:
     name: Run Python tests
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- set `run.shell: bash` on the pytest job to ensure Poetry is available on Windows runners

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a725920c8331b1c79f40d41abf26