### PR TITLE
Add unauthenticated download for Windows artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,10 @@ The suite includes a YAML parsing test that is skipped unless the
 Install-Module powershell-yaml -Scope CurrentUser
 ```
 
+Download the latest Windows test results with `lab_utils/Get-WindowsJobArtifacts.ps1`.
+If the GitHub CLI isn't authenticated, the script falls back to public
+downloads via the nightly.link service.
+
 Python unit tests live under `py/`. Install the dependencies first using
 either Poetry or a direct `pip` install to get packages like `typer`:
 

--- a/tests/Get-WindowsJobArtifacts.Tests.ps1
+++ b/tests/Get-WindowsJobArtifacts.Tests.ps1
@@ -1,0 +1,38 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
+
+Describe 'Get-WindowsJobArtifacts' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-WindowsJobArtifacts.ps1'
+    }
+
+    It 'uses gh CLI when authenticated' {
+        Mock Get-Command { [pscustomobject]@{ Name = 'gh' } } -ParameterFilter { $Name -eq 'gh' }
+        Mock gh {} -ParameterFilter { $args[0] -eq 'auth status' }
+        Mock gh { '{"workflow_runs":[{"id":1}]}' } -ParameterFilter { $args[0] -like '*runs?*' }
+        Mock gh { '{"artifacts":[{"name":"pester-coverage-windows-latest","archive_download_url":"cov"},{"name":"pester-results-windows-latest","archive_download_url":"res"}]}' } -ParameterFilter { $args[0] -like '*artifacts*' }
+        Mock gh {} -ParameterFilter { $args[0] -eq 'cov' -or $args[0] -eq 'res' }
+        Mock Expand-Archive {}
+        Mock Get-ChildItem { [pscustomobject]@{ FullName = 'dummy.xml' } }
+        Mock Select-Xml { @() }
+
+        & $scriptPath
+
+        Should -Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'auth status' } -Times 1
+        Should -Not -Invoke -CommandName Invoke-WebRequest
+    }
+
+    It 'falls back to nightly.link when gh auth fails' {
+        Mock Get-Command { [pscustomobject]@{ Name = 'gh' } } -ParameterFilter { $Name -eq 'gh' }
+        Mock gh { throw 'unauthenticated' } -ParameterFilter { $args[0] -eq 'auth status' }
+        Mock Invoke-WebRequest {}
+        Mock Expand-Archive {}
+        Mock Get-ChildItem { [pscustomobject]@{ FullName = 'dummy.xml' } }
+        Mock Select-Xml { @() }
+
+        & $scriptPath
+
+        Should -Invoke -CommandName Invoke-WebRequest -Times 1 -ParameterFilter { $Uri -match 'nightly\.link' }
+    }
+}


### PR DESCRIPTION
## Summary
- add fallback to nightly.link for `Get-WindowsJobArtifacts.ps1`
- test both authenticated and unauthenticated flows
- mention unauthenticated mode in README

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_6848ac04b9a4833187bf8a46e1cff3f9