### PR TITLE
Upload Pester logs on failure

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -79,8 +79,14 @@ jobs:
         shell: pwsh
         run: |
           $cfg = New-PesterConfiguration -Hashtable (Import-PowerShellDataFile 'tests/PesterConfiguration.psd1')
-          Invoke-Pester -Configuration $cfg -ErrorAction Stop
+          Invoke-Pester -Configuration $cfg -ErrorAction Stop 2>&1 | Tee-Object -FilePath coverage/pester.log
           "pester_exit_code=$LASTEXITCODE" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+      - name: Upload Pester log
+        if: steps.pester.outputs.pester_exit_code != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pester-log-${{ matrix.os }}
+          path: coverage/pester.log
       - name: Upload coverage
         if: steps.pester.outcome == 'success'
         uses: actions/upload-artifact@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,4 +19,5 @@ The [root README](../README.md) provides quick start instructions. Additional gu
 - [Network switch module](../modules/network_switch/README.md)
 - [Example infrastructure](../example-infrastructure/README.md)
 - [Minimal example](../examples/minimal/README.md)
+- [Troubleshooting CI](troubleshooting.md)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,7 @@
+# Troubleshooting CI failures
+
+When a Pester job fails in GitHub Actions, the console output is saved as an artifact.
+Look for `pester-log-<os>` on the run summary page. These text files mirror the
+**Run Pester** step and can be downloaded without signing in to GitHub.
+
+Inspect the log to see which tests failed and view any stack traces.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,3 +5,4 @@ nav:
   - Lab Utils: docs/lab_utils.md
   - ISO Tools: docs/iso_tools.md
   - Python CLI: docs/python-cli.md
+  - Troubleshooting: docs/troubleshooting.md


### PR DESCRIPTION
## Summary
- collect `Run Pester` output in `pester.yml`
- upload the log artifact on failure
- document where to find failing CI logs

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6848ac65a0f0833196e164af73bd3802