### PR TITLE
Fix Pester log path

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -83,7 +83,9 @@ jobs:
           $repoRoot = $env:GITHUB_WORKSPACE
           $cfg.TestResult.OutputPath   = Join-Path $repoRoot 'coverage/testResults.xml'
           $cfg.CodeCoverage.OutputPath = Join-Path $repoRoot 'coverage/coverage.xml'
-          Invoke-Pester -Configuration $cfg -ErrorAction Stop 2>&1 | Tee-Object -FilePath coverage/pester.log
+          $logPath = Join-Path $repoRoot 'coverage/pester.log'
+
+          Invoke-Pester -Configuration $cfg -ErrorAction Stop 2>&1 | Tee-Object -FilePath $logPath
 
           "pester_exit_code=$LASTEXITCODE" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
       - name: Upload Pester log


### PR DESCRIPTION
## Summary
- fix pester log path in workflow so artifact uploads

## Testing
- `poetry run pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848aeed3b848331b802f39d7cf15874