### PR TITLE
Simplify bootstrap tests

### DIFF
--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -3,10 +3,9 @@
 if ($SkipNonWindows) { return }
 Describe 'kicker-bootstrap utilities' -Skip:($SkipNonWindows) {
     It 'defines Write-CustomLog fallback' {
-        $script:scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
-        $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:scriptPath, [ref]$null, [ref]$null)
-        $funcs = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
-        ($funcs.Name -contains 'Write-CustomLog') | Should -BeTrue
+        $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
+        $content = Get-Content $scriptPath -Raw
+        $content | Should -Match 'function\s+Write-CustomLog'
     }
 
     It 'invokes runner and propagates exit code using PassThru' {
@@ -33,9 +32,8 @@ Describe 'kicker-bootstrap utilities' -Skip:($SkipNonWindows) {
 
     It 'defines Update-RepoPreserveConfig function' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
-        $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$null, [ref]$null)
-        $funcs = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
-        ($funcs.Name -contains 'Update-RepoPreserveConfig') | Should -BeTrue
+        $content = Get-Content $scriptPath -Raw
+        $content | Should -Match 'function\s+Update-RepoPreserveConfig'
     }
 
     It 'prompts when multiple config files exist' {


### PR DESCRIPTION
## Summary
- simplify function checks in `Kicker-Bootstrap.Tests.ps1`

## Testing
- `poetry run pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ba9a90108331bebb9479e1db99d6