### PR TITLE
Add module guard in Windows tests

### DIFF
--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -4,6 +4,12 @@ if ($SkipNonWindows) { return }
 
 if ($IsLinux -or $IsMacOS) { return }
 
+# Skip entirely if the required Windows modules are unavailable
+if (-not (Get-Module -ListAvailable -Name 'ServerManager') -or
+    -not (Get-Module -ListAvailable -Name 'ADCSDeployment')) {
+    return
+}
+
 Describe '0104_Install-CA script' {
     BeforeAll {
         $scriptPath = Get-RunnerScriptPath '0104_Install-CA.ps1'

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -3,6 +3,9 @@ $script:testRoot = if ($PSScriptRoot) { $PSScriptRoot } elseif ($PSCommandPath) 
 . (Join-Path $script:testRoot 'helpers' 'TestHelpers.ps1')
 if ($SkipNonWindows) { return }
 
+# Skip tests if the Hyper-V module isn't available
+if (-not (Get-Module -ListAvailable -Name 'Hyper-V')) { return }
+
 BeforeAll {
     $script:scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
     . $script:scriptPath


### PR DESCRIPTION
## Summary
- skip `Install-CA` tests if ServerManager or ADCSDeployment modules aren't installed
- skip `PrepareHyperVProvider` tests when the Hyper-V module is missing

## Testing
- `pip install -e ./py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ba9b229883319ef4630d033f9dc7