### PR TITLE
Fix Pester log upload condition

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -89,7 +89,7 @@ jobs:
 
           "pester_exit_code=$LASTEXITCODE" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
       - name: Upload Pester log
-        if: steps.pester.outputs.pester_exit_code != '0'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pester-log-${{ matrix.os }}


### PR DESCRIPTION
## Summary
- always run the "Upload Pester log" step

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: ParseException)*
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6848ba9cf6cc83318608080a242ee277