### PR TITLE
Fix Get-WindowsJobArtifacts RunId handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,11 +383,12 @@ Install-Module powershell-yaml -Scope CurrentUser
 Download the latest Windows test results with `lab_utils/Get-WindowsJobArtifacts.ps1`.
 If the GitHub CLI isn't authenticated, the script falls back to public
 downloads via the nightly.link service. You can also pass a specific
-workflow run ID obtained from `gh run list`:
+workflow run ID obtained from `gh run list`. Because run IDs are 64-bit
+integers, wrap the value in quotes on PowerShell:
 
 ```powershell
 gh run list --limit 20
-lab_utils/Get-WindowsJobArtifacts.ps1 -RunId <id>
+lab_utils/Get-WindowsJobArtifacts.ps1 -RunId "<id>"
 ```
 
 Python unit tests live under `py/`. Install the dependencies first using

--- a/docs/lab_utils.md
+++ b/docs/lab_utils.md
@@ -9,6 +9,6 @@ This folder contains helper tools used across the project. Each script focuses o
 - **Menu.ps1** – Provides an interactive menu for selecting items from a list.
 - **Hypervisor.psm1** – Stub module defining `Get-HVFacts`, `Enable-Provider` and `Deploy-VM` functions.
 - **get_platform.py** – Python version of `Get-Platform.ps1`.
-- **Get-WindowsJobArtifacts.ps1** – Downloads the latest Windows job artifacts from GitHub and shows failing tests. Use `gh run list` to grab a run ID and call the script with `-RunId <id>` if automatic discovery fails. The script falls back to nightly.link URLs when unauthenticated.
+- **Get-WindowsJobArtifacts.ps1** – Downloads the latest Windows job artifacts from GitHub and shows failing tests. Use `gh run list` to grab a run ID and call the script with `-RunId <id>` if automatic discovery fails. Run IDs are 64‑bit integers, so quote them if needed. The script falls back to nightly.link URLs when unauthenticated.
 
 The `__init__.py` file is currently empty and simply marks the folder as a Python package.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,7 +14,7 @@ Use `lab_utils/Get-WindowsJobArtifacts.ps1` to download the latest artifacts fro
 pwsh -File lab_utils/Get-WindowsJobArtifacts.ps1
 ```
 
-Pass `-RunId <id>` to target a specific run if automatic discovery fails. The helper extracts two ZIP archives into a temporary folder: one containing `testResults.xml` and another with `coverage.xml`.
+Pass `-RunId <id>` to target a specific run if automatic discovery fails. Run IDs may exceed 32-bit range, so wrap them in quotes on PowerShell 7. The helper extracts two ZIP archives into a temporary folder: one containing `testResults.xml` and another with `coverage.xml`.
 
 ### Reading `testResults.xml`
 

--- a/lab_utils/Get-WindowsJobArtifacts.ps1
+++ b/lab_utils/Get-WindowsJobArtifacts.ps1
@@ -2,7 +2,7 @@
 param(
     [string]$Repo = 'wizzense/opentofu-lab-automation',
     [string]$Workflow = 'pester.yml',
-    [int]$RunId
+    [long]$RunId
 )
 
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "gh-artifacts-$([System.Guid]::NewGuid())"


### PR DESCRIPTION
## Summary
- allow larger workflow IDs in `Get-WindowsJobArtifacts.ps1`
- clarify quoting requirements in documentation

## Testing
- `Invoke-Pester tests/Get-WindowsJobArtifacts.Tests.ps1` *(no tests discovered)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bd2559e08331947f4dfbd42ed897