### PR TITLE
Add Pester failure issue helper

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -29,6 +29,16 @@ jobs:
             core.setOutput('summary', summary);
             core.setOutput('failed', failed);
 
+      - name: Download Pester results and open issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          run_id=${{ github.event.workflow_run.id }}
+          gh run download "$run_id" -n 'pester-results-*' -D artifacts
+          find artifacts -name testResults.xml -print0 | while IFS= read -r -d '' f; do
+            python py/labctl/pester_failures.py "$f"
+          done
+
       - name: Check existing issue
         id: find
         uses: actions/github-script@v7

--- a/docs/windows-test-failures.md
+++ b/docs/windows-test-failures.md
@@ -1,6 +1,6 @@
 # Windows Test Failures
 
-The following table lists failing tests collected from `coverage/testResults.xml` along with their error messages. The matching log (`coverage/pester.log`) only contained `gh: Not Found (HTTP 404)`.
+The following table lists failing tests collected from `coverage/testResults.xml` along with their error messages. When the `Pester` workflow fails, the `issue-on-fail` workflow downloads the `pester-results-<os>` artifact and runs `py/labctl/pester_failures.py` to open GitHub issues for each failing test. The matching log (`coverage/pester.log`) only contained `gh: Not Found (HTTP 404)`.
 
 | Test Name | Error Message |
 |-----------|--------------|

--- a/py/labctl/github_utils.py
+++ b/py/labctl/github_utils.py
@@ -13,6 +13,11 @@ def close_issue(issue_number: int) -> None:
     subprocess.run(["gh", "issue", "close", str(issue_number)], check=True)
 
 
+def create_issue(title: str, body: str) -> None:
+    """Create a GitHub issue using the CLI."""
+    subprocess.run(["gh", "issue", "create", "-t", title, "-b", body], check=True)
+
+
 def cleanup_branches(remote: str = "origin") -> List[str]:
     """Delete remote branches keeping the newest per hour.
 

--- a/py/labctl/pester_failures.py
+++ b/py/labctl/pester_failures.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+from .github_utils import create_issue
+
+
+def report_failures(xml_path: Path) -> None:
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    for case in root.findall(".//test-case[@result='Failed']"):
+        title = case.get("name", "Pester test failed")
+        message = case.findtext("failure/message", default="")
+        create_issue(title, message)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: pester_failures.py <testResults.xml>")
+        sys.exit(1)
+    report_failures(Path(sys.argv[1]))

--- a/py/tests/test_github_utils.py
+++ b/py/tests/test_github_utils.py
@@ -45,3 +45,16 @@ def test_cleanup(monkeypatch):
     assert deletes == [["git", "push", "origin", "--delete", "feat1"]]
 
 
+def test_create_issue(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, check=True):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    github_utils.create_issue("title", "body")
+
+    assert called["cmd"] == ["gh", "issue", "create", "-t", "title", "-b", "body"]
+
+

--- a/py/tests/test_pester_failures.py
+++ b/py/tests/test_pester_failures.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+import subprocess
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from labctl import pester_failures
+
+
+def test_report_failures(tmp_path, monkeypatch):
+    xml = tmp_path / "testResults.xml"
+    xml.write_text(
+        """
+<test-results>
+  <test-suite>
+    <results>
+      <test-case name='Pass.Test' result='Passed'>
+        <failure/>
+      </test-case>
+      <test-case name='Fail.Test' result='Failed'>
+        <failure>
+          <message>boom</message>
+        </failure>
+      </test-case>
+    </results>
+  </test-suite>
+</test-results>
+"""
+    )
+    calls = []
+
+    def fake_run(cmd, check=True):
+        calls.append(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    pester_failures.report_failures(xml)
+
+    assert calls == [["gh", "issue", "create", "-t", "Fail.Test", "-b", "boom"]]


### PR DESCRIPTION
## Summary
- create `github_utils.create_issue`
- add `pester_failures.py` to open issues for failing Pester tests
- test utilities with pytest
- parse `pester-results-<os>` artifacts in `issue-on-fail.yml`
- document automatic issue creation

## Testing
- `poetry run pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848c38870888331ac4d2567361c3233