### PR TITLE
Add pytest failure issue automation

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -29,14 +29,18 @@ jobs:
             core.setOutput('summary', summary);
             core.setOutput('failed', failed);
 
-      - name: Download Pester results and open issues
+      - name: Download test results and open issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           run_id=${{ github.event.workflow_run.id }}
           gh run download "$run_id" -n 'pester-results-*' -D artifacts
+          gh run download "$run_id" -n 'pytest-results-*' -D artifacts
           find artifacts -name testResults.xml -print0 | while IFS= read -r -d '' f; do
             python py/labctl/pester_failures.py "$f"
+          done
+          find artifacts -name junit.xml -print0 | while IFS= read -r -d '' f; do
+            python py/labctl/pytest_failures.py "$f"
           done
 
       - name: Check existing issue

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,15 @@ jobs:
         run: |
           cd py
           poetry install
+      - name: Ensure coverage directory
+        run: mkdir -p coverage
       - name: Run pytest
         run: |
           cd py
-          poetry run pytest
+          poetry run pytest --junitxml=../coverage/junit.xml
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-${{ matrix.os }}
+          path: coverage/junit.xml

--- a/docs/windows-test-failures.md
+++ b/docs/windows-test-failures.md
@@ -1,6 +1,6 @@
 # Windows Test Failures
 
-The following table lists failing tests collected from `coverage/testResults.xml` along with their error messages. When the `Pester` workflow fails, the `issue-on-fail` workflow downloads the `pester-results-<os>` artifact and runs `py/labctl/pester_failures.py` to open GitHub issues for each failing test. The matching log (`coverage/pester.log`) only contained `gh: Not Found (HTTP 404)`.
+The following table lists failing tests collected from `coverage/testResults.xml` along with their error messages. When a test workflow fails, `.github/workflows/issue-on-fail.yml` downloads the `pester-results-*` or `pytest-results-*` artifacts and runs `py/labctl/pester_failures.py` or `py/labctl/pytest_failures.py` to open GitHub issues for each failing test. The matching log (`coverage/pester.log`) only contained `gh: Not Found (HTTP 404)`.
 
 | Test Name | Error Message |
 |-----------|--------------|

--- a/py/labctl/pytest_failures.py
+++ b/py/labctl/pytest_failures.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+from .github_utils import create_issue
+
+
+def report_failures(xml_path: Path) -> None:
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    for case in root.findall(".//testcase"):
+        failure = case.find("failure")
+        if failure is None:
+            failure = case.find("error")
+        if failure is None:
+            continue
+        classname = case.get("classname")
+        name = case.get("name")
+        parts = [p for p in [classname, name] if p]
+        title = ".".join(parts) if parts else "Pytest test failed"
+        message = failure.get("message") or (failure.text or "")
+        create_issue(title, message)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: pytest_failures.py <junit.xml>")
+        sys.exit(1)
+    report_failures(Path(sys.argv[1]))

--- a/py/tests/test_pytest_failures.py
+++ b/py/tests/test_pytest_failures.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sys
+import subprocess
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from labctl import pytest_failures
+
+
+def test_report_failures(tmp_path, monkeypatch):
+    xml = tmp_path / "junit.xml"
+    xml.write_text(
+        """
+<testsuite>
+  <testcase classname='pkg.TestCase' name='test_pass'/>
+  <testcase classname='pkg.TestCase' name='test_fail'>
+    <failure message='oops'>AssertionError</failure>
+  </testcase>
+</testsuite>
+"""
+    )
+    calls = []
+
+    def fake_run(cmd, check=True):
+        calls.append(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    pytest_failures.report_failures(xml)
+
+    assert calls == [["gh", "issue", "create", "-t", "pkg.TestCase.test_fail", "-b", "oops"]]


### PR DESCRIPTION
## Summary
- parse pytest JUnit output in `pytest_failures.py`
- open issues for failed pytest cases
- test pytest failure detection
- upload pytest JUnit artifacts in workflow and process them in `issue-on-fail`
- document automatic issue creation for both test suites

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c8e2d0ac833199bfcc31dd8e5a60