### PR TITLE
Fix parse error in Runner.Tests.ps1

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -312,7 +312,6 @@ Write-Error 'err message'
 
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
-}
 
     It 'suppresses informational logs when -Verbosity silent is used' {
         $tempDir   = New-RunnerTestEnv


### PR DESCRIPTION
## Summary
- remove stray closing brace from `Runner.Tests.ps1`

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_6848ca9995348331b7a3ecfe5e5bf061