### PR TITLE
Fix unmatched brace in Pester tests

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -312,7 +312,6 @@ Write-Error 'err message'
 
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
-}
 
     It 'suppresses informational logs when -Verbosity silent is used' {
         $tempDir   = New-RunnerTestEnv


### PR DESCRIPTION
## Summary
- fix unmatched `}` in `Runner.Tests.ps1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848cc01a1c88331a2a956161711b16e