### PR TITLE
Fix issue-on-fail workflow

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -11,6 +11,9 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Collect job results
         id: jobs
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- checkout repo before scanning test artifacts in issue-on-fail workflow

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848cce85d10833192a59a874047ef7a