### PR TITLE
Improve CI issue creation

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
+      - uses: actions/checkout@v4
       - name: Collect job results
         id: jobs
         uses: actions/github-script@v7
@@ -32,6 +33,9 @@ jobs:
       - name: Download test results and open issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
           run_id=${{ github.event.workflow_run.id }}
           gh run download "$run_id" -n 'pester-results-*' -D artifacts

--- a/py/labctl/github_utils.py
+++ b/py/labctl/github_utils.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from datetime import datetime
 from typing import List
@@ -15,7 +16,11 @@ def close_issue(issue_number: int) -> None:
 
 def create_issue(title: str, body: str) -> None:
     """Create a GitHub issue using the CLI."""
-    subprocess.run(["gh", "issue", "create", "-t", title, "-b", body], check=True)
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    cmd = ["gh", "issue", "create", "-t", title, "-b", body]
+    if repo:
+        cmd.extend(["-R", repo])
+    subprocess.run(cmd, check=True)
 
 
 def cleanup_branches(remote: str = "origin") -> List[str]:

--- a/py/labctl/pester_failures.py
+++ b/py/labctl/pester_failures.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 import xml.etree.ElementTree as ET
@@ -8,10 +9,22 @@ from .github_utils import create_issue
 def report_failures(xml_path: Path) -> None:
     tree = ET.parse(xml_path)
     root = tree.getroot()
+    run_url = os.environ.get("RUN_URL")
+    commit = os.environ.get("COMMIT_SHA")
+    branch = os.environ.get("BRANCH_NAME")
+    os_name = xml_path.parent.name.replace("pester-results-", "")
+    details = []
+    if run_url:
+        details.append(f"Run: {run_url}")
+    if commit:
+        details.append(f"Commit `{commit}` on branch `{branch}`")
+    details.append(f"OS: {os_name}")
+    extra = "\n".join(details)
     for case in root.findall(".//test-case[@result='Failed']"):
         title = case.get("name", "Pester test failed")
         message = case.findtext("failure/message", default="")
-        create_issue(title, message)
+        body = f"{message}\n\n{extra}" if message else extra
+        create_issue(title, body)
 
 
 if __name__ == "__main__":

--- a/py/labctl/pytest_failures.py
+++ b/py/labctl/pytest_failures.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 import xml.etree.ElementTree as ET
@@ -8,6 +9,17 @@ from .github_utils import create_issue
 def report_failures(xml_path: Path) -> None:
     tree = ET.parse(xml_path)
     root = tree.getroot()
+    run_url = os.environ.get("RUN_URL")
+    commit = os.environ.get("COMMIT_SHA")
+    branch = os.environ.get("BRANCH_NAME")
+    os_name = xml_path.parent.name.replace("pytest-results-", "")
+    details = []
+    if run_url:
+        details.append(f"Run: {run_url}")
+    if commit:
+        details.append(f"Commit `{commit}` on branch `{branch}`")
+    details.append(f"OS: {os_name}")
+    extra = "\n".join(details)
     for case in root.findall(".//testcase"):
         failure = case.find("failure")
         if failure is None:
@@ -19,7 +31,8 @@ def report_failures(xml_path: Path) -> None:
         parts = [p for p in [classname, name] if p]
         title = ".".join(parts) if parts else "Pytest test failed"
         message = failure.get("message") or (failure.text or "")
-        create_issue(title, message)
+        body = f"{message}\n\n{extra}" if message else extra
+        create_issue(title, body)
 
 
 if __name__ == "__main__":

--- a/py/tests/test_github_utils.py
+++ b/py/tests/test_github_utils.py
@@ -52,9 +52,34 @@ def test_create_issue(monkeypatch):
         called["cmd"] = cmd
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
 
     github_utils.create_issue("title", "body")
 
     assert called["cmd"] == ["gh", "issue", "create", "-t", "title", "-b", "body"]
+
+
+def test_create_issue_with_repo(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, check=True):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+
+    github_utils.create_issue("title", "body")
+
+    assert called["cmd"] == [
+        "gh",
+        "issue",
+        "create",
+        "-t",
+        "title",
+        "-b",
+        "body",
+        "-R",
+        "owner/repo",
+    ]
 
 

--- a/py/tests/test_pester_failures.py
+++ b/py/tests/test_pester_failures.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import sys
-import subprocess
+from types import SimpleNamespace
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -29,10 +29,16 @@ def test_report_failures(tmp_path, monkeypatch):
     )
     calls = []
 
-    def fake_run(cmd, check=True):
-        calls.append(cmd)
+    def fake_issue(title, body):
+        calls.append(SimpleNamespace(title=title, body=body))
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(pester_failures, "create_issue", fake_issue)
+    monkeypatch.setenv("RUN_URL", "http://run")
+    monkeypatch.setenv("COMMIT_SHA", "deadbeef")
+    monkeypatch.setenv("BRANCH_NAME", "feat")
     pester_failures.report_failures(xml)
 
-    assert calls == [["gh", "issue", "create", "-t", "Fail.Test", "-b", "boom"]]
+    assert len(calls) == 1
+    assert calls[0].title == "Fail.Test"
+    assert "boom" in calls[0].body
+    assert "http://run" in calls[0].body


### PR DESCRIPTION
## Summary
- check out repo before parsing test artifacts
- pass run metadata to test issue scripts
- handle repo name in issue creation
- enrich pester/pytest issue bodies with run info
- expand tests for new functionality

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cad1748883319d316295648acd9b