### PR TITLE
Improve OpenTofu init fallback

### DIFF
--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -133,11 +133,11 @@ provider "hyperv" {
 }
 
 # --------------------------------------------------
-# 3) Check if tofu is in the PATH. If not, add it.
+# 3) Check if tofu is in the PATH. If not, attempt install and/or add it.
 # --------------------------------------------------
 $tofuCmd = Get-Command tofu -ErrorAction SilentlyContinue
 if (-not $tofuCmd) {
-    $defaultTofuExe = Join-Path $env:USERPROFILE -ChildPath "AppData\\Local\\Programs\\OpenTofu\\tofu.exe"
+    $defaultTofuExe = Join-Path $env:LOCALAPPDATA -ChildPath "Programs\\OpenTofu\\tofu.exe"
     if (Test-Path $defaultTofuExe) {
         Write-CustomLog "Tofu command not found in PATH. Adding its folder to the session PATH..."
         $tofuFolder = Split-Path -Path $defaultTofuExe
@@ -145,14 +145,18 @@ if (-not $tofuCmd) {
         $tofuCmd = Get-Command tofu -ErrorAction SilentlyContinue
         if (-not $tofuCmd) {
             Write-Warning "Even after updating PATH, tofu command is not recognized."
-        }
-        else {
+        } else {
             Write-CustomLog "Tofu command found: $($tofuCmd.Path)"
         }
-    }
-    else {
-        Write-Error "Tofu executable not found at $defaultTofuExe. Please install OpenTofu or update your PATH."
-        exit 1
+    } else {
+        Write-Warning "Tofu executable not found at $defaultTofuExe. Attempting installation via 0008_Install-OpenTofu.ps1..."
+        . "$PSScriptRoot/0008_Install-OpenTofu.ps1"
+        Install-OpenTofu -Config $Config
+        $tofuCmd = Get-Command tofu -ErrorAction SilentlyContinue
+        if (-not $tofuCmd) {
+            Write-Error "Tofu still not found after installation. Please ensure OpenTofu is installed and in PATH."
+            exit 1
+        }
     }
 }
 

--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -98,4 +98,67 @@ Describe 'Initialize-OpenTofu script' {
 
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
+
+    It 'installs OpenTofu when tofu command is missing' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid())
+        $env:LOCALAPPDATA = $tempDir
+        $config = [pscustomobject]@{
+            InitializeOpenTofu = $true
+            InfraRepoUrl  = 'https://example.com/repo.git'
+            InfraRepoPath = $tempDir
+            HyperV        = @{}
+            CosignPath    = 'C:\\temp'
+            OpenTofuVersion = 'latest'
+        }
+
+        $script:getCalls = 0
+        Mock Get-Command {
+            param($Name)
+            if ($Name -eq 'gh') { return @{ Name = 'gh' } }
+            if ($Name -eq 'tofu') {
+                $script:getCalls++
+                if ($script:getCalls -eq 1) { return $null } else { return @{ Name = 'tofu' } }
+            }
+        }
+        function global:gh {}
+        function global:tofu {}
+        Mock gh { $global:LASTEXITCODE = 0 }
+        Mock git {}
+        Mock tofu {}
+        Mock Invoke-OpenTofuInstaller {}
+
+        & $script:ScriptPath -Config $config
+
+        Should -Invoke -CommandName Invoke-OpenTofuInstaller -Times 1
+        Should -Invoke -CommandName tofu -Times 1 -ParameterFilter { $args[0] -eq 'init' }
+
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
+
+    It 'throws when installation does not make tofu available' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid())
+        $env:LOCALAPPDATA = $tempDir
+        $config = [pscustomobject]@{
+            InitializeOpenTofu = $true
+            InfraRepoUrl  = 'https://example.com/repo.git'
+            InfraRepoPath = $tempDir
+            HyperV        = @{}
+            CosignPath    = 'C:\\temp'
+            OpenTofuVersion = 'latest'
+        }
+
+        Mock Get-Command {
+            param($Name)
+            if ($Name -eq 'gh') { return @{ Name = 'gh' } }
+            if ($Name -eq 'tofu') { return $null }
+        }
+        function global:gh {}
+        Mock gh { $global:LASTEXITCODE = 0 }
+        Mock git {}
+        Mock Invoke-OpenTofuInstaller {}
+
+        { & $script:ScriptPath -Config $config } | Should -Throw 'Tofu still not found after installation'
+
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
 }


### PR DESCRIPTION
## Summary
- auto install OpenTofu if tofu command is missing
- add tests for missing tofu path

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d080612c833186d878c1cd2e5e5c