### PR TITLE
Fix run ID handling in issue-on-fail workflow

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -37,8 +37,9 @@ jobs:
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+        # Use the triggering run ID unless RUN_ID is explicitly provided
         run: |
-          run_id=${{ github.event.workflow_run.id }}
+          run_id="${RUN_ID:-${{ github.event.workflow_run.id }}}"
           gh run download "$run_id" -n 'pester-results-*' -D artifacts
           gh run download "$run_id" -n 'pytest-results-*' -D artifacts
           find artifacts -name testResults.xml -print0 | while IFS= read -r -d '' f; do


### PR DESCRIPTION
## Summary
- allow overriding run ID when downloading artifacts

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d2b888c483319c0b71aebc5e4ed6