### PR TITLE
Update Invoke-Scripts config handling

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -290,6 +290,9 @@ function Invoke-Scripts {
 
             Remove-Item $tempCfg -ErrorAction SilentlyContinue
 
+            $Config | ConvertTo-Json -Depth 5 |
+                Out-File -FilePath $ConfigFile -Encoding utf8
+
             $results[$s.Name] = $exitCode
             if ($exitCode) {
                 Write-CustomLog "ERROR: $($s.Name) exited with code $exitCode."

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -227,11 +227,15 @@ if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath "$out" } else { Wri
         Push-Location $tempDir
         Mock Read-Host { throw 'Read-Host should not be called' }
         & "$tempDir/runner.ps1" -Scripts '0001' -Auto -ConfigFile $configFile -Force | Out-Null
-        $updated = Get-Content -Raw $configFile | ConvertFrom-Json
+        $updated1 = Get-Content -Raw $configFile | ConvertFrom-Json
+
+        & "$tempDir/runner.ps1" -Scripts '0001' -Auto -ConfigFile $configFile | Out-Null
+        $updated2 = Get-Content -Raw $configFile | ConvertFrom-Json
         Pop-Location
 
         Test-Path $out | Should -BeTrue
-        $updated.RunFoo | Should -BeTrue
+        $updated1.RunFoo | Should -BeTrue
+        $updated2.RunFoo | Should -BeTrue
 
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
@@ -252,11 +256,15 @@ if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath "$out" }
         Push-Location $tempDir
         Mock Read-Host { throw 'Read-Host should not be called' }
         & "$tempDir/runner.ps1" -Scripts '0001' -Auto -ConfigFile $configFile | Out-Null
-        $updated = Get-Content -Raw $configFile | ConvertFrom-Json
+        $updated1 = Get-Content -Raw $configFile | ConvertFrom-Json
+
+        & "$tempDir/runner.ps1" -Scripts '0001' -Auto -ConfigFile $configFile | Out-Null
+        $updated2 = Get-Content -Raw $configFile | ConvertFrom-Json
         Pop-Location
 
         Test-Path $out | Should -BeFalse
-        $updated.RunFoo | Should -BeFalse
+        $updated1.RunFoo | Should -BeFalse
+        $updated2.RunFoo | Should -BeFalse
 
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
## Summary
- write the current configuration to disk after each script finishes
- test Runner behaviour using the updated config file each run

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_6848d31ca574833187a42417f1f9ca7d