### PR TITLE
Define Hyper-V cert helpers without guards

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -1,7 +1,6 @@
 Param([pscustomobject]$Config)
 . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 
-if (-not (Get-Command Convert-CerToPem -ErrorAction SilentlyContinue)) {
 function Convert-CerToPem {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -21,9 +20,7 @@ function Convert-CerToPem {
     $b64   = [System.Convert]::ToBase64String($bytes, 'InsertLineBreaks')
     "-----BEGIN CERTIFICATE-----`n$b64`n-----END CERTIFICATE-----" | Set-Content -Path $PemPath
 }
-}
 
-if (-not (Get-Command Convert-PfxToPem -ErrorAction SilentlyContinue)) {
 function Convert-PfxToPem {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -54,7 +51,6 @@ function Convert-PfxToPem {
     if ($PSCmdlet.ShouldProcess($KeyPath, 'Write key PEM')) {
         "-----BEGIN PRIVATE KEY-----`n$keyB64`n-----END PRIVATE KEY-----" | Set-Content -Path $KeyPath
     }
-}
 }
 
 function Get-HyperVProviderVersion {

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -218,13 +218,6 @@ Describe 'Convert certificate helpers honour -WhatIf' -Skip:($SkipNonWindows) {
 
 Describe 'Convert certificate helpers validate paths' -Skip:($SkipNonWindows) {
     BeforeAll {
-        if (Get-Command Remove-Mock -ErrorAction SilentlyContinue) {
-            Remove-Mock Convert-CerToPem -ErrorAction SilentlyContinue
-            Remove-Mock Convert-PfxToPem -ErrorAction SilentlyContinue
-        } else {
-            Remove-Item Function:Convert-CerToPem -ErrorAction SilentlyContinue
-            Remove-Item Function:Convert-PfxToPem -ErrorAction SilentlyContinue
-        }
         $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
     }


### PR DESCRIPTION
## Summary
- expose `Convert-CerToPem` and `Convert-PfxToPem` always
- clean up `PrepareHyperVProvider` tests
- run `Invoke-Pester` to ensure the test suite still passes (none run on Linux)

## Testing
- `pwsh -NoLogo -NoProfile -File /tmp/run_pester.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6848d2d35afc8331acf0dee439f98fd5