### PR TITLE
Fix runner script imports

### DIFF
--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -56,7 +56,6 @@ function Find-Gpg {
     }
 }
 
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0006_Install-ValidationTools.ps1'
 

--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -1,3 +1,4 @@
+Param([pscustomobject]$Config)
 . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 function Invoke-OpenTofuInstaller {
     param(
@@ -16,7 +17,6 @@ function Install-OpenTofu {
     [CmdletBinding()]
     param([pscustomobject]$Config)
 
-    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
     Invoke-LabStep -Config $Config -Body {
         Write-CustomLog 'Running 0008_Install-OpenTofu.ps1'
 

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -85,7 +85,6 @@ function Get-HyperVProviderVersion {
     return $defaultVersion
 }
 
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 if ($MyInvocation.InvocationName -ne '.') {
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0010_Prepare-HyperVProvider.ps1'

--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -1,11 +1,9 @@
-[CmdletBinding(SupportsShouldProcess = $true)]
 Param([pscustomobject]$Config)
 . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 function Install-CA {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)
 
-    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
     Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0104_Install-CA.ps1'
 
@@ -55,7 +53,6 @@ if ($PSCmdlet.ShouldProcess($CAName, 'Configure Standalone Root CA')) {
     $installCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
     if (-not $installCmd) {
         if (Get-Module -ListAvailable -Name ADCSDeployment) {
-            Import-Module ADCSDeployment -ErrorAction SilentlyContinue
             $installCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
         }
     }

--- a/runner_scripts/0106_Install-WAC.ps1
+++ b/runner_scripts/0106_Install-WAC.ps1
@@ -16,7 +16,6 @@ function Get-WacRegistryInstallation {
     return $null
 }
 
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0106_Install-WAC.ps1'
 

--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -11,11 +11,7 @@ function Get-SystemInfo {
         [pscustomobject]$Config
     )
 
-    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
     Invoke-LabStep -Config $Config -Body {
-        if (-not (Get-Command Get-Platform -ErrorAction SilentlyContinue)) {
-            . "$PSScriptRoot/../lab_utils/Get-Platform.ps1"
-        }
         Write-CustomLog 'Running 0200_Get-SystemInfo.ps1'
         $platform = Get-Platform
         Write-CustomLog "Detected platform: $platform"
@@ -117,13 +113,11 @@ function Get-SystemInfo {
                 Write-CustomLog "Unsupported platform: $platform" -Level 'ERROR'
                 exit 1
             }
-        }
 
         if ($AsJson) {
             $info | ConvertTo-Json -Depth 5
         } else {
             $info
-        }
     }
 }
 

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -5,7 +5,6 @@ function Install-NodeCore {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)
 
-    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
     Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0201_Install-NodeCore.ps1'
 <#

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -24,7 +24,6 @@ function Install-NodeGlobalPackages {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)
 
-    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
     Invoke-LabStep -Config $Config -Body {
     param($Config)
     Write-CustomLog 'Running 0202_Install-NodeGlobalPackages.ps1'

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -8,7 +8,6 @@ function Install-NpmDependencies {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)
 
-    . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 
     Invoke-LabStep -Config $Config -Body {
         param($Config)

--- a/runner_scripts/9999_Reset-Machine.ps1
+++ b/runner_scripts/9999_Reset-Machine.ps1
@@ -1,9 +1,6 @@
 Param([pscustomobject]$Config)
 . "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
 Invoke-LabStep -Config $Config -Body {
-    if (-not (Get-Command Get-Platform -ErrorAction SilentlyContinue)) {
-        . "$PSScriptRoot/../lab_utils/Get-Platform.ps1"
-    }
     Write-CustomLog 'Running 9999_Reset-Machine.ps1'
     $platform = Get-Platform
     Write-CustomLog "Detected platform: $platform"
@@ -29,5 +26,4 @@ Invoke-LabStep -Config $Config -Body {
     } else {
         Write-CustomLog 'Unknown platform; cannot reset.'
         exit 1
-    }
 }


### PR DESCRIPTION
## Summary
- clean up duplicate `ScriptTemplate.ps1` imports
- remove extra imports from functions
- ensure each runner script starts with `Param([pscustomobject]$Config)` and a single dot-source line

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile 'tests/PesterConfiguration.psd1')`

------
https://chatgpt.com/codex/tasks/task_e_6848d2ed9ae48331a26cf981f0d77488