### PR TITLE
Fix runner script discovery path

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding(SupportsShouldProcess)]
 param(
-    [string]$ConfigFile = "./config_files/default-config.json",
+    [string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files' 'default-config.json'),
     [switch]$Auto,
     [string]$Scripts,
     [switch]$Force,
@@ -214,7 +214,7 @@ if (-not $Auto) {
 
 # ─── Discover scripts ────────────────────────────────────────────────────────
 Write-CustomLog "==== Locating scripts ===="
-$ScriptFiles = Get-ChildItem .\runner_scripts -Filter "????_*.ps1" -File | Sort-Object Name
+$ScriptFiles = Get-ChildItem (Join-Path $PSScriptRoot 'runner_scripts') -Filter "????_*.ps1" -File | Sort-Object Name
 if (-not $ScriptFiles) {
     Write-CustomLog "ERROR: No scripts found matching pattern."
     exit 1


### PR DESCRIPTION
## Summary
- look for `runner_scripts` relative to script directory
- use absolute path for default config file

## Testing
- `pytest`
- ❌ `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d9dc7ba4833194375c251ea18a92