### PR TITLE
Fix Get-SystemInfo script

### DIFF
--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -113,11 +113,13 @@ function Get-SystemInfo {
                 Write-CustomLog "Unsupported platform: $platform" -Level 'ERROR'
                 exit 1
             }
+        }
 
         if ($AsJson) {
             $info | ConvertTo-Json -Depth 5
         } else {
             $info
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- fix missing braces in `0200_Get-SystemInfo.ps1`
- Python and PowerShell tests pass locally

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_6848db0cd41883318dbb837863d169fb