### PR TITLE
Fix missing Get-Platform import

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -41,6 +41,7 @@ if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
 $env:LAB_CONSOLE_LEVEL = $script:VerbosityLevels[$Verbosity]
 . (Join-Path $PSScriptRoot 'lab_utils' 'Get-LabConfig.ps1')
 . (Join-Path $PSScriptRoot 'lab_utils' 'Format-Config.ps1')
+. (Join-Path $PSScriptRoot 'lab_utils' 'Get-Platform.ps1')
 $menuPath = Join-Path $PSScriptRoot 'lab_utils' 'Menu.ps1'
 if (-not (Test-Path $menuPath)) {
     Write-Error "Menu module not found at $menuPath"

--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -49,30 +49,26 @@ Describe 'runner.ps1 executing 0200_Get-SystemInfo' {
             $null = New-Item -ItemType Directory -Path $scriptsDir
             Copy-Item $script:ScriptPath -Destination $scriptsDir
 
-            Push-Location $tempDir
-            $script:logLines = @()
-            function global:Write-Host {
-                param([Parameter(Mandatory=$true,Position=0)][string]$Object,
-                      [Parameter(Position=1)][string]$ForegroundColor)
-                $script:logLines += $Object
-            }
-            & "$tempDir/runner.ps1" -Scripts '0200' -Auto | Out-Null
-            Pop-Location
+        Push-Location $tempDir
+        $pwsh = (Get-Command pwsh).Source
+        $output = & $pwsh -NoLogo -NoProfile -File './runner.ps1' -Scripts '0200' -Auto
+        $code   = $LASTEXITCODE
+        Pop-Location
 
-            $text = $script:logLines -join [Environment]::NewLine
-            $text | Should -Match 'ComputerName'
-            $text | Should -Match 'IPAddresses'
-            $text | Should -Match 'OSVersion'
-            $text | Should -Match 'DiskInfo'
-            if ($IsWindows) {
-                $text | Should -Match 'RolesFeatures'
-                $text | Should -Match 'LatestHotfix'
-            }
+        $code | Should -Be 0
+        $text = $output -join [Environment]::NewLine
+        $text | Should -Match 'ComputerName'
+        $text | Should -Match 'IPAddresses'
+        $text | Should -Match 'OSVersion'
+        $text | Should -Match 'DiskInfo'
+        if ($IsWindows) {
+            $text | Should -Match 'RolesFeatures'
+            $text | Should -Match 'LatestHotfix'
+        }
 
         }
         finally {
             Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
-            Remove-Item Function:Write-Host -ErrorAction SilentlyContinue
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `Get-Platform.ps1` is loaded by `runner.ps1`
- update system info test to run `runner.ps1` in a clean process

## Testing
- `Invoke-Pester`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848dd451810833183b5523c9be3612d