### PR TITLE
Switch runner scripts to LabRunner module

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -63,3 +63,14 @@ Individual scripts can also be executed directly:
 ```powershell
 pwsh -File runner_scripts/0001_Reset-Git.ps1 -Config ./config_files/default-config.json
 ```
+
+Step scripts import a small PowerShell module that provides common helpers:
+
+```powershell
+Param([pscustomobject]$Config)
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
+```
+
+`LabRunner` exposes functions like `Invoke-LabStep`, `Write-CustomLog` and
+`Get-Platform` so every script shares the same logging and platform detection
+logic.

--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0000_Cleanup-Files.ps1'
 

--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0001_Reset-Git.ps1'
 

--- a/runner_scripts/0002_Setup-Directories.ps1
+++ b/runner_scripts/0002_Setup-Directories.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0002_Setup-Directories.ps1'
 

--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 
 function Install-Cosign {
     [CmdletBinding(SupportsShouldProcess)]

--- a/runner_scripts/0007_Install-Go.ps1
+++ b/runner_scripts/0007_Install-Go.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0007_Install-Go.ps1'
 if ($Config.InstallGo -eq $true) {

--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 function Invoke-OpenTofuInstaller {
     param(
         [string]$CosignPath,

--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0009_Initialize-OpenTofu.ps1'
 <#

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 
 function Convert-CerToPem {
     [CmdletBinding(SupportsShouldProcess)]

--- a/runner_scripts/0100_Enable-WinRM.ps1
+++ b/runner_scripts/0100_Enable-WinRM.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0100_Enable-WinRM.ps1'
 

--- a/runner_scripts/0101_Enable-RemoteDesktop.ps1
+++ b/runner_scripts/0101_Enable-RemoteDesktop.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0101_Enable-RemoteDesktop.ps1'
 

--- a/runner_scripts/0102_Configure-Firewall.ps1
+++ b/runner_scripts/0102_Configure-Firewall.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0102_Configure-Firewall.ps1'
 

--- a/runner_scripts/0103_Change-ComputerName.ps1
+++ b/runner_scripts/0103_Change-ComputerName.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0103_Change-ComputerName.ps1'
 

--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 function Install-CA {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)

--- a/runner_scripts/0105_Install-HyperV.ps1
+++ b/runner_scripts/0105_Install-HyperV.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0105_Install-HyperV.ps1'
 

--- a/runner_scripts/0106_Install-WAC.ps1
+++ b/runner_scripts/0106_Install-WAC.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 
 function Get-WacRegistryInstallation {
     param(

--- a/runner_scripts/0111_Disable-TCPIP6.ps1
+++ b/runner_scripts/0111_Disable-TCPIP6.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0111_Disable-TCPIP6.ps1'
 

--- a/runner_scripts/0112_Enable-PXE.ps1
+++ b/runner_scripts/0112_Enable-PXE.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0112_Enable-PXE.ps1'
 

--- a/runner_scripts/0113_Config-DNS.ps1
+++ b/runner_scripts/0113_Config-DNS.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0113_Config-DNS.ps1'
 

--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0114_Config-TrustedHosts.ps1'
 

--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -3,7 +3,7 @@ Param(
     [switch]$AsJson
 )
 
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 function Get-SystemInfo {
     [CmdletBinding()]
     param(

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 
 function Install-NodeCore {
     [CmdletBinding(SupportsShouldProcess = $true)]

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 
 function Install-GlobalPackage {
     [CmdletBinding(SupportsShouldProcess)]

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -3,7 +3,7 @@ Param(
     [pscustomobject]$Config
 )
 
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 function Install-NpmDependencies {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param([pscustomobject]$Config)

--- a/runner_scripts/9999_Reset-Machine.ps1
+++ b/runner_scripts/9999_Reset-Machine.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-. "$PSScriptRoot/../runner_utility_scripts/ScriptTemplate.ps1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 9999_Reset-Machine.ps1'
     $platform = Get-Platform

--- a/runner_utility_scripts/LabRunner.psd1
+++ b/runner_utility_scripts/LabRunner.psd1
@@ -1,0 +1,7 @@
+@{
+    RootModule = 'LabRunner.psm1'
+    ModuleVersion = '0.1.0'
+    GUID = 'c0000000-0000-4000-8000-000000000001'
+    Author = 'OpenTofu'
+    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Get-Platform')
+}

--- a/runner_utility_scripts/LabRunner.psm1
+++ b/runner_utility_scripts/LabRunner.psm1
@@ -1,0 +1,6 @@
+#. dot-source utilities
+. $PSScriptRoot/ScriptTemplate.ps1
+. $PSScriptRoot/Logger.ps1
+. $PSScriptRoot/../lab_utils/Get-Platform.ps1
+
+Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform

--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -6,7 +6,7 @@ if ($SkipNonWindows) { return }
 
 Describe '0200_Get-SystemInfo' {
     BeforeAll {
-        . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')
+        Import-Module (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'LabRunner.psd1')
         $script:ScriptPath = Get-RunnerScriptPath '0200_Get-SystemInfo.ps1'
     }
 


### PR DESCRIPTION
## Summary
- create `LabRunner` module and manifest
- update all runner scripts to import the new module
- adjust tests for updated import pattern
- document usage of the module in `runner.md`

## Testing
- `Invoke-Pester` *(fails: `pwsh` not found)*
- `pytest -q` *(fails: ImportError: Typer)*

------
https://chatgpt.com/codex/tasks/task_e_6848e6cf0c7483318be55621e825962b