### PR TITLE
Fix hyperv provider tests

### DIFF
--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -15,7 +15,6 @@ BeforeAll {
 }
 Describe 'Prepare-HyperVProvider path restoration' -Skip:($SkipNonWindows) {
     It 'restores location after execution' {
-        . (Join-Path $script:testRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $script:scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         $config = [pscustomobject]@{
             PrepareHyperVHost = $true
@@ -71,7 +70,6 @@ Describe 'Prepare-HyperVProvider path restoration' -Skip:($SkipNonWindows) {
 Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
     It 'creates PEM files and updates providers.tf' {
 
-        . (Join-Path $script:testRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $script:scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
 


### PR DESCRIPTION
## Summary
- clean up redundant Logger import in Hyper-V provider tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command ""` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ee35b74883319bbc010f0c45a2cc