### PR TITLE
Fix Reset-Machine parse error

### DIFF
--- a/runner_scripts/9999_Reset-Machine.ps1
+++ b/runner_scripts/9999_Reset-Machine.ps1
@@ -26,4 +26,5 @@ Invoke-LabStep -Config $Config -Body {
     } else {
         Write-CustomLog 'Unknown platform; cannot reset.'
         exit 1
+    }
 }


### PR DESCRIPTION
## Summary
- ensure 9999_Reset-Machine.ps1 closes its Invoke-LabStep block

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: pwsh not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6848ee8151dc83318c3c97d1ca8a4b21