### PR TITLE
Fix runner.ps1 tests by stubbing Get-Platform

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -51,6 +51,8 @@ Describe 'runner.ps1 script selection' -Skip:($SkipNonWindows) {
                 Set-Content -Path (Join-Path $labs 'Get-LabConfig.ps1')
             'function Format-Config { param($Config) $Config | ConvertTo-Json -Depth 5 }' |
                 Set-Content -Path (Join-Path $labs 'Format-Config.ps1')
+            'function Get-Platform { if ($IsWindows) { "Windows" } elseif ($IsLinux) { "Linux" } elseif ($IsMacOS) { "MacOS" } else { "Unknown" } }' |
+                Set-Content -Path (Join-Path $labs 'Get-Platform.ps1')
             'function Get-MenuSelection { }' |
                 Set-Content -Path (Join-Path $labs 'Menu.ps1')
 


### PR DESCRIPTION
## Summary
- stub `Get-Platform` in `New-RunnerTestEnv` to avoid missing script error

## Testing
- `poetry run pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848eea3a94c8331b7a0fec5fcc07f25