### PR TITLE
Fix Format-Config null pipeline test

### DIFF
--- a/docs/windows-test-failures.md
+++ b/docs/windows-test-failures.md
@@ -10,8 +10,6 @@ Older versions attempted to fetch `pester-results-*` or `pytest-results-*` with 
 
 | Test Name | Error Message |
 |-----------|--------------|
-| Format-Config.is a terminating error when Config is null | ParameterBindingException: The input object cannot be bound to any parameters for the command either because the command does not take pipeline input or the input and its properties do not match any of the parameters that take pipeline input. |
-| Format-Config.is a terminating error when piped null | ParameterBindingException: The input object cannot be bound to any parameters for the command either because the command does not take pipeline input or the input and its properties do not match any of the parameters that take pipeline input. |
 | runner.ps1 executing 0200_Get-SystemInfo.outputs system info when run via runner | Expected regular expression 'ComputerName' to match <empty>, but it did not match. |
 | Get-WindowsJobArtifacts.uses gh CLI when authenticated | Expected gh.exe to be called at least 1 times, but was called 0 times |
 | Get-WindowsJobArtifacts.falls back to nightly.link when gh auth fails | Expected Invoke-WebRequest to be called at least 1 times, but was called 0 times |

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -28,6 +28,6 @@ Describe 'Format-Config' {
     }
 
     It 'is a terminating error when piped null' {
-        { $null | Format-Config } | Should -Throw -ErrorType System.ArgumentNullException
+        { ,$null | Format-Config } | Should -Throw -ErrorType System.ArgumentNullException
     }
 }


### PR DESCRIPTION
## Summary
- update `Format-Config` test to use an explicit null pipeline element
- remove outdated `Format-Config` entries from Windows failures docs

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_6848ef321fb48331b70bec39434ef46a