### PR TITLE
Fix Windows artifact helper and installer path

### DIFF
--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -1,5 +1,6 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
+$scriptRoot = $PSScriptRoot
+Import-Module "$scriptRoot/../runner_utility_scripts/LabRunner.psd1"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog 'Running 0009_Initialize-OpenTofu.ps1'
 <#
@@ -30,7 +31,7 @@ if ($Config.InitializeOpenTofu -eq $true) {
 
     # Fallback if InfraRepoPath is not specified
     if ([string]::IsNullOrWhiteSpace($infraRepoPath)) {
-        $infraRepoPath = Join-Path $PSScriptRoot "my-infra"
+        $infraRepoPath = Join-Path $scriptRoot "my-infra"
     }
 
     Write-CustomLog "Using InfraRepoPath: $infraRepoPath"
@@ -154,7 +155,7 @@ if (-not $tofuCmd) {
         }
     } else {
         Write-Warning "Tofu executable not found at $defaultTofuExe. Attempting installation..."
-        . "$PSScriptRoot/0008_Install-OpenTofu.ps1"
+        . "$scriptRoot/0008_Install-OpenTofu.ps1"
         $cosign   = Join-Path $Config.CosignPath 'cosign-windows-amd64.exe'
         $version  = if ($Config.OpenTofuVersion) { $Config.OpenTofuVersion } else { 'latest' }
         Invoke-OpenTofuInstaller -CosignPath $cosign -OpenTofuVersion $version


### PR DESCRIPTION
## Summary
- correct GitHub CLI argument handling and JSON parsing in `Get-WindowsJobArtifacts.ps1`
- preserve script root when invoking `Initialize-OpenTofu` so it can dot-source installer script

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration tests/PesterConfiguration.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f362be048331bf2faa56d5525d64