### PR TITLE
Fix Get-WindowsJobArtifacts auth check

### DIFF
--- a/lab_utils/Get-WindowsJobArtifacts.ps1
+++ b/lab_utils/Get-WindowsJobArtifacts.ps1
@@ -11,7 +11,7 @@ New-Item -ItemType Directory -Path $tempDir | Out-Null
 $useGh = $false
 if (Get-Command gh -ErrorAction SilentlyContinue) {
     try {
-        gh 'auth status' --hostname github.com *> $null
+        gh auth status --hostname github.com *> $null
         $useGh = $true
     } catch {
         Write-Host 'gh authentication failed; using public download URLs.' -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- fix argument list for `gh auth status`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f5f0db24833195d5df6b0165356b