### PR TITLE
Ensure CA installation gated by ShouldProcess

### DIFF
--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -60,7 +60,7 @@ if ($PSCmdlet.ShouldProcess($CAName, 'Configure Standalone Root CA')) {
         Write-CustomLog 'Install-AdcsCertificationAuthority command not found. Ensure AD CS features are available.'
         return
     }
-    Install-AdcsCertificationAuthority `
+    & $installCmd `
         -CAType StandaloneRootCA `
         -CACommonName $CAName `
         -KeyLength 2048 `

--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -38,6 +38,24 @@ Describe '0104_Install-CA script' {
         }
     }
 
+    It 'honours -WhatIf for CA installation' -Skip:($SkipNonWindows) {
+        . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+        $config = [pscustomobject]@{
+            InstallCA = $true
+            CertificateAuthority = @{ CommonName = 'TestCA'; ValidityYears = 1 }
+        }
+        Mock-WriteLog
+        Mock Get-WindowsFeature { @{ Installed = $false } } -ParameterFilter { $Name -eq 'Adcs-Cert-Authority' }
+        Mock Install-WindowsFeature {}
+        Mock Get-Item { $null }
+        function global:Install-AdcsCertificationAuthority {}
+        Mock Install-AdcsCertificationAuthority {}
+
+        & $scriptPath -Config $config -WhatIf
+
+        Should -Invoke -CommandName Install-AdcsCertificationAuthority -Times 0
+    }
+
     It 'skips CA installation when InstallCA is false' -Skip:($SkipNonWindows) {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
         $config = [pscustomobject]@{


### PR DESCRIPTION
## Summary
- call `Install-AdcsCertificationAuthority` only when command is found
- verify `-WhatIf` prevents CA install in tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6848f5f7cf8083318d39510adcc05783