### PR TITLE
Fix runner auto flow and logging

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -405,7 +405,7 @@ exit 0
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
         @"
 Param([PSCustomObject]`$Config)
-Write-Output 'hello world'
+Write-CustomLog 'hello world'
 "@ | Set-Content -Path (Join-Path $scriptsDir '0001_Echo.ps1')
 
         Push-Location $tempDir


### PR DESCRIPTION
## Summary
- allow `-Force` to skip flag checks and run the step
- avoid duplicate logging from scripts
- rework menu loop for `-Auto`
- update unit test for new logging behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f605e960833196603a396b126bc1