### PR TITLE
Show system info in runner output

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -286,6 +286,7 @@ function Invoke-Scripts {
                     Write-Warning $line.ToString()
                 } else {
                     Write-CustomLog $line.ToString()
+                    Write-Output $line
 
                 }
             }

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -419,6 +419,25 @@ Write-Output 'hello world'
 
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
+
+    It 'pipes Get-SystemInfo output to the caller' {
+        $tempDir   = New-RunnerTestEnv
+        $scriptsDir = Join-Path $tempDir 'runner_scripts'
+        Copy-Item (Join-Path $PSScriptRoot '..' 'runner_scripts' '0200_Get-SystemInfo.ps1') -Destination $scriptsDir
+        Copy-Item (Join-Path $PSScriptRoot '..' 'runner_utility_scripts') -Destination $tempDir -Recurse
+        Copy-Item (Join-Path $PSScriptRoot '..' 'lab_utils') -Destination $tempDir -Recurse
+        Copy-Item (Join-Path $PSScriptRoot '..' 'config_files') -Destination (Join-Path $tempDir 'config_files') -Recurse
+
+        Push-Location $tempDir
+        $pwsh = (Get-Command pwsh).Source
+        $output = & $pwsh -NoLogo -NoProfile -File './runner.ps1' -Scripts '0200' -Auto
+        Pop-Location
+
+        $text = $output -join [Environment]::NewLine
+        $text | Should -Match 'ComputerName'
+
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
 }
 
 Describe 'Set-LabConfig' {


### PR DESCRIPTION
## Summary
- pipe script output to the console in `runner.ps1`
- add Pester test ensuring `Get-SystemInfo` data is surfaced

## Testing
- `pwsh -NoLogo -NoProfile -Command '$cfg = Invoke-Expression (Get-Content tests/PesterConfiguration.psd1 -Raw); Invoke-Pester -Configuration $cfg'`

------
https://chatgpt.com/codex/tasks/task_e_6848f5e860f48331b1817ebb9d34921a