### PR TITLE
Fix Windows artifacts script catch block

### DIFF
--- a/lab_utils/Get-WindowsJobArtifacts.ps1
+++ b/lab_utils/Get-WindowsJobArtifacts.ps1
@@ -13,7 +13,8 @@ if (Get-Command gh -ErrorAction SilentlyContinue) {
     try {
         gh auth status --hostname github.com *> $null
         $useGh = $true
-    } else {
+    }
+    catch {
         Write-Host 'gh authentication failed; using public download URLs.' -ForegroundColor Yellow
     }
 }


### PR DESCRIPTION
## Summary
- fix try/catch logic in `Get-WindowsJobArtifacts.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fc439fb8833198fa4b7d2cfd4157