### PR TITLE
Fix detection of LabRunner import in runner tests

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -77,7 +77,10 @@ Describe 'Runner scripts parameter and command checks' -Skip:($SkipNonWindows) {
         $found = $commands | Where-Object {
             $_.GetCommandName() -eq 'Import-Module' -and
             $_.CommandElements.Count -ge 2 -and
-            ($_.CommandElements[1] -is [System.Management.Automation.Language.StringConstantExpressionAst]) -and
+            (
+                $_.CommandElements[1] -is [System.Management.Automation.Language.StringConstantExpressionAst] -or
+                $_.CommandElements[1] -is [System.Management.Automation.Language.ExpandableStringExpressionAst]
+            ) -and
             ([System.IO.Path]::GetFileName($_.CommandElements[1].Value) -eq 'LabRunner.psd1')
         }
 


### PR DESCRIPTION
## Summary
- ensure test accepts expandable string ASTs when verifying `Import-Module`

## Testing
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849008b25748331abc8d4f477a0d1ad