### PR TITLE
Improve Format-Config parameter handling

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -1,7 +1,11 @@
 function Format-Config {
     [CmdletBinding()]
     param(
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            Mandatory = $true
+        )]
         [AllowNull()]
         [psobject]$Config
     )

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -18,6 +18,18 @@ Describe 'Format-Config' {
         $result | Should -Match '"Foo"\s*:\s*"pipe"'
     }
 
+    It 'accepts pipeline input by property name' {
+        $cfg = [pscustomobject]@{ Foo = 'prop' }
+        $wrapper = [pscustomobject]@{ Config = $cfg }
+        $result = $wrapper | Format-Config
+        $result | Should -Match '"Foo"\s*:\s*"prop"'
+    }
+
+    It 'fails when no Config is provided' {
+        { Format-Config } |
+            Should -Throw -ErrorType System.Management.Automation.ParameterBindingException
+    }
+
     It 'throws when Config is null' {
         { Format-Config -Config $null } | Should -Throw
     }


### PR DESCRIPTION
## Summary
- allow `Format-Config` to accept pipeline property input
- make `Config` mandatory
- test new property binding and mandatory behaviour

## Testing
- `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490199eb9c83319b851b3016a28fbc