### PR TITLE
Fix issue-on-fail labctl install

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -28,15 +28,18 @@ jobs:
             });
             const summary = jobs.map(j => `- [${j.name}](${j.html_url}) - ${j.conclusion}`).join('\n');
             const failed = jobs.filter(j => j.conclusion !== 'success').map(j => j.name).join(', ');
-            core.setOutput('summary', summary);
-            core.setOutput('failed', failed);
+          core.setOutput('summary', summary);
+          core.setOutput('failed', failed);
+
+      - name: Install labctl
+        run: python -m pip install --quiet ./py
 
       - name: Download test results and open issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
-          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
-          BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+        COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+        BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
         # Use the triggering run ID unless RUN_ID is explicitly provided
         run: |
           run_id="${RUN_ID:-${{ github.event.workflow_run.id }}}"


### PR DESCRIPTION
## Summary
- install labctl prior to parsing failures in the issue workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6849017db0e88331a24a63939ad8c00c