### PR TITLE
Update cert helper params to mandatory

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -5,15 +5,13 @@ if (-not (Get-Command Convert-CerToPem -ErrorAction SilentlyContinue)) {
 function Convert-CerToPem {
     [CmdletBinding(SupportsShouldProcess)]
     param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$CerPath,
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$PemPath
     )
-    if (-not $PSBoundParameters.ContainsKey('CerPath') -or [string]::IsNullOrWhiteSpace($CerPath)) {
-        throw 'Convert-CerToPem: CerPath is required'
-    }
-    if (-not $PSBoundParameters.ContainsKey('PemPath') -or [string]::IsNullOrWhiteSpace($PemPath)) {
-        throw 'Convert-CerToPem: PemPath is required'
-    }
     if (-not $PSCmdlet.ShouldProcess($PemPath, 'Create PEM file')) { return }
 
     $bytes = [System.IO.File]::ReadAllBytes($CerPath)
@@ -27,20 +25,17 @@ if (-not (Get-Command Convert-PfxToPem -ErrorAction SilentlyContinue)) {
 function Convert-PfxToPem {
     [CmdletBinding(SupportsShouldProcess)]
     param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$PfxPath,
         [securestring]$Password,
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$CertPath,
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
         [string]$KeyPath
     )
-    if (-not $PSBoundParameters.ContainsKey('PfxPath') -or [string]::IsNullOrWhiteSpace($PfxPath)) {
-        throw 'Convert-PfxToPem: PfxPath is required'
-    }
-    if (-not $PSBoundParameters.ContainsKey('CertPath') -or [string]::IsNullOrWhiteSpace($CertPath)) {
-        throw 'Convert-PfxToPem: CertPath is required'
-    }
-    if (-not $PSBoundParameters.ContainsKey('KeyPath') -or [string]::IsNullOrWhiteSpace($KeyPath)) {
-        throw 'Convert-PfxToPem: KeyPath is required'
-    }
     if (-not $PSCmdlet.ShouldProcess($PfxPath, 'Convert PFX to PEM')) { return }
     $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($PfxPath,$Password,[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
     $certBytes = $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -223,12 +223,12 @@ Describe 'Convert certificate helpers validate paths' -Skip:($SkipNonWindows) {
         $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
 
-        { Convert-CerToPem -CerPath '' -PemPath 'x' } | Should -Throw 'Convert-CerToPem: CerPath is required'
-        { Convert-CerToPem -CerPath '   ' -PemPath 'x' } | Should -Throw 'Convert-CerToPem: CerPath is required'
-        { Convert-CerToPem -PemPath 'x' } | Should -Throw 'Convert-CerToPem: CerPath is required'
-        { Convert-CerToPem -CerPath 'x' -PemPath '' } | Should -Throw 'Convert-CerToPem: PemPath is required'
-        { Convert-CerToPem -CerPath 'x' -PemPath '   ' } | Should -Throw 'Convert-CerToPem: PemPath is required'
-        { Convert-CerToPem -CerPath 'x' } | Should -Throw 'Convert-CerToPem: PemPath is required'
+        { Convert-CerToPem -CerPath '' -PemPath 'x' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-CerToPem -CerPath '   ' -PemPath 'x' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-CerToPem -PemPath 'x' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-CerToPem -CerPath 'x' -PemPath '' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-CerToPem -CerPath 'x' -PemPath '   ' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-CerToPem -CerPath 'x' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
     }
 
     It 'errors when PfxPath, CertPath, or KeyPath is missing' {
@@ -238,16 +238,16 @@ Describe 'Convert certificate helpers validate paths' -Skip:($SkipNonWindows) {
         foreach ($c in 'pw'.ToCharArray()) { $pwd.AppendChar($c) }
         $pwd.MakeReadOnly()
 
-        { Convert-PfxToPem -PfxPath '' -Password $pwd -CertPath 'c' -KeyPath 'k' } | Should -Throw 'Convert-PfxToPem: PfxPath is required'
-        { Convert-PfxToPem -PfxPath '   ' -Password $pwd -CertPath 'c' -KeyPath 'k' } | Should -Throw 'Convert-PfxToPem: PfxPath is required'
-        { Convert-PfxToPem -Password $pwd -CertPath 'c' -KeyPath 'k' } | Should -Throw 'Convert-PfxToPem: PfxPath is required'
+        { Convert-PfxToPem -PfxPath '' -Password $pwd -CertPath 'c' -KeyPath 'k' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-PfxToPem -PfxPath '   ' -Password $pwd -CertPath 'c' -KeyPath 'k' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-PfxToPem -Password $pwd -CertPath 'c' -KeyPath 'k' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
 
-        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath '' -KeyPath 'k' } | Should -Throw 'Convert-PfxToPem: CertPath is required'
-        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath '   ' -KeyPath 'k' } | Should -Throw 'Convert-PfxToPem: CertPath is required'
-        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -KeyPath 'k' } | Should -Throw 'Convert-PfxToPem: CertPath is required'
+        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath '' -KeyPath 'k' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath '   ' -KeyPath 'k' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -KeyPath 'k' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
 
-        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath 'c' -KeyPath '' } | Should -Throw 'Convert-PfxToPem: KeyPath is required'
-        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath 'c' -KeyPath '   ' } | Should -Throw 'Convert-PfxToPem: KeyPath is required'
-        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath 'c' } | Should -Throw 'Convert-PfxToPem: KeyPath is required'
+        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath 'c' -KeyPath '' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath 'c' -KeyPath '   ' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
+        { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath 'c' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
     }
 }


### PR DESCRIPTION
## Summary
- mark certificate helper parameters as mandatory and add validation attributes
- adjust tests for parameter binding errors

## Testing
- `Invoke-Pester -Configuration @{ Run = @{ Exit = $false }}`

------
https://chatgpt.com/codex/tasks/task_e_684901afe6208331804064fea718cd56