### PR TITLE
Fix Invoke-OpenTofuInstaller mocking

### DIFF
--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -4,7 +4,9 @@ Import-Module "$scriptRoot/../runner_utility_scripts/LabRunner.psd1"
 $installScript      = Join-Path $scriptRoot '0008_Install-OpenTofu.ps1'
 $installerAvailable = Test-Path $installScript
 if ($installerAvailable) {
-    . $installScript
+    if (-not (Get-Command Invoke-OpenTofuInstaller -ErrorAction SilentlyContinue)) {
+        . $installScript
+    }
 } else {
     Write-Warning "Install script '$installScript' not found. OpenTofu installation commands will be unavailable."
 }


### PR DESCRIPTION
## Summary
- fix OpenTofu initialization so mocks of `Invoke-OpenTofuInstaller` aren't overwritten

## Testing
- `Invoke-Pester`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684902f72b608331b804a6c677f3f911