### PR TITLE
Fix runner Quiet/Verbosity parameter sets

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -1,10 +1,25 @@
-[CmdletBinding(SupportsShouldProcess)]
+[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName='Normal')]
 param(
+    [Parameter(ParameterSetName='Normal')]
+    [Parameter(ParameterSetName='Quiet')]
     [string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files' 'default-config.json'),
+
+    [Parameter(ParameterSetName='Normal')]
+    [Parameter(ParameterSetName='Quiet')]
     [switch]$Auto,
+
+    [Parameter(ParameterSetName='Normal')]
+    [Parameter(ParameterSetName='Quiet')]
     [string]$Scripts,
+
+    [Parameter(ParameterSetName='Normal')]
+    [Parameter(ParameterSetName='Quiet')]
     [switch]$Force,
+
+    [Parameter(ParameterSetName='Quiet', Mandatory=$true)]
     [switch]$Quiet,
+
+    [Parameter(ParameterSetName='Normal')]
     [ValidateSet('silent','normal','detailed')]
     [string]$Verbosity = 'normal'
 )

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -328,6 +328,33 @@ Write-Error 'err message'
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
 
+    It 'suppresses informational logs when -Quiet is used' {
+        $tempDir   = New-RunnerTestEnv
+        $scriptsDir = Join-Path $tempDir 'runner_scripts'
+        @"
+Param([PSCustomObject]`$Config)
+Write-Warning 'warn message'
+Write-Error 'err message'
+"@ | Set-Content -Path (Join-Path $scriptsDir '0001_Log.ps1')
+
+        Push-Location $tempDir
+        $script:logLines = @()
+        $script:warnings = @()
+        $script:errors   = @()
+        function global:Write-Host { param([object]$Object,[string]$ForegroundColor) process { $script:logLines += "$Object" } }
+        function global:Write-Warning { param([string]$Message) $script:warnings += $Message }
+        function global:Write-Error   { param([string]$Message) $script:errors   += $Message }
+        $output = & "$tempDir/runner.ps1" -Scripts '0001' -Auto -Quiet *>&1
+        Pop-Location
+
+        ($script:logLines | Measure-Object).Count | Should -Be 0
+        ($output | Out-String).Trim()       | Should -BeEmpty
+        $script:warnings | Should -Contain 'warn message'
+        $script:errors   | Should -Contain 'err message'
+
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
+
     It 'suppresses informational logs when -Verbosity silent is used' {
         $tempDir   = New-RunnerTestEnv
         $scriptsDir = Join-Path $tempDir 'runner_scripts'


### PR DESCRIPTION
## Summary
- make `-Quiet` its own parameter set so it can't conflict with `-Verbosity`
- test `runner.ps1` with the `-Quiet` switch

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849030be4888331b1ecc7baa4acf20e