### PR TITLE
Run config flag persistance on force

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -261,10 +261,12 @@ function Invoke-Scripts {
                 if (-not $current) {
                     if ($Force) {
                         Set-NestedConfigValue -Config $Config -Path $flag -Value $true
+                        $Config | ConvertTo-Json -Depth 5 | Out-File -FilePath $ConfigFile -Encoding utf8
                         $current = $true
                     }
                     elseif (-not $Auto -and (Read-Host "Enable flag '$flag' and run? (Y/N)") -match '^(?i)y') {
                         Set-NestedConfigValue -Config $Config -Path $flag -Value $true
+                        $Config | ConvertTo-Json -Depth 5 | Out-File -FilePath $ConfigFile -Encoding utf8
                         $current = $true
                     }
                 }


### PR DESCRIPTION
## Summary
- persist config flags immediately when enabling with `-Force`

## Testing
- `Invoke-Pester -Output Detailed -Script tests/Runner.Tests.ps1` *(fails: 16 tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6849030612c48331b953e2411da8ae71