### PR TITLE
Fix script template param block

### DIFF
--- a/runner_utility_scripts/ScriptTemplate.ps1
+++ b/runner_utility_scripts/ScriptTemplate.ps1
@@ -2,7 +2,7 @@ if (-not $PSScriptRoot) {
     $PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 }
 
-Param([pscustomobject]$Config)
+#Param([pscustomobject]$Config)
 Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 
 function Invoke-LabStep {


### PR DESCRIPTION
## Summary
- comment param block in ScriptTemplate to support dot-sourcing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849066000d88331af3ea995bcfdad36