### PR TITLE
Fix YAML indentation for issue-on-fail workflow

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -28,8 +28,8 @@ jobs:
             });
             const summary = jobs.map(j => `- [${j.name}](${j.html_url}) - ${j.conclusion}`).join('\n');
             const failed = jobs.filter(j => j.conclusion !== 'success').map(j => j.name).join(', ');
-          core.setOutput('summary', summary);
-          core.setOutput('failed', failed);
+            core.setOutput('summary', summary);
+            core.setOutput('failed', failed);
 
       - name: Install labctl
         run: python -m pip install --quiet ./py
@@ -38,8 +38,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
-        COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
-        BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
         # Use the triggering run ID unless RUN_ID is explicitly provided
         run: |
           run_id="${RUN_ID:-${{ github.event.workflow_run.id }}}"


### PR DESCRIPTION
## Summary
- fix indentation for setOutput commands so they are inside the github-script block
- move COMMIT_SHA and BRANCH_NAME under the env block

## Testing
- `pip install 'typer>=0.12' 'pyyaml>=6.0' 'textual>=0.58,<0.59' 'click>=8,<8.2'`
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849078f1800833188df45911b8aad9c