### PR TITLE
Fix module import loop in LabRunner

### DIFF
--- a/runner_utility_scripts/LabRunner.psm1
+++ b/runner_utility_scripts/LabRunner.psm1
@@ -1,5 +1,4 @@
 #. dot-source utilities
-. $PSScriptRoot/ScriptTemplate.ps1
 . $PSScriptRoot/Logger.ps1
 . $PSScriptRoot/../lab_utils/Get-Platform.ps1
 


### PR DESCRIPTION
## Summary
- fix bootstrapping loop by removing ScriptTemplate import from LabRunner

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684907d629988331b62f3916932bd4d4