### PR TITLE
Fix issue creation quoting

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Create or update issue
         uses: actions/github-script@v7
+        env:
+          SUMMARY: ${{ steps.jobs.outputs.summary }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -89,7 +91,7 @@ jobs:
             const branch = context.payload.workflow_run.head_branch;
             const sha = context.payload.workflow_run.head_sha;
             const runUrl = context.payload.workflow_run.html_url;
-            const summary = '${{ steps.jobs.outputs.summary }}';
+            const summary = process.env.SUMMARY;
             const body = `Run [${runUrl}](${runUrl}) for commit \`${sha}\` on branch \`${branch}\` failed.\n\n### Failed jobs\n${summary}`;
             if (issueNumber) {
               await github.rest.issues.createComment({


### PR DESCRIPTION
## Summary
- pass failing job summary via environment variable
- use `process.env.SUMMARY` in issue creation script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849093377208331974ec7bbc7f50576