### PR TITLE
Restore LabRunner functions for tests

### DIFF
--- a/runner_utility_scripts/LabRunner.psm1
+++ b/runner_utility_scripts/LabRunner.psm1
@@ -2,4 +2,9 @@
 . $PSScriptRoot/Logger.ps1
 . $PSScriptRoot/../lab_utils/Get-Platform.ps1
 
+if (-not $script:LabRunner__Loaded) {
+    $script:LabRunner__Loaded = $true
+    . "$PSScriptRoot/ScriptTemplate.ps1"
+}
+
 Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform


### PR DESCRIPTION
## Summary
- guard dot-sourcing ScriptTemplate so LabRunner exports `Invoke-LabStep`

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_684909683d14833199deb427bf4b8686