### PR TITLE
Add repo view-issue command

### DIFF
--- a/docs/python-cli.md
+++ b/docs/python-cli.md
@@ -40,11 +40,12 @@ The `repo` group wraps a few common GitHub tasks. These commands require the
 ```bash
 poetry run labctl repo close-pr 123
 poetry run labctl repo close-issue 42
+poetry run labctl repo view-issue 99
 poetry run labctl repo cleanup
 ```
 
-`cleanup` removes merged remote branches while keeping the most recent branch
-per hour.
+`view-issue` prints the issue title and body as JSON, while `cleanup` removes
+merged remote branches and keeps the most recent branch per hour.
 
 ### `ui`
 Launch a simple Textual interface showing runner scripts, log output and

--- a/py/labctl/cli.py
+++ b/py/labctl/cli.py
@@ -100,6 +100,13 @@ def close_issue(issue_number: int):
     logger.info("Closed issue #%s", issue_number)
 
 
+@repo_app.command("view-issue")
+def view_issue(issue_number: int):
+    """Output issue details as JSON."""
+    data = github_utils.view_issue(issue_number)
+    typer.echo(data)
+
+
 @repo_app.command()
 def cleanup(
     remote: str = typer.Option("origin", help="Remote name"),

--- a/py/labctl/github_utils.py
+++ b/py/labctl/github_utils.py
@@ -64,3 +64,11 @@ def cleanup_branches(remote: str = "origin") -> List[str]:
         subprocess.run(["git", "push", remote, "--delete", name], check=True)
 
     return delete
+
+
+def view_issue(issue_number: int) -> str:
+    """Return the issue title and body as a JSON string."""
+    result = subprocess.check_output(
+        ["gh", "issue", "view", str(issue_number), "--json", "title,body"]
+    )
+    return result.decode()

--- a/py/tests/test_github_utils.py
+++ b/py/tests/test_github_utils.py
@@ -83,3 +83,26 @@ def test_create_issue_with_repo(monkeypatch):
     ]
 
 
+def test_view_issue(monkeypatch):
+    called = {}
+
+    def fake_check_output(cmd):
+        called["cmd"] = cmd
+        return b'{"title":"T","body":"B"}'
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repo", "view-issue", "7"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '{"title":"T","body":"B"}'
+    assert called["cmd"] == [
+        "gh",
+        "issue",
+        "view",
+        "7",
+        "--json",
+        "title,body",
+    ]
+
+


### PR DESCRIPTION
## Summary
- expose gh issue view via `labctl repo view-issue`
- implement helper in `github_utils`
- document repo command usage
- test the new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490c7e5fb88331ab8e19b53bddf56c