### PR TITLE
Add CI failure summaries

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -34,26 +34,35 @@ jobs:
       - name: Install labctl
         run: python -m pip install --quiet ./py
 
-      - name: Download test results and open issues
+      - name: Download test results
+        id: summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
-        # Use the triggering run ID unless RUN_ID is explicitly provided
         run: |
           run_id="${RUN_ID:-${{ github.event.workflow_run.id }}}"
-          # Download all artifacts from the triggering run. Wildcards are not
-          # supported by `gh run download`, so grab everything and filter locally.
           gh run download "$run_id" -D artifacts || true
 
-          find artifacts -name testResults.xml -print0 | while IFS= read -r -d '' f; do
-            python -m labctl.pester_failures "$f" || true
-          done
+          summary=""
+          while IFS= read -r -d '' f; do
+            out=$(python -m labctl.pester_failures "$f" --summary || true)
+            if [ -n "$out" ]; then
+              summary="$summary$out\n"
+            fi
+          done < <(find artifacts -name testResults.xml -print0)
 
-          find artifacts -name junit.xml -print0 | while IFS= read -r -d '' f; do
-            python -m labctl.pytest_failures "$f" || true
-          done
+          while IFS= read -r -d '' f; do
+            out=$(python -m labctl.pytest_failures "$f" --summary || true)
+            if [ -n "$out" ]; then
+              summary="$summary$out\n"
+            fi
+          done < <(find artifacts -name junit.xml -print0)
+
+          echo "failures<<EOF" >> "$GITHUB_OUTPUT"
+          echo -e "$summary" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Check existing issue
         id: find
@@ -83,7 +92,8 @@ jobs:
       - name: Create or update issue
         uses: actions/github-script@v7
         env:
-          SUMMARY: ${{ steps.jobs.outputs.summary }}
+          JOB_SUMMARY: ${{ steps.jobs.outputs.summary }}
+          TEST_SUMMARY: ${{ steps.summary.outputs.failures }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -91,8 +101,9 @@ jobs:
             const branch = context.payload.workflow_run.head_branch;
             const sha = context.payload.workflow_run.head_sha;
             const runUrl = context.payload.workflow_run.html_url;
-            const summary = process.env.SUMMARY;
-            const body = `Run [${runUrl}](${runUrl}) for commit \`${sha}\` on branch \`${branch}\` failed.\n\n### Failed jobs\n${summary}`;
+            const jobSummary = process.env.JOB_SUMMARY;
+            const failSummary = process.env.TEST_SUMMARY;
+            const body = `Run [${runUrl}](${runUrl}) for commit \`${sha}\` on branch \`${branch}\` failed.\n\n### Failed jobs\n${jobSummary}\n\n### Failing tests\n${failSummary}`;
             if (issueNumber) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,3 +35,7 @@ Select-String -Path path\to\coverage.xml -Pattern 'your-module.ps1'
 ```
 
 Missing or zero-hit sections often reveal code paths that were not exercised on Windows, hinting at platform-specific issues. Compare the uncovered lines with the failing tests to narrow down the root cause.
+
+## Automatic failure issues
+
+The workflow `.github/workflows/issue-on-fail.yml` opens a single GitHub issue whenever any CI job fails. It gathers Pester and pytest results from the run artifacts and posts a summary of failing tests in the issue body. Subsequent failed runs append a comment rather than creating new issues.

--- a/py/tests/test_pester_failures.py
+++ b/py/tests/test_pester_failures.py
@@ -42,3 +42,24 @@ def test_report_failures(tmp_path, monkeypatch):
     assert calls[0].title == "Fail.Test"
     assert "boom" in calls[0].body
     assert "http://run" in calls[0].body
+
+
+def test_summarize_failures(tmp_path):
+    xml = tmp_path / "testResults.xml"
+    xml.write_text(
+        """
+<test-results>
+  <test-suite>
+    <results>
+      <test-case name='Fail.Test' result='Failed'>
+        <failure>
+          <message>boom</message>
+        </failure>
+      </test-case>
+    </results>
+  </test-suite>
+</test-results>
+"""
+    )
+    summary = pester_failures.summarize_failures(xml)
+    assert summary.strip() == "- **Fail.Test**: boom"

--- a/py/tests/test_pytest_failures.py
+++ b/py/tests/test_pytest_failures.py
@@ -34,3 +34,18 @@ def test_report_failures(tmp_path, monkeypatch):
     assert calls[0].title == "pkg.TestCase.test_fail"
     assert "oops" in calls[0].body
     assert "http://run" in calls[0].body
+
+
+def test_summarize_failures(tmp_path):
+    xml = tmp_path / "junit.xml"
+    xml.write_text(
+        """
+<testsuite>
+  <testcase classname='pkg.TestCase' name='test_fail'>
+    <failure message='oops'>AssertionError</failure>
+  </testcase>
+</testsuite>
+"""
+    )
+    summary = pytest_failures.summarize_failures(xml)
+    assert summary.strip() == "- **pkg.TestCase.test_fail**: oops"


### PR DESCRIPTION
## Summary
- extract failing test info into summary helpers
- allow `--summary` CLI flag for parsers
- collect summaries in issue-on-fail workflow
- document automatic issue summary behaviour
- test new summary functionality

## Testing
- `ruff check .`
- `pytest -q`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68490c775d648331b95a1dc13dc7d74c