### PR TITLE
Fix circular dependency between LabRunner and ScriptTemplate

### DIFF
--- a/runner_utility_scripts/LabRunner.psm1
+++ b/runner_utility_scripts/LabRunner.psm1
@@ -2,9 +2,7 @@
 . $PSScriptRoot/Logger.ps1
 . $PSScriptRoot/../lab_utils/Get-Platform.ps1
 
-if (-not $script:LabRunner__Loaded) {
-    $script:LabRunner__Loaded = $true
-    . "$PSScriptRoot/ScriptTemplate.ps1"
-}
+# LabRunner should be imported by runner scripts before dot-sourcing
+# ScriptTemplate.ps1. Avoid dot-sourcing here to prevent circular imports.
 
 Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform

--- a/runner_utility_scripts/ScriptTemplate.ps1
+++ b/runner_utility_scripts/ScriptTemplate.ps1
@@ -3,7 +3,9 @@ if (-not $PSScriptRoot) {
 }
 
 #Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
+if (-not (Get-Module -Name LabRunner)) {
+    Import-Module (Join-Path $PSScriptRoot '..\runner_utility_scripts\LabRunner.psd1')
+}
 
 function Invoke-LabStep {
     param([scriptblock]$Body, [pscustomobject]$Config)


### PR DESCRIPTION
## Summary
- avoid dot-sourcing ScriptTemplate inside LabRunner
- guard LabRunner import in ScriptTemplate so it loads once
- run tests

## Testing
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490d135efc8331953a3aeb06b53636