### PR TITLE
Fix lint warnings

### DIFF
--- a/py/labctl/pester_failures.py
+++ b/py/labctl/pester_failures.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import sys
 from pathlib import Path
 import xml.etree.ElementTree as ET
 

--- a/py/labctl/pytest_failures.py
+++ b/py/labctl/pytest_failures.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import sys
 from pathlib import Path
 import xml.etree.ElementTree as ET
 


### PR DESCRIPTION
## Summary
- fix ruff F401 warnings by removing unused `sys` imports

## Testing
- `ruff check .`
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration @{ Run = @{ Exit = $false }}"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490e7b405083318caa222ed469f0cb