### PR TITLE
Fix LabRunner exports

### DIFF
--- a/runner_utility_scripts/LabRunner.psd1
+++ b/runner_utility_scripts/LabRunner.psd1
@@ -3,5 +3,5 @@
     ModuleVersion = '0.1.0'
     GUID = 'c0000000-0000-4000-8000-000000000001'
     Author = 'OpenTofu'
-    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Get-Platform')
+    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Get-Platform','Get-LabConfig')
 }

--- a/runner_utility_scripts/LabRunner.psm1
+++ b/runner_utility_scripts/LabRunner.psm1
@@ -1,10 +1,9 @@
 #. dot-source utilities
+
+. (Join-Path $PSScriptRoot 'ScriptTemplate.ps1')   # pulls in Invoke-LabStep, etc.
 . $PSScriptRoot/Logger.ps1
 . $PSScriptRoot/../lab_utils/Get-Platform.ps1
 
-if (-not $script:LabRunner__Loaded) {
-    $script:LabRunner__Loaded = $true
-    . "$PSScriptRoot/ScriptTemplate.ps1"
-}
+# Only this side (LabRunner) brings ScriptTemplate in.
 
-Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform
+Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform, Get-LabConfig

--- a/runner_utility_scripts/ScriptTemplate.ps1
+++ b/runner_utility_scripts/ScriptTemplate.ps1
@@ -3,7 +3,6 @@ if (-not $PSScriptRoot) {
 }
 
 #Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 
 function Invoke-LabStep {
     param([scriptblock]$Body, [pscustomobject]$Config)


### PR DESCRIPTION
## Summary
- avoid ScriptTemplate importing LabRunner
- dot source ScriptTemplate from LabRunner
- export helpers including Get-LabConfig

## Testing
- `Invoke-Pester`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68490f77d7b08331a65ca655344887da