### PR TITLE
Update runner docs and module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,13 @@
 
 ## Quick start
 
-The easiest way to bootstrap a fresh Windows host is to run the project’s
-`kicker-bootstrap.ps1` script. It installs Git and the GitHub CLI if needed,
-clones this repository and then launches `runner.ps1`.
+Clone this repository and run `runner.ps1` directly. PowerShell 7 or later is
+required:
 
-
-```
-
-
-Powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/main/kicker-bootstrap.ps1' -OutFile '.\kicker-bootstrap.ps1'; .\kicker-bootstrap.ps1 -Quiet"
-
-
+```powershell
+git clone https://github.com/wizzense/opentofu-lab-automation.git
+cd opentofu-lab-automation
+pwsh -File runner.ps1
 ```
 **Note:** These scripts require PowerShell 7 or later. Install the latest `pwsh` and use it instead of `powershell.exe`.
 
@@ -65,6 +61,22 @@ Individual step scripts can also be invoked this way when debugging:
 ```powershell
 pwsh -File runner_scripts/0001_Reset-Git.ps1 -Config ./config_files/default-config.json
 ```
+
+### Writing new runner scripts
+
+All runner steps follow a small template. Import the helper module and wrap your
+logic in `Invoke-LabScript`:
+
+```powershell
+Param([pscustomobject]$Config)
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psm1"
+
+Invoke-LabScript -Config $Config -Body {
+    Write-CustomLog "Hello from $($MyInvocation.MyCommand.Name)"
+    # your commands here
+}
+```
+
 
 
 Clone this repository and apply the lab template:

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -68,9 +68,14 @@ Step scripts import a small PowerShell module that provides common helpers:
 
 ```powershell
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psm1"
+
+Invoke-LabScript -Config $Config -Body {
+    Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
+    # script body goes here
+}
 ```
 
-`LabRunner` exposes functions like `Invoke-LabStep`, `Write-CustomLog` and
+`LabRunner` exposes functions like `Invoke-LabScript`, `Write-CustomLog` and
 `Get-Platform` so every script shares the same logging and platform detection
 logic.

--- a/runner_utility_scripts/LabRunner.psm1
+++ b/runner_utility_scripts/LabRunner.psm1
@@ -2,9 +2,37 @@
 . $PSScriptRoot/Logger.ps1
 . $PSScriptRoot/../lab_utils/Get-Platform.ps1
 
-if (-not $script:LabRunner__Loaded) {
-    $script:LabRunner__Loaded = $true
-    . "$PSScriptRoot/ScriptTemplate.ps1"
+function Invoke-LabScript {
+    param(
+        [scriptblock]$Body,
+        [pscustomobject]$Config
+    )
+
+    if ($Config -is [string]) {
+        if (Test-Path $Config) {
+            $Config = Get-Content -Raw -Path $Config | ConvertFrom-Json
+        } else {
+            try { $Config = $Config | ConvertFrom-Json } catch {}
+        }
+    }
+
+    if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
+        . $PSScriptRoot/Logger.ps1
+    }
+
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    try {
+        & $Body $Config
+    } catch {
+        Write-CustomLog "ERROR: $_"
+        throw
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
 }
 
-Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform
+Set-Alias Invoke-LabStep Invoke-LabScript
+
+Export-ModuleMember -Function Invoke-LabScript, Write-CustomLog, Get-Platform
+Export-ModuleMember -Alias Invoke-LabStep

--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -6,7 +6,7 @@ if ($SkipNonWindows) { return }
 
 Describe '0200_Get-SystemInfo' {
     BeforeAll {
-        Import-Module (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'LabRunner.psd1')
+        Import-Module (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'LabRunner.psm1')
         $script:ScriptPath = Get-RunnerScriptPath '0200_Get-SystemInfo.ps1'
     }
 

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -56,13 +56,13 @@ Describe 'Runner scripts parameter and command checks' -Skip:($SkipNonWindows) {
         }
     }
 
-    It 'contains Invoke-LabStep call' -TestCases $testCases {
+    It 'contains Invoke-LabScript call' -TestCases $testCases {
         param($File, $Commands)
         $ast = Get-ScriptAst $File.FullName
         $commands = if ($ast) { $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) } else { @() }
-        $found = $commands | Where-Object { $_.GetCommandName() -eq 'Invoke-LabStep' }
+        $found = $commands | Where-Object { $_.GetCommandName() -eq 'Invoke-LabScript' }
         if (-not $found) {
-            Write-Host "Invoke-LabStep not found in $($File.FullName)"
+            Write-Host "Invoke-LabScript not found in $($File.FullName)"
         }
         ($found | Measure-Object).Count | Should -BeGreaterThan 0
     }
@@ -81,7 +81,7 @@ Describe 'Runner scripts parameter and command checks' -Skip:($SkipNonWindows) {
                 $_.CommandElements[1] -is [System.Management.Automation.Language.StringConstantExpressionAst] -or
                 $_.CommandElements[1] -is [System.Management.Automation.Language.ExpandableStringExpressionAst]
             ) -and
-            ([System.IO.Path]::GetFileName($_.CommandElements[1].Value) -eq 'LabRunner.psd1')
+            ([System.IO.Path]::GetFileName($_.CommandElements[1].Value) -eq 'LabRunner.psm1')
         }
 
         if (-not $found) {
@@ -98,8 +98,8 @@ Describe 'Runner scripts parameter and command checks' -Skip:($SkipNonWindows) {
             $dummy = Join-Path $tempDir 'dummy.ps1'
             @"
 Param([pscustomobject]`$Config)
-Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
-Invoke-LabStep -Config `$Config -Body { Write-Output `$PSScriptRoot }
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psm1"
+Invoke-LabScript -Config `$Config -Body { Write-Output `$PSScriptRoot }
 "@ | Set-Content -Path $dummy
 
             $pwsh = (Get-Command pwsh).Source


### PR DESCRIPTION
## Summary
- update docs for new Invoke-LabScript pattern
- drop bootstrap references
- inline script helper into LabRunner module
- adjust tests for new module path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `powershell -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491003b0548331b3e6195722c592c3