### PR TITLE
Fix Pester config object update

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -79,7 +79,7 @@ jobs:
         shell: pwsh
         run: |
           $cfg = New-PesterConfiguration -Hashtable (Import-PowerShellDataFile 'tests/PesterConfiguration.psd1')
-          $cfg.CodeCoverage.Path += 'iso_tools'
+          $cfg.CodeCoverage.Path.Add('iso_tools')
 
           $repoRoot = $env:GITHUB_WORKSPACE
           $cfg.TestResult.OutputPath   = Join-Path $repoRoot 'coverage/testResults.xml'


### PR DESCRIPTION
## Summary
- fix code coverage path update in Pester workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849129d6be083318a13154995747171