### PR TITLE
Fix Pester workflow coverage path

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -79,7 +79,10 @@ jobs:
         shell: pwsh
         run: |
           $cfg = New-PesterConfiguration -Hashtable (Import-PowerShellDataFile 'tests/PesterConfiguration.psd1')
-          $cfg.CodeCoverage.Path.Add('iso_tools')
+
+          $coveragePaths = @($cfg.CodeCoverage.Path.Value)
+          $coveragePaths += 'iso_tools'
+          $cfg.CodeCoverage.Path = [Pester.StringArrayOption]::new($coveragePaths)
 
           $repoRoot = $env:GITHUB_WORKSPACE
           $cfg.TestResult.OutputPath   = Join-Path $repoRoot 'coverage/testResults.xml'


### PR DESCRIPTION
## Summary
- fix CodeCoverage path configuration using StringArrayOption

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684915167e988331bb587079712f0d0c