### PR TITLE
Fix failure summary workflow

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -45,6 +45,12 @@ jobs:
           run_id="${RUN_ID:-${{ github.event.workflow_run.id }}}"
           gh run download "$run_id" -D artifacts || true
 
+          if ls artifacts/*.zip >/dev/null 2>&1; then
+            for z in artifacts/*.zip; do
+              unzip -q "$z" -d artifacts
+            done
+          fi
+
           summary=""
           while IFS= read -r -d '' f; do
             out=$(python -m labctl.pester_failures "$f" --summary || true)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,3 +39,11 @@ Missing or zero-hit sections often reveal code paths that were not exercised on 
 ## Automatic failure issues
 
 The workflow `.github/workflows/issue-on-fail.yml` opens a single GitHub issue whenever any CI job fails. It gathers Pester and pytest results from the run artifacts and posts a summary of failing tests in the issue body. Subsequent failed runs append a comment rather than creating new issues.
+
+After fetching the artifacts with `gh run download`, remember to extract the downloaded archives:
+
+```bash
+for z in artifacts/*.zip; do
+  unzip -q "$z" -d artifacts
+done
+```


### PR DESCRIPTION
## Summary
- unzip job artifacts so failure summary finds test results
- update docs with extraction example

## Testing
- `poetry run pytest`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849153976cc8331b894a7664264cff9