### PR TITLE
Fix issue comments for failing Pester tests

### DIFF
--- a/py/labctl/pester_failures.py
+++ b/py/labctl/pester_failures.py
@@ -12,6 +12,7 @@ def summarize_failures(xml_path: Path) -> str:
     root = tree.getroot()
     lines = []
     cases = list(root.findall(".//test-case[@result='Failed']"))
+    cases += list(root.findall(".//test-case[@result='Failure']"))
     cases += list(root.findall(".//UnitTestResult[@outcome='Failed']"))
 
     for case in cases:
@@ -37,6 +38,7 @@ def report_failures(xml_path: Path) -> None:
     details.append(f"OS: {os_name}")
     extra = "\n".join(details)
     cases = list(root.findall(".//test-case[@result='Failed']"))
+    cases += list(root.findall(".//test-case[@result='Failure']"))
     cases += list(root.findall(".//UnitTestResult[@outcome='Failed']"))
 
     for case in cases:


### PR DESCRIPTION
## Summary
- handle `result="Failure"` from Pester NUnit XML

## Testing
- `pytest -q`
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_684918604b948331b28c6baf42546d65