### PR TITLE
Fix Format-Config mandatory parameter

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -4,7 +4,7 @@ function Format-Config {
         [Parameter(
             ValueFromPipeline = $true,
             ValueFromPipelineByPropertyName = $true,
-            Mandatory = $true
+            Mandatory
         )]
         [AllowNull()]
         [psobject]$Config


### PR DESCRIPTION
## Summary
- make `$Config` mandatory via attribute shorthand

## Testing
- `Invoke-Pester tests/Format-Config.Tests.ps1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684919acfe34833187a0a79b9b7df477