### PR TITLE
Improve PFX validation

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -37,7 +37,14 @@ function Convert-PfxToPem {
         [string]$KeyPath
     )
     if (-not $PSCmdlet.ShouldProcess($PfxPath, 'Convert PFX to PEM')) { return }
-    $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($PfxPath,$Password,[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
+    if (-not (Test-Path $PfxPath) -or ((Get-Item -Path $PfxPath -ErrorAction SilentlyContinue).Length -eq 0)) {
+        throw "Invalid or unreadable PFX at $PfxPath"
+    }
+    try {
+        $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($PfxPath,$Password,[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
+    } catch {
+        throw "Invalid or unreadable PFX at $PfxPath"
+    }
     $certBytes = $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
     $certB64   = [System.Convert]::ToBase64String($certBytes,'InsertLineBreaks')
     if ($PSCmdlet.ShouldProcess($CertPath, 'Write certificate PEM')) {

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -246,4 +246,16 @@ Describe 'Convert certificate helpers validate paths' -Skip:($SkipNonWindows) {
         { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath 'c' -KeyPath '' } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
         { Convert-PfxToPem -PfxPath 'p' -Password $pwd -CertPath 'c' -KeyPath $null } | Should -Throw -ErrorType [System.Management.Automation.ParameterBindingException]
     }
+
+    It 'throws when the PFX file is unreadable' {
+        $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
+        . $scriptPath
+        $pwd = New-Object System.Security.SecureString
+        foreach ($c in 'pw'.ToCharArray()) { $pwd.AppendChar($c) }
+        $pwd.MakeReadOnly()
+        $pfx = Join-Path $TestDrive 'bad.pfx'
+        New-Item -ItemType File -Path $pfx | Out-Null
+        { Convert-PfxToPem -PfxPath $pfx -Password $pwd -CertPath 'c' -KeyPath 'k' } |
+            Should -Throw -ErrorMessage "Invalid or unreadable PFX at $pfx"
+    }
 }


### PR DESCRIPTION
## Summary
- improve Convert-PfxToPem with better validation
- test zero length PFX failure

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `Invoke-Pester` *(fails: pwsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684919c811648331a15d7c8fda23be8a