### PR TITLE
Add LabSetup module and update tests

### DIFF
--- a/lab_utils/LabSetup/LabSetup.psd1
+++ b/lab_utils/LabSetup/LabSetup.psd1
@@ -1,8 +1,7 @@
 @{
-    RootModule = 'LabRunner.psm1'
+    RootModule = 'LabSetup.psm1'
     ModuleVersion = '0.1.0'
     GUID = 'c0000000-0000-4000-8000-000000000001'
-    NestedModules = @('../LabSetup/LabSetup.psd1')
     Author = 'OpenTofu'
     FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Get-Platform')
 }

--- a/lab_utils/LabSetup/LabSetup.psm1
+++ b/lab_utils/LabSetup/LabSetup.psm1
@@ -1,0 +1,31 @@
+#. dot-source utilities
+. $PSScriptRoot/Logger.ps1
+. $PSScriptRoot/../Get-Platform.ps1
+
+function Invoke-LabStep {
+    param(
+        [scriptblock]$Body,
+        [pscustomobject]$Config
+    )
+
+    if ($Config -is [string]) {
+        if (Test-Path $Config) {
+            $Config = Get-Content -Raw -Path $Config | ConvertFrom-Json
+        } else {
+            try { $Config = $Config | ConvertFrom-Json } catch {}
+        }
+    }
+
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    try {
+        & $Body $Config
+    } catch {
+        Write-CustomLog "ERROR: $_" 'ERROR'
+        throw
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
+Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform

--- a/lab_utils/LabSetup/Logger.ps1
+++ b/lab_utils/LabSetup/Logger.ps1
@@ -1,0 +1,30 @@
+function Write-CustomLog {
+    param(
+        [string]$Message,
+        [ValidateSet('INFO','WARN','ERROR')] [string]$Level = 'INFO'
+    )
+    $levelIdx = @{ INFO = 1; WARN = 0; ERROR = 0 }[$Level]
+
+    if (-not (Get-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue)) {
+        $logDir = $env:LAB_LOG_DIR
+        if (-not $logDir) { $logDir = if ($IsWindows) { 'C:\\temp' } else { [System.IO.Path]::GetTempPath() } }
+        $script:LogFilePath = Join-Path $logDir 'lab.log'
+    }
+
+    if (-not (Get-Variable -Name ConsoleLevel -Scope Script -ErrorAction SilentlyContinue)) {
+        if ($env:LAB_CONSOLE_LEVEL) {
+            $script:ConsoleLevel = [int]$env:LAB_CONSOLE_LEVEL
+        } else {
+            $script:ConsoleLevel = 1
+        }
+    }
+
+    $ts  = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $fmt = "[$ts] [$Level] $Message"
+    $fmt | Out-File -FilePath $script:LogFilePath -Encoding utf8 -Append
+
+    if ($levelIdx -le $script:ConsoleLevel) {
+        $color = @{ INFO='Gray'; WARN='Yellow'; ERROR='Red' }[$Level]
+        Write-Host $fmt -ForegroundColor $color
+    }
+}

--- a/lab_utils/LabSetup/ScriptTemplate.ps1
+++ b/lab_utils/LabSetup/ScriptTemplate.ps1
@@ -1,0 +1,36 @@
+if (-not $PSScriptRoot) {
+    $PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+}
+
+#Param([pscustomobject]$Config)
+
+function Invoke-LabStep {
+    param([scriptblock]$Body, [pscustomobject]$Config)
+    if ($Config -is [string]) {
+        if (Test-Path $Config) {
+            $Config = Get-Content -Raw -Path $Config | ConvertFrom-Json
+        } else {
+            try { $Config = $Config | ConvertFrom-Json } catch {}
+        }
+    }
+    if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
+        . $PSScriptRoot/Logger.ps1
+    }
+
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Stop'
+    try {
+        . $Body $Config
+    } catch {
+        Write-CustomLog "ERROR: $_"
+        throw
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
+Invoke-LabStep -Config $Config -Body {
+    Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
+
+}
+

--- a/runner_utility_scripts/LabRunner.psd1
+++ b/runner_utility_scripts/LabRunner.psd1
@@ -2,6 +2,7 @@
     RootModule = 'LabRunner.psm1'
     ModuleVersion = '0.1.0'
     GUID = 'c0000000-0000-4000-8000-000000000001'
+        NestedModules = @('../lab_utils/LabSetup/LabSetup.psd1')
     Author = 'OpenTofu'
     FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Get-Platform','Get-LabConfig')
 }

--- a/runner_utility_scripts/LabRunner.psm1
+++ b/runner_utility_scripts/LabRunner.psm1
@@ -1,4 +1,5 @@
 #. dot-source utilities
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabSetup' 'LabSetup.psd1')
 
 . (Join-Path $PSScriptRoot 'ScriptTemplate.ps1')   # pulls in Invoke-LabStep, etc.
 . $PSScriptRoot/Logger.ps1

--- a/tests/Get-WindowsJobArtifacts.Tests.ps1
+++ b/tests/Get-WindowsJobArtifacts.Tests.ps1
@@ -2,6 +2,7 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 if ($SkipNonWindows) { return }
 
+InModuleScope LabSetup {
 Describe 'Get-WindowsJobArtifacts' {
     BeforeAll {
         $scriptPath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-WindowsJobArtifacts.ps1'
@@ -26,7 +27,7 @@ Describe 'Get-WindowsJobArtifacts' {
     It 'falls back to nightly.link when gh auth fails' {
         Mock Get-Command { [pscustomobject]@{ Name = 'gh' } } -ParameterFilter { $Name -eq 'gh' }
         Mock gh { throw 'unauthenticated' } -ParameterFilter { $args[0] -eq 'auth' -and $args[1] -eq 'status' }
-        Mock Invoke-WebRequest {}
+        Mock Invoke-WebRequest -ModuleName LabSetup {}
         Mock Expand-Archive {}
         Mock Get-ChildItem { [pscustomobject]@{ FullName = 'dummy.xml' } }
         Mock Select-Xml { @() }
@@ -55,7 +56,7 @@ Describe 'Get-WindowsJobArtifacts' {
         $id = 456
         Mock Get-Command { [pscustomobject]@{ Name = 'gh' } } -ParameterFilter { $Name -eq 'gh' }
         Mock gh { throw 'unauthenticated' } -ParameterFilter { $args[0] -eq 'auth' -and $args[1] -eq 'status' }
-        Mock Invoke-WebRequest {}
+        Mock Invoke-WebRequest -ModuleName LabSetup {}
         Mock Expand-Archive {}
         Mock Get-ChildItem { [pscustomobject]@{ FullName = 'dummy.xml' } }
         Mock Select-Xml { @() }
@@ -84,11 +85,12 @@ Describe 'Get-WindowsJobArtifacts' {
 
     It 'returns nonzero exit code when download fails' {
         Mock Get-Command { $null } -ParameterFilter { $Name -eq 'gh' }
-        Mock Invoke-WebRequest { throw '404' }
+        Mock Invoke-WebRequest -ModuleName LabSetup { throw '404' }
         $messages = @()
         function global:Write-Host { param($Object,$Color); $script:messages += $Object }
         try { & $scriptPath } catch {}
 
         $LASTEXITCODE | Should -Be 1
     }
+}
 }

--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -2,6 +2,7 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 if ($SkipNonWindows) { return }
 Describe 'Initialize-OpenTofu script' {
+InModuleScope LabSetup {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0009_Initialize-OpenTofu.ps1'
     }
@@ -195,4 +196,5 @@ Describe 'Initialize-OpenTofu script' {
             Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
         }
     }
+}
 }

--- a/tests/Install-Go.Tests.ps1
+++ b/tests/Install-Go.Tests.ps1
@@ -7,7 +7,7 @@ Describe '0007_Install-Go' -Skip:($SkipNonWindows) {
     It 'installs Go when enabled' {
         $cfg = [pscustomobject]@{ InstallGo = $true; Go = @{ InstallerUrl = 'http://example.com/go1.21.0.windows-amd64.msi' } }
         Mock Get-Command {} -ParameterFilter { $Name -eq 'go' }
-        Mock Invoke-WebRequest {}
+        Mock Invoke-WebRequest -ModuleName LabSetup {}
         Mock Start-Process {}
         Mock-WriteLog
         & $script:ScriptPath -Config $cfg
@@ -17,7 +17,7 @@ Describe '0007_Install-Go' -Skip:($SkipNonWindows) {
 
     It 'skips when InstallGo is false' {
         $cfg = [pscustomobject]@{ InstallGo = $false; Go = @{ InstallerUrl = 'http://example.com/go1.21.0.windows-amd64.msi' } }
-        Mock Invoke-WebRequest {}
+        Mock Invoke-WebRequest -ModuleName LabSetup {}
         Mock Start-Process {}
         Mock-WriteLog
         & $script:ScriptPath -Config $cfg
@@ -28,7 +28,7 @@ Describe '0007_Install-Go' -Skip:($SkipNonWindows) {
     It 'does nothing when Go is already installed' {
         $cfg = [pscustomobject]@{ InstallGo = $true; Go = @{ InstallerUrl = 'http://example.com/go1.21.0.windows-amd64.msi' } }
         Mock Get-Command { @{ Name = 'go' } } -ParameterFilter { $Name -eq 'go' }
-        Mock Invoke-WebRequest {}
+        Mock Invoke-WebRequest -ModuleName LabSetup {}
         Mock Start-Process {}
         Mock-WriteLog
         & $script:ScriptPath -Config $cfg

--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -13,7 +13,7 @@ Describe '0006_Install-ValidationTools' -Skip:($SkipNonWindows) {
             CosignURL     = 'http://example.com/cosign.exe'
             CosignPath    = Join-Path $env:TEMP ([guid]::NewGuid())
         }
-        Mock Invoke-WebRequest {}
+        Mock Invoke-WebRequest -ModuleName LabSetup {}
         Mock New-Item {}
         Mock Test-Path { $false }
         Mock-WriteLog

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Node installation scripts' -Skip:$skipNpm {
     It 'uses Node_Dependencies.Node.InstallerUrl when installing Node' {
         $cfg = @{ Node_Dependencies = @{ InstallNode=$true; Node = @{ InstallerUrl = 'http://example.com/node.msi' } } }
         $core = Get-RunnerScriptPath '0201_Install-NodeCore.ps1'
-        Mock Invoke-WebRequest {}
+        Mock Invoke-WebRequest -ModuleName LabSetup {}
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command { @{Name='node'} } -ParameterFilter { $Name -eq 'node' }
@@ -43,7 +43,7 @@ Describe 'Node installation scripts' -Skip:$skipNpm {
     It 'does nothing when InstallNode is $false' {
         $cfg = @{ Node_Dependencies = @{ InstallNode = $false } }
         $core = Get-RunnerScriptPath '0201_Install-NodeCore.ps1'
-        Mock Invoke-WebRequest {}
+        Mock Invoke-WebRequest -ModuleName LabSetup {}
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command {}

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -31,7 +31,7 @@ if ($IsLinux -or $IsMacOS) { return }
         $zipPath = Join-Path $temp 'tofu_0.0.0_windows_amd64.zip'
         'dummy' | Set-Content $zipPath
         $hash = (Get-FileHash -Algorithm SHA256 $zipPath).Hash
-        Mock Invoke-WebRequest {
+        Mock Invoke-WebRequest -ModuleName LabSetup {
             param([string]$Uri, [string]$OutFile)
             if ($Uri -match 'SHA256SUMS$') {
                 "${hash}  tofu_0.0.0_windows_amd64.zip" | Set-Content $OutFile
@@ -76,7 +76,7 @@ if ($IsLinux -or $IsMacOS) { return }
         $zipPath = Join-Path $temp 'tofu_0.0.0_windows_amd64.zip'
         'dummy' | Set-Content $zipPath
         $hash = (Get-FileHash -Algorithm SHA256 $zipPath).Hash
-        Mock Invoke-WebRequest {
+        Mock Invoke-WebRequest -ModuleName LabSetup {
             param([string]$Uri, [string]$OutFile)
             if ($Uri -match 'SHA256SUMS$') {
                 "${hash}  tofu_0.0.0_windows_amd64.zip" | Set-Content $OutFile


### PR DESCRIPTION
## Summary
- add new `LabSetup` module mirrored from `LabRunner`
- import `LabSetup` from the legacy `LabRunner` module for compatibility
- wrap related tests in `InModuleScope LabSetup`
- bind `Invoke-WebRequest` mocks to `LabSetup`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration tests/PesterConfiguration.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684919bbc6908331b23c952e87a73402