### PR TITLE
Add Read-LoggedInput for logged prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ system temporary directory on other platforms). Set the `LAB_LOG_DIR`
 environment variable or `$script:LogFilePath` to override the location. The
 `labctl` Python CLI uses the same variable and writes to `lab.log` within that
 directory.
+Prompts displayed during script execution use `Read-LoggedInput`, so user
+responses are recorded in the same log file (except secure inputs).
 
 Make sure to modify the 'main.tf' so it uses your admin credentials and hostname/IP of the host machine if you don't have a customized config.json or choose not to customize.
 

--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -38,7 +38,8 @@ $prompt = "`n<press any key to continue>`n"
 
 function Write-Continue($prompt) {
   [Console]::Write($prompt + '  ')
-  Microsoft.PowerShell.Utility\Read-Host }
+  Read-LoggedInput -Prompt $prompt | Out-Null
+}
 
 $ErrorActionPreference = 'Stop'  # So any error throws an exception
 $ProgressPreference = 'SilentlyContinue'
@@ -159,7 +160,7 @@ The script will do the following if you proceed:
 
 # Prompt for input to provide remote/local or accept default
 
-$configOption = Read-Host -prompt "`nEnter a remote URL or local path, or leave blank for default."
+$configOption = Read-LoggedInput -Prompt "`nEnter a remote URL or local path, or leave blank for default."
 
 if ($configOption -match "https://") {
     Invoke-WebRequest -Uri $configOption -OutFile '.\custom-config.json'
@@ -178,7 +179,7 @@ if ($configOption -match "https://") {
             $num = $i + 1
             Write-CustomLog ("{0}) {1}" -f $num, $configFiles[$i].Name) "INFO" | Write-Host
         }
-        $ans = Read-Host 'Select configuration number'
+        $ans = Read-LoggedInput -Prompt 'Select configuration number'
         if ($ans -match '^[0-9]+$' -and [int]$ans -ge 1 -and [int]$ans -le $configFiles.Count) {
             $ConfigFile = $configFiles[[int]$ans - 1].FullName
         } else {
@@ -320,7 +321,7 @@ catch {
     Write-CustomLog "GitHub CLI is not authenticated."
 
     # Optional: Prompt user for a personal access token
-    $pat = Read-Host "Enter your GitHub Personal Access Token (or press Enter to skip):"
+    $pat = Read-LoggedInput -Prompt "Enter your GitHub Personal Access Token (or press Enter to skip):"
 
     if (-not [string]::IsNullOrWhiteSpace($pat)) {
         Write-CustomLog "Attempting PAT-based GitHub CLI login..."

--- a/lab_utils/Expand-All.ps1
+++ b/lab_utils/Expand-All.ps1
@@ -13,7 +13,7 @@ function Expand-All {
             return
         }
         Write-CustomLog "Specified ZIP file: $ZipFile"
-        $confirmation = Read-Host "Do you want to expand this archive? (y/n)"
+        $confirmation = Read-LoggedInput "Do you want to expand this archive? (y/n)"
         if ($confirmation -ne 'y') {
             Write-CustomLog "Operation canceled."
             return
@@ -27,7 +27,7 @@ function Expand-All {
         # Expand all zip files recursively in the current directory
         $currentDir = Get-Location
         Write-CustomLog "Current Directory: $currentDir"
-        $confirmation = Read-Host "Do you want to expand all archives in this directory and its subdirectories? (y/n)"
+        $confirmation = Read-LoggedInput "Do you want to expand all archives in this directory and its subdirectories? (y/n)"
         if ($confirmation -ne 'y') {
             Write-CustomLog "Operation canceled."
             return

--- a/lab_utils/LabRunner/LabRunner.psd1
+++ b/lab_utils/LabRunner/LabRunner.psd1
@@ -3,5 +3,5 @@
     ModuleVersion = '0.1.0'
     GUID = 'c0000000-0000-4000-8000-000000000001'
     Author = 'OpenTofu'
-    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Get-Platform')
+    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Read-LoggedInput','Get-Platform')
 }

--- a/lab_utils/LabRunner/LabRunner.psm1
+++ b/lab_utils/LabRunner/LabRunner.psm1
@@ -28,4 +28,4 @@ function Invoke-LabStep {
     }
 }
 
-Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform
+Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Read-LoggedInput, Get-Platform

--- a/lab_utils/LabRunner/Logger.ps1
+++ b/lab_utils/LabRunner/Logger.ps1
@@ -28,3 +28,20 @@ function Write-CustomLog {
         Write-Host $fmt -ForegroundColor $color
     }
 }
+
+function Read-LoggedInput {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Prompt,
+        [switch]$AsSecureString
+    )
+
+    if ($AsSecureString) {
+        Write-CustomLog "$Prompt (secure input)"
+        return Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt -AsSecureString
+    }
+
+    $answer = Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt
+    Write-CustomLog "$Prompt: $answer"
+    return $answer
+}

--- a/lab_utils/Menu.ps1
+++ b/lab_utils/Menu.ps1
@@ -21,7 +21,7 @@ function Get-MenuSelection {
     }
     while ($true) {
         $prompt = if ($AllowAll) { "Enter numbers/prefixes (comma separated), 'all', or 'exit'" } else { "Enter numbers/prefixes or 'exit'" }
-        $input = Read-Host $prompt
+        $input = Read-LoggedInput $prompt
         if ($input -match '^(?i)exit$') { return @() }
         if ($AllowAll -and $input -eq 'all') { return $Items }
         $tokens = $input -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }

--- a/runner.ps1
+++ b/runner.ps1
@@ -153,7 +153,7 @@ function Set-LabConfig {
     function Edit-PrimitiveValue {
         param([string]$Path, [object]$Current)
         $prompt = "New value for '$Path' [$Current]"
-        $ans = Read-Host $prompt
+        $ans = Read-LoggedInput $prompt
         if (-not $ans) { return $Current }
         if ($Current -is [bool]) { return $ans -match '^(?i)y|true$' }
         if ($Current -is [int])  { return [int]$ans }
@@ -219,7 +219,7 @@ Write-CustomLog (Format-Config -Config $ConfigRaw)
 
 # ─── Optional customization ──────────────────────────────────────────────────
 if (-not $Auto) {
-    if ((Read-Host "Customize configuration? (Y/N)") -match '^(?i)y') {
+    if ((Read-LoggedInput "Customize configuration? (Y/N)") -match '^(?i)y') {
         $Config = Set-LabConfig -ConfigObject $Config
         if ($PSCmdlet.ShouldProcess($ConfigFile, 'Save updated configuration')) {
             $Config | ConvertTo-Json -Depth 5 | Out-File $ConfigFile -Encoding utf8
@@ -247,7 +247,7 @@ function Invoke-Scripts {
         if ($cleanup) {
             Write-CustomLog "WARNING: Cleanup script 0000 will remove local files."
             if (-not $Auto) {
-                if ((Read-Host "Continue with cleanup and exit? (Y/N)") -notmatch '^(?i)y') {
+                if ((Read-LoggedInput "Continue with cleanup and exit? (Y/N)") -notmatch '^(?i)y') {
                     Write-CustomLog 'Aborting per user request.'; return $false
                 }
             }
@@ -279,7 +279,7 @@ function Invoke-Scripts {
                         $Config | ConvertTo-Json -Depth 5 | Out-File -FilePath $ConfigFile -Encoding utf8
                         $current = $true
                     }
-                    elseif (-not $Auto -and (Read-Host "Enable flag '$flag' and run? (Y/N)") -match '^(?i)y') {
+                    elseif (-not $Auto -and (Read-LoggedInput "Enable flag '$flag' and run? (Y/N)") -match '^(?i)y') {
                         Set-NestedConfigValue -Config $Config -Path $flag -Value $true
                         $Config | ConvertTo-Json -Depth 5 | Out-File -FilePath $ConfigFile -Encoding utf8
                         $current = $true

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -171,7 +171,7 @@ else {
 # ------------------------------
 
 $rootCaName = $config.CertificateAuthority.CommonName
-$UserInput = Read-Host -Prompt "Enter the password for the Root CA certificate" -AsSecureString
+$UserInput = Read-LoggedInput -Prompt "Enter the password for the Root CA certificate" -AsSecureString
 $rootCaPassword = $UserInput
 $rootCaCertificate = Get-ChildItem cert:\LocalMachine\Root | Where-Object {$_.Subject -eq "CN=$rootCaName"}
 
@@ -229,7 +229,7 @@ if (-not $rootCaCertificate) {
 
 # Create Host Certificate
 $hostName      = [System.Net.Dns]::GetHostName()
-$UserInput = Read-Host -Prompt "Enter the password for the host." -AsSecureString
+$UserInput = Read-LoggedInput -Prompt "Enter the password for the host." -AsSecureString
 $hostPassword = $UserInput
 $hostCertificate = Get-ChildItem cert:\LocalMachine\My | Where-Object {$_.Subject -eq "CN=$hostName"}
 

--- a/runner_utility_scripts/LabRunner.psd1
+++ b/runner_utility_scripts/LabRunner.psd1
@@ -3,5 +3,5 @@
     ModuleVersion = '0.1.0'
     GUID = 'c0000000-0000-4000-8000-000000000001'
     Author = 'OpenTofu'
-    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Get-Platform','Get-LabConfig')
+    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Read-LoggedInput','Get-Platform','Get-LabConfig')
 }

--- a/runner_utility_scripts/LabRunner.psm1
+++ b/runner_utility_scripts/LabRunner.psm1
@@ -6,4 +6,4 @@
 
 # Only this side (LabRunner) brings ScriptTemplate in.
 
-Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform, Get-LabConfig
+Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Read-LoggedInput, Get-Platform, Get-LabConfig

--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -28,3 +28,20 @@ function Write-CustomLog {
         Write-Host $fmt -ForegroundColor $color
     }
 }
+
+function Read-LoggedInput {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Prompt,
+        [switch]$AsSecureString
+    )
+
+    if ($AsSecureString) {
+        Write-CustomLog "$Prompt (secure input)"
+        return Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt -AsSecureString
+    }
+
+    $answer = Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt
+    Write-CustomLog "$Prompt: $answer"
+    return $answer
+}

--- a/tests/Expand-All.Tests.ps1
+++ b/tests/Expand-All.Tests.ps1
@@ -10,6 +10,7 @@ Describe 'Expand-All' {
     }
     AfterEach {
         Remove-Item Function:Write-CustomLog -ErrorAction SilentlyContinue
+        Remove-Item Function:Read-LoggedInput -ErrorAction SilentlyContinue
     }
 
     It 'expands a specific ZIP file when provided' {
@@ -19,7 +20,7 @@ Describe 'Expand-All' {
         New-Item -ItemType File -Path $zipPath | Out-Null
 
         Mock Expand-Archive {}
-        Mock Read-Host { 'y' }
+        Mock Read-LoggedInput { 'y' }
 
         Expand-All -ZipFile $zipPath
 
@@ -37,7 +38,7 @@ Describe 'Expand-All' {
         $zip2 = Join-Path $subDir 'b.zip'
 
         Mock Expand-Archive {}
-        Mock Read-Host { 'y' }
+        Mock Read-LoggedInput { 'y' }
         Mock Get-ChildItem {
             @(
                 [pscustomobject]@{ FullName = $zip1; DirectoryName = $temp; BaseName = 'a' },
@@ -63,7 +64,7 @@ Describe 'Expand-All' {
         $zipPath = Join-Path $TestDrive 'missing.zip'
 
         Mock Expand-Archive {}
-        Mock Read-Host {}
+        Mock Read-LoggedInput {}
 
         Expand-All -ZipFile $zipPath
 
@@ -80,7 +81,7 @@ Describe 'Expand-All' {
         New-Item -ItemType File -Path $zipPath | Out-Null
 
         Mock Expand-Archive {}
-        Mock Read-Host { 'n' }
+        Mock Read-LoggedInput { 'n' }
 
         Expand-All -ZipFile $zipPath
 

--- a/tests/Menu.Tests.ps1
+++ b/tests/Menu.Tests.ps1
@@ -7,11 +7,11 @@ Describe 'Get-MenuSelection' {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
     }
     AfterEach {
-        Remove-Item Function:Read-Host -ErrorAction SilentlyContinue
+        Remove-Item Function:Read-LoggedInput -ErrorAction SilentlyContinue
     }
     It 'returns all items when user types all' {
         $items = @('0001_Test.ps1','0002_Other.ps1')
-        function global:Read-Host { param($Prompt) 'all' }
+        function global:Read-LoggedInput { param($Prompt) 'all' }
         $sel = Get-MenuSelection -Items $items -AllowAll
         $sel | Should -Be $items
     }
@@ -19,7 +19,7 @@ Describe 'Get-MenuSelection' {
         $items = @('0001_Test.ps1','0002_Other.ps1')
         $responses = @('0002')
         $script:i = 0
-        function global:Read-Host { param($Prompt) $responses[$script:i++] }
+        function global:Read-LoggedInput { param($Prompt) $responses[$script:i++] }
         $sel = Get-MenuSelection -Items $items
         $sel | Should -Be @('0002_Other.ps1')
     }

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -53,7 +53,7 @@ Describe 'Prepare-HyperVProvider path restoration' -Skip:($SkipNonWindows) {
         Mock go {}
         Mock Copy-Item {}
         Mock Convert-CerToPem {}
-        Mock Read-Host {
+        Mock Read-LoggedInput {
             $pwd = New-Object System.Security.SecureString
             foreach ($c in ''.ToCharArray()) { $pwd.AppendChar($c) }
             $pwd.MakeReadOnly()
@@ -112,7 +112,7 @@ Describe 'Prepare-HyperVProvider certificate handling' -Skip:($SkipNonWindows) {
         Mock Export-PfxCertificate {}
         Mock Import-PfxCertificate {}
         Mock Remove-Item {}
-        Mock Read-Host {
+        Mock Read-LoggedInput {
             $pwd = New-Object System.Security.SecureString
             foreach ($c in 'pw'.ToCharArray()) { $pwd.AppendChar($c) }
             $pwd.MakeReadOnly()

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -71,7 +71,7 @@ Describe 'runner.ps1 script selection' -Skip:($SkipNonWindows) {
     }
     AfterEach {
         Remove-Item Function:Write-Host -ErrorAction SilentlyContinue
-        Remove-Item Function:Read-Host -ErrorAction SilentlyContinue
+        Remove-Item Function:Read-LoggedInput -ErrorAction SilentlyContinue
         Remove-Item Function:Write-Warning -ErrorAction SilentlyContinue
         Remove-Item Function:Write-Error -ErrorAction SilentlyContinue
     }
@@ -85,7 +85,7 @@ exit 0" | Set-Content -Path $dummy
 
         Push-Location $tempDir
         Mock Get-MenuSelection {}
-        Mock Read-Host { throw 'Read-Host should not be called' }
+        Mock Read-LoggedInput { throw 'Read-LoggedInput should not be called' }
         & "$tempDir/runner.ps1" -Scripts '0001' -Auto | Out-Null
         Pop-Location
 
@@ -105,7 +105,7 @@ exit 0" | Set-Content -Path $dummy
         $env:PATH  = ''
         try {
             Push-Location $tempDir
-            Mock Read-Host { throw 'Read-Host should not be called' }
+            Mock Read-LoggedInput { throw 'Read-LoggedInput should not be called' }
             & "$tempDir/runner.ps1" -Scripts '0001' -Auto | Out-Null
             $code = $LASTEXITCODE
             Pop-Location
@@ -148,7 +148,7 @@ exit 0
 "@ | Set-Content -Path (Join-Path $scriptsDir '0002_Success.ps1')
 
         Push-Location $tempDir
-        Mock Read-Host { throw 'Read-Host should not be called' }
+        Mock Read-LoggedInput { throw 'Read-LoggedInput should not be called' }
         & "$tempDir/runner.ps1" -Scripts '0001,0002' -Auto | Out-Null
         $code = $LASTEXITCODE
         Pop-Location
@@ -177,7 +177,7 @@ exit 0
 "@ | Set-Content -Path (Join-Path $scriptsDir '0002_Success.ps1')
 
         Push-Location $tempDir
-        Mock Read-Host { throw 'Read-Host should not be called' }
+        Mock Read-LoggedInput { throw 'Read-LoggedInput should not be called' }
         & "$tempDir/runner.ps1" -Scripts '0001,0002' -Auto | Out-Null
         $code = $LASTEXITCODE
         Pop-Location
@@ -206,7 +206,7 @@ exit 0
 "@ | Set-Content -Path (Join-Path $scriptsDir '0001_Other.ps1')
 
         Push-Location $tempDir
-        Mock Read-Host { throw 'Read-Host should not be called' }
+        Mock Read-LoggedInput { throw 'Read-LoggedInput should not be called' }
         & "$tempDir/runner.ps1" -Scripts '0000,0001' -Auto | Out-Null
         $code = $LASTEXITCODE
         Pop-Location
@@ -232,7 +232,7 @@ if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath "$out" } else { Wri
             Set-Content -Path (Join-Path $scriptsDir '0001_Test.ps1')
 
         Push-Location $tempDir
-        Mock Read-Host { throw 'Read-Host should not be called' }
+        Mock Read-LoggedInput { throw 'Read-LoggedInput should not be called' }
         & "$tempDir/runner.ps1" -Scripts '0001' -Auto -ConfigFile $configFile -Force | Out-Null
         $updated1 = Get-Content -Raw $configFile | ConvertFrom-Json
 
@@ -261,7 +261,7 @@ if (`$Config.RunFoo -eq `$true) { 'foo' | Out-File -FilePath "$out" }
             Set-Content -Path (Join-Path $scriptsDir '0001_Test.ps1')
 
         Push-Location $tempDir
-        Mock Read-Host { throw 'Read-Host should not be called' }
+        Mock Read-LoggedInput { throw 'Read-LoggedInput should not be called' }
         & "$tempDir/runner.ps1" -Scripts '0001' -Auto -ConfigFile $configFile | Out-Null
         $updated1 = Get-Content -Raw $configFile | ConvertFrom-Json
 
@@ -287,7 +287,7 @@ Param([PSCustomObject]`$Config)
             Set-Content -Path (Join-Path $scriptsDir '0001_NoExit.ps1')
 
         Push-Location $tempDir
-        Mock Read-Host { throw 'Read-Host should not be called' }
+        Mock Read-LoggedInput { throw 'Read-LoggedInput should not be called' }
         & "$tempDir/runner.ps1" -Scripts '0001' -Auto | Out-Null
         $code = $LASTEXITCODE
         Pop-Location
@@ -484,25 +484,25 @@ Describe 'Set-LabConfig' {
                 switch ($choice) {
                     'Done' { return $ConfigObject }
                     'InstallGit' {
-                        $ans = Read-Host "InstallGit? (Y/N) [$($ConfigObject.InstallGit)]"
+                        $ans = Read-LoggedInput "InstallGit? (Y/N) [$($ConfigObject.InstallGit)]"
                         if ($ans) { $ConfigObject.InstallGit = $ans -match '^(?i)y' }
                     }
                     'InstallGo' {
-                        $ans = Read-Host "InstallGo? (Y/N) [$($ConfigObject.InstallGo)]"
+                        $ans = Read-LoggedInput "InstallGo? (Y/N) [$($ConfigObject.InstallGo)]"
                         if ($ans) { $ConfigObject.InstallGo = $ans -match '^(?i)y' }
                     }
                     'InstallOpenTofu' {
-                        $ans = Read-Host "InstallOpenTofu? (Y/N) [$($ConfigObject.InstallOpenTofu)]"
+                        $ans = Read-LoggedInput "InstallOpenTofu? (Y/N) [$($ConfigObject.InstallOpenTofu)]"
                         if ($ans) { $ConfigObject.InstallOpenTofu = $ans -match '^(?i)y' }
                     }
                     'LocalPath' {
-                        $ans = Read-Host "Local repo path [$($ConfigObject.LocalPath)]"
+                        $ans = Read-LoggedInput "Local repo path [$($ConfigObject.LocalPath)]"
                         if ($ans) { $ConfigObject.LocalPath = $ans }
                     }
                     'Node_Dependencies' {
-                        $p1 = Read-Host "Path to Node project [$($ConfigObject.Node_Dependencies.NpmPath)]"
+                        $p1 = Read-LoggedInput "Path to Node project [$($ConfigObject.Node_Dependencies.NpmPath)]"
                         if ($p1) { $ConfigObject.Node_Dependencies.NpmPath = $p1 }
-                        $p2 = Read-Host "Create NpmPath if missing? (Y/N) [$($ConfigObject.Node_Dependencies.CreateNpmPath)]"
+                        $p2 = Read-LoggedInput "Create NpmPath if missing? (Y/N) [$($ConfigObject.Node_Dependencies.CreateNpmPath)]"
                         if ($p2) { $ConfigObject.Node_Dependencies.CreateNpmPath = $p2 -match '^(?i)y' }
                     }
                 }
@@ -528,7 +528,7 @@ Describe 'Set-LabConfig' {
             'Y'
         )
         $script:idx = 0
-        function global:Read-Host {
+        function global:Read-LoggedInput {
             param([string]$Prompt)
             $null = $Prompt
             $answers[$script:idx++]


### PR DESCRIPTION
## Summary
- add `Read-LoggedInput` helper in Logger
- export new function in LabRunner modules
- log user prompts via `Read-LoggedInput`
- update scripts to use the new helper
- adjust tests for the new behaviour
- document that responses are logged

## Testing
- `Invoke-Pester`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491a51ab948331977df00e012121fa