### PR TITLE
Add full config option and doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pwsh -File runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto -Quiet
 Use a custom configuration file:
 
 ```powershell
-pwsh -File runner.ps1 -ConfigFile path\to\config.json -Scripts '0006,0007,0008,0009,0010' -Auto
+pwsh -File runner.ps1 -ConfigFile ./config_files/full-config.json -Scripts all -Auto
 ```
 
 Force optional script flags and show detailed logs:

--- a/config_files/full-config.json
+++ b/config_files/full-config.json
@@ -1,0 +1,89 @@
+{
+  "ComputerName": "default-lab",
+  "SetComputerName": true,
+  "DNSServers": "8.8.8.8,1.1.1.1",
+  "SetDNSServers": true,
+  "TrustedHosts": "",
+  "SetTrustedHosts": true,
+  "DisableTCPIP6": true,
+  "AllowRemoteDesktop": true,
+  "ConfigureFirewall": true,
+  "FirewallPorts": [
+    3389,
+    5985,
+    5986,
+    445,
+    135,
+    "49152-65535"
+  ],
+  "ConfigPXE": true,
+  "InstallGit": true,
+  "InstallGitHubCLI": true,
+  "InstallPwsh": true,
+  "InstallHyperV": true,
+  "InstallWAC": true,
+  "InstallGo": true,
+  "InstallOpenTofu": true,
+  "OpenTofuVersion": "latest",
+  "InitializeOpenTofu": true,
+  "PrepareHyperVHost": true,
+  "InstallCA": true,
+  "InstallCosign": true,
+  "CosignURL": "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-windows-amd64.exe",
+  "CosignPath": "C:\\temp\\cosign",
+  "InstallGPG": true,
+  "CertificateAuthority": {
+    "CommonName": "default-lab-RootCA",
+    "ValidityYears": 5
+  },
+  "HyperV": {
+    "User": "",
+    "Password": "",
+    "Host": "",
+    "Port": 5986,
+    "Https": true,
+    "Insecure": true,
+    "UseNtlm": true,
+    "EnableManagementTools": true,
+    "TlsServerName": "",
+    "CacertPath": "",
+    "CertPath": "",
+    "KeyPath": "",
+    "ScriptPath": "C:/Temp/terraform_%RAND%.cmd",
+    "Timeout": "30s"
+  },
+  "WAC": {
+    "InstallPort": 443
+  },
+  "GitHubCLIInstallerUrl": "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_windows_amd64.msi",
+  "RepoUrl": "https://github.com/wizzense/opentofu-lab-automation.git",
+  "LocalPath": "C:\\temp",
+  "RunnerScriptName": "runner.ps1",
+  "ConfigFile": "./config_files/full-config.json",
+  "Go": {
+    "InstallerUrl": "https://go.dev/dl/go1.24.1.windows-amd64.msi"
+  },
+  "InfraRepoUrl": "https://github.com/wizzense/tofu-base-lab.git",
+  "InfraRepoPath": "C:\\Temp\\base-infra",
+  "Directories": {
+    "HyperVPath": "C:\\HyperV",
+    "IsoSharePath": "C:\\iso_share"
+  },
+  "Node_Dependencies": {
+    "InstallNode": true,
+    "InstallYarn": true,
+    "InstallVite": true,
+    "InstallNodemon": true,
+    "InstallNpm": true,
+    "GlobalPackages": [
+      "yarn",
+      "vite",
+      "nodemon"
+    ],
+    "NpmPath": "C:\\Projects\\vde-mvp\\frontend",
+    "CreateNpmPath": true,
+    "Node": {
+      "InstallerUrl": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
+    }
+  }
+}

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -58,6 +58,12 @@ When running in CI or other automated environments, invoke the runner with `pwsh
 pwsh -File runner.ps1 -Scripts all -Auto
 ```
 
+Use the provided full configuration file to enable every feature:
+
+```powershell
+pwsh -File runner.ps1 -ConfigFile ./config_files/full-config.json -Scripts all -Auto
+```
+
 Individual scripts can also be executed directly:
 
 ```powershell

--- a/py/labctl/config_files/full-config.json
+++ b/py/labctl/config_files/full-config.json
@@ -1,0 +1,89 @@
+{
+  "ComputerName": "default-lab",
+  "SetComputerName": true,
+  "DNSServers": "8.8.8.8,1.1.1.1",
+  "SetDNSServers": true,
+  "TrustedHosts": "",
+  "SetTrustedHosts": true,
+  "DisableTCPIP6": true,
+  "AllowRemoteDesktop": true,
+  "ConfigureFirewall": true,
+  "FirewallPorts": [
+    3389,
+    5985,
+    5986,
+    445,
+    135,
+    "49152-65535"
+  ],
+  "ConfigPXE": true,
+  "InstallGit": true,
+  "InstallGitHubCLI": true,
+  "InstallPwsh": true,
+  "InstallHyperV": true,
+  "InstallWAC": true,
+  "InstallGo": true,
+  "InstallOpenTofu": true,
+  "OpenTofuVersion": "latest",
+  "InitializeOpenTofu": true,
+  "PrepareHyperVHost": true,
+  "InstallCA": true,
+  "InstallCosign": true,
+  "CosignURL": "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-windows-amd64.exe",
+  "CosignPath": "C:\\temp\\cosign",
+  "InstallGPG": true,
+  "CertificateAuthority": {
+    "CommonName": "default-lab-RootCA",
+    "ValidityYears": 5
+  },
+  "HyperV": {
+    "User": "",
+    "Password": "",
+    "Host": "",
+    "Port": 5986,
+    "Https": true,
+    "Insecure": true,
+    "UseNtlm": true,
+    "EnableManagementTools": true,
+    "TlsServerName": "",
+    "CacertPath": "",
+    "CertPath": "",
+    "KeyPath": "",
+    "ScriptPath": "C:/Temp/terraform_%RAND%.cmd",
+    "Timeout": "30s"
+  },
+  "WAC": {
+    "InstallPort": 443
+  },
+  "GitHubCLIInstallerUrl": "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_windows_amd64.msi",
+  "RepoUrl": "https://github.com/wizzense/opentofu-lab-automation.git",
+  "LocalPath": "C:\\temp",
+  "RunnerScriptName": "runner.ps1",
+  "ConfigFile": "./config_files/full-config.json",
+  "Go": {
+    "InstallerUrl": "https://go.dev/dl/go1.24.1.windows-amd64.msi"
+  },
+  "InfraRepoUrl": "https://github.com/wizzense/tofu-base-lab.git",
+  "InfraRepoPath": "C:\\Temp\\base-infra",
+  "Directories": {
+    "HyperVPath": "C:\\HyperV",
+    "IsoSharePath": "C:\\iso_share"
+  },
+  "Node_Dependencies": {
+    "InstallNode": true,
+    "InstallYarn": true,
+    "InstallVite": true,
+    "InstallNodemon": true,
+    "InstallNpm": true,
+    "GlobalPackages": [
+      "yarn",
+      "vite",
+      "nodemon"
+    ],
+    "NpmPath": "C:\\Projects\\vde-mvp\\frontend",
+    "CreateNpmPath": true,
+    "Node": {
+      "InstallerUrl": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `full-config.json` with every option enabled
- copy same file under `py/labctl/config_files`
- document using the new config in `README.md` and `docs/runner.md`

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491e7f7aa88331b25a1a8ee2c740b5