### PR TITLE
Auto-relaunch runner under pwsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,38 +17,38 @@ Powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -U
 
 
 ```
-**Note:** These scripts require PowerShell 7 or later. Install the latest `pwsh` and use it instead of `powershell.exe`.
+**Note:** `runner.ps1` automatically restarts with `pwsh` when invoked from Windows PowerShell. Ensure PowerShell 7 is installed and available in `PATH`.
 
 ### Runner usage
 
 Interactive mode:
 
 ```powershell
-pwsh -File runner.ps1
+./runner.ps1
 ```
 
 Fully automated Hyper-V setup:
 
 ```powershell
-pwsh -File runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto
+./runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto
 ```
 
 Silence most output:
 
 ```powershell
-pwsh -File runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto -Quiet
+./runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto -Quiet
 ```
 
 Use a custom configuration file:
 
 ```powershell
-pwsh -File runner.ps1 -ConfigFile path\to\config.json -Scripts '0006,0007,0008,0009,0010' -Auto
+./runner.ps1 -ConfigFile path\to\config.json -Scripts '0006,0007,0008,0009,0010' -Auto
 ```
 
 Force optional script flags and show detailed logs:
 
 ```powershell
-pwsh -File runner.ps1 -Scripts '0006,0007' -Auto -Force -Verbosity detailed
+./runner.ps1 -Scripts '0006,0007' -Auto -Force -Verbosity detailed
 ```
 
 ### CI usage
@@ -57,7 +57,7 @@ In automation scenarios or CI jobs, call the runner using `pwsh -File` so each
 child script sees a valid `$PSScriptRoot`:
 
 ```powershell
-pwsh -File runner.ps1 -Scripts all -Auto
+./runner.ps1 -Scripts all -Auto
 ```
 
 Individual step scripts can also be invoked this way when debugging:

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -1,14 +1,14 @@
 # runner.ps1 guide
 
 `runner.ps1` orchestrates the numbered scripts under `runner_scripts/`.
-It loads `config_files/default-config.json` by default and then prompts for script selection unless told otherwise.
+It loads `config_files/default-config.json` by default and then prompts for script selection unless told otherwise. When launched from Windows PowerShell it automatically restarts itself using `pwsh` so you can simply run `./runner.ps1`.
 
 ## Interactive mode
 
-Simply invoke the script with no parameters using `pwsh -File`:
+Simply invoke the script from the repository root:
 
 ```powershell
-pwsh -File runner.ps1
+./runner.ps1
 ```
 
 You will be shown a menu to choose which scripts to run. After the selected scripts complete, the menu will appear again so you can run additional scripts without restarting the runner. Type `exit` at the prompt when you are finished.
@@ -22,13 +22,13 @@ defaults** to merge values from `config_files/recommended-config.json`.
 Supply a comma-separated list of 4-digit script prefixes via `-Scripts` to run without prompts. Combine this with `-Auto` to skip configuration customization and cleanup confirmations.
 
 ```powershell
-pwsh -File runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto
+./runner.ps1 -Scripts '0006,0007,0008,0009,0010' -Auto
 ```
 
 To quickly gather system information, run script `0200` directly:
 
 ```powershell
-pwsh -File runner.ps1 -Scripts '0200'
+./runner.ps1 -Scripts '0200'
 ```
 
 The script now calls `Get-Platform` to detect the host OS. On Windows it
@@ -42,7 +42,7 @@ To suppress informational output, use the `-Quiet` switch (equivalent to
 silently and non-interactively:
 
 ```powershell
-pwsh -File runner.ps1 -Scripts '0006,0007' -Auto -Quiet
+./runner.ps1 -Scripts '0006,0007' -Auto -Quiet
 ```
 
 You can also specify the output level directly with the `-Verbosity`
@@ -52,10 +52,10 @@ The default configuration path (`./config_files/default-config.json`) and the `-
 
 ### CI usage
 
-When running in CI or other automated environments, invoke the runner with `pwsh -File` so each step script receives a populated `$PSScriptRoot`:
+When running in CI or other automated environments, you can call the runner directly. It relaunches itself with `pwsh` so each step script receives a populated `$PSScriptRoot`:
 
 ```powershell
-pwsh -File runner.ps1 -Scripts all -Auto
+./runner.ps1 -Scripts all -Auto
 ```
 
 Individual scripts can also be executed directly:

--- a/runner.ps1
+++ b/runner.ps1
@@ -2,7 +2,7 @@
 param(
     [Parameter(ParameterSetName='Normal')]
     [Parameter(ParameterSetName='Quiet')]
-    [string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files' 'default-config.json'),
+    [string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files/default-config.json'),
 
     [Parameter(ParameterSetName='Normal')]
     [Parameter(ParameterSetName='Quiet')]
@@ -37,9 +37,20 @@ if (-not (Test-Path $pwshPath)) {
 }
 
 
+
+# Re-launch under PowerShell 7 when invoked from Windows PowerShell
 if ($PSVersionTable.PSVersion.Major -lt 7) {
-    Write-Error "PowerShell 7 or later is required. Current version: $($PSVersionTable.PSVersion)"
-    exit 1
+    $argList = @()
+    foreach ($kvp in $PSBoundParameters.GetEnumerator()) {
+        if ($kvp.Value -is [System.Management.Automation.SwitchParameter]) {
+            if ($kvp.Value.IsPresent) { $argList += "-$($kvp.Key)" }
+        } else {
+            $argList += "-$($kvp.Key)"
+            $argList += $kvp.Value
+        }
+    }
+    & $pwshPath -File $PSCommandPath @argList
+    exit $LASTEXITCODE
 }
 
 # expose quiet flag to logger and apply before console level calculation

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -118,6 +118,42 @@ exit 0" | Set-Content -Path $dummy
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
 
+    It 'relaunches under pwsh when invoked from PowerShell 5' {
+        $tempDir   = New-RunnerTestEnv
+        $scriptsDir = Join-Path $tempDir 'runner_scripts'
+        $dummy      = Join-Path $scriptsDir '0001_Test.ps1'
+        "Param([PSCustomObject]`$Config)
+exit 0" | Set-Content -Path $dummy
+
+        $binDir = Join-Path $tempDir 'bin'
+        New-Item -ItemType Directory -Path $binDir | Out-Null
+        $outFile = Join-Path $binDir 'invoked.txt'
+        $stub    = Join-Path $binDir 'pwsh'
+        $stubContent = @"
+#!/bin/bash
+echo stub > \"$outFile\"
+"@
+        Set-Content -Path $stub -Value $stubContent -NoNewline
+        chmod +x $stub
+
+        $oldPath = $env:PATH
+        $env:PATH  = "${binDir}:${oldPath}"
+        $origVer = $PSVersionTable.PSVersion
+        try {
+            Push-Location $tempDir
+            $PSVersionTable.PSVersion = [version]'5.1'
+            & "$tempDir/runner.ps1" -Scripts '0001' -Auto | Out-Null
+            $PSVersionTable.PSVersion = $origVer
+            Pop-Location
+        } finally {
+            $env:PATH = $oldPath
+            $PSVersionTable.PSVersion = $origVer
+        }
+
+        Test-Path $outFile | Should -BeTrue
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
+
     It 'exits with code 1 when -Scripts has no matching prefixes' {
         $tempDir   = New-RunnerTestEnv
         Push-Location $tempDir
@@ -136,16 +172,18 @@ exit 0" | Set-Content -Path $dummy
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
         $out1       = Join-Path $tempDir 'out1.txt'
         $out2       = Join-Path $tempDir 'out2.txt'
-        @"
+        $failContent = @"
 Param([PSCustomObject]`$Config)
 '1' | Out-File -FilePath "$out1"
 exit 1
-"@ | Set-Content -Path (Join-Path $scriptsDir '0001_Fail.ps1')
-        @"
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0001_Fail.ps1') -Value $failContent
+        $successContent = @"
 Param([PSCustomObject]`$Config)
 '2' | Out-File -FilePath "$out2"
 exit 0
-"@ | Set-Content -Path (Join-Path $scriptsDir '0002_Success.ps1')
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0002_Success.ps1') -Value $successContent
 
         Push-Location $tempDir
         Mock Read-Host { throw 'Read-Host should not be called' }
@@ -165,16 +203,18 @@ exit 0
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
         $out1       = Join-Path $tempDir 'out1_throw.txt'
         $out2       = Join-Path $tempDir 'out2_throw.txt'
-        @"
+        $throwContent = @"
 Param([PSCustomObject]`$Config)
 '1' | Out-File -FilePath "$out1"
 throw 'bad'
-"@ | Set-Content -Path (Join-Path $scriptsDir '0001_Throw.ps1')
-        @"
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0001_Throw.ps1') -Value $throwContent
+        $successContent = @"
 Param([PSCustomObject]`$Config)
 '2' | Out-File -FilePath "$out2"
 exit 0
-"@ | Set-Content -Path (Join-Path $scriptsDir '0002_Success.ps1')
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0002_Success.ps1') -Value $successContent
 
         Push-Location $tempDir
         Mock Read-Host { throw 'Read-Host should not be called' }
@@ -194,16 +234,18 @@ exit 0
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
         $out1       = Join-Path $tempDir 'out_cleanup.txt'
         $out2       = Join-Path $tempDir 'out_other.txt'
-        @"
+        $cleanupContent = @"
 Param([PSCustomObject]`$Config)
 'c' | Out-File -FilePath "$out1"
 exit 0
-"@ | Set-Content -Path (Join-Path $scriptsDir '0000_Cleanup.ps1')
-        @"
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0000_Cleanup.ps1') -Value $cleanupContent
+        $otherContent = @"
 Param([PSCustomObject]`$Config)
 'o' | Out-File -FilePath "$out2"
 exit 0
-"@ | Set-Content -Path (Join-Path $scriptsDir '0001_Other.ps1')
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0001_Other.ps1') -Value $otherContent
 
         Push-Location $tempDir
         Mock Read-Host { throw 'Read-Host should not be called' }
@@ -301,11 +343,12 @@ Param([PSCustomObject]`$Config)
     It 'suppresses informational logs when -Verbosity silent is used' {
         $tempDir   = New-RunnerTestEnv
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
-        @"
+        $logContent = @"
 Param([PSCustomObject]`$Config)
 Write-Warning 'warn message'
 Write-Error 'err message'
-"@ | Set-Content -Path (Join-Path $scriptsDir '0001_Log.ps1')
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0001_Log.ps1') -Value $logContent
 
         Push-Location $tempDir
         $script:logLines = @()
@@ -331,11 +374,12 @@ Write-Error 'err message'
     It 'suppresses informational logs when -Quiet is used' {
         $tempDir   = New-RunnerTestEnv
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
-        @"
+        $logContent = @"
 Param([PSCustomObject]`$Config)
 Write-Warning 'warn message'
 Write-Error 'err message'
-"@ | Set-Content -Path (Join-Path $scriptsDir '0001_Log.ps1')
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0001_Log.ps1') -Value $logContent
 
         Push-Location $tempDir
         $script:logLines = @()
@@ -358,11 +402,12 @@ Write-Error 'err message'
     It 'suppresses informational logs when -Verbosity silent is used' {
         $tempDir   = New-RunnerTestEnv
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
-        @"
+        $logContent = @"
 Param([PSCustomObject]`$Config)
 Write-Warning 'warn message'
 Write-Error 'err message'
-"@ | Set-Content -Path (Join-Path $scriptsDir '0001_Log.ps1')
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0001_Log.ps1') -Value $logContent
 
         Push-Location $tempDir
         $script:logLines = @()
@@ -407,11 +452,12 @@ exit 0" | Set-Content -Path (Join-Path $scriptsDir '0001_Test.ps1')
         $tempDir   = New-RunnerTestEnv
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
         $out        = Join-Path $tempDir 'out.txt'
-        @"
+        $testContent = @"
 Param([PSCustomObject]`$Config)
 'ran' | Out-File -FilePath "$out"
 exit 0
-"@ | Set-Content -Path (Join-Path $scriptsDir '0001_Test.ps1')
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0001_Test.ps1') -Value $testContent
 
         Mock Get-MenuSelection { @() }
         Mock-WriteLog
@@ -430,10 +476,11 @@ exit 0
     It 'logs script output exactly once' {
         $tempDir   = New-RunnerTestEnv
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
-        @"
+        $echoContent = @"
 Param([PSCustomObject]`$Config)
 Write-CustomLog 'hello world'
-"@ | Set-Content -Path (Join-Path $scriptsDir '0001_Echo.ps1')
+"@
+        Set-Content -Path (Join-Path $scriptsDir '0001_Echo.ps1') -Value $echoContent
 
         Push-Location $tempDir
         $script:messages = @()


### PR DESCRIPTION
## Summary
- fix default config path
- auto-relaunch `runner.ps1` under PowerShell 7 when invoked from Windows PowerShell
- document that `./runner.ps1` works without extra args
- update Pester tests for relaunch logic

## Testing
- `pytest -q`
- `Invoke-Pester -Configuration @{Run=@{Path="tests"}}`

------
https://chatgpt.com/codex/tasks/task_e_68491ebb767c8331bafd1aea021ea82a