### PR TITLE
Allow runner config via path or object

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -67,7 +67,7 @@ pwsh -File runner_scripts/0001_Reset-Git.ps1 -Config ./config_files/default-conf
 Step scripts import a small PowerShell module that provides common helpers:
 
 ```powershell
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 ```
 

--- a/lab_utils/LabRunner/LabRunner.psm1
+++ b/lab_utils/LabRunner/LabRunner.psm1
@@ -5,7 +5,7 @@
 function Invoke-LabStep {
     param(
         [scriptblock]$Body,
-        [pscustomobject]$Config
+        [object]$Config
     )
 
     if ($Config -is [string]) {

--- a/lab_utils/LabRunner/ScriptTemplate.ps1
+++ b/lab_utils/LabRunner/ScriptTemplate.ps1
@@ -2,10 +2,10 @@ if (-not $PSScriptRoot) {
     $PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 }
 
-#Param([pscustomobject]$Config)
+#Param([object]$Config)
 
 function Invoke-LabStep {
-    param([scriptblock]$Body, [pscustomobject]$Config)
+    param([scriptblock]$Body, [object]$Config)
     if ($Config -is [string]) {
         if (Test-Path $Config) {
             $Config = Get-Content -Raw -Path $Config | ConvertFrom-Json

--- a/lab_utils/LabSetup/LabSetup.psm1
+++ b/lab_utils/LabSetup/LabSetup.psm1
@@ -5,7 +5,7 @@
 function Invoke-LabStep {
     param(
         [scriptblock]$Body,
-        [pscustomobject]$Config
+        [object]$Config
     )
 
     if ($Config -is [string]) {

--- a/lab_utils/LabSetup/ScriptTemplate.ps1
+++ b/lab_utils/LabSetup/ScriptTemplate.ps1
@@ -2,10 +2,10 @@ if (-not $PSScriptRoot) {
     $PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 }
 
-#Param([pscustomobject]$Config)
+#Param([object]$Config)
 
 function Invoke-LabStep {
-    param([scriptblock]$Body, [pscustomobject]$Config)
+    param([scriptblock]$Body, [object]$Config)
     if ($Config -is [string]) {
         if (Test-Path $Config) {
             $Config = Get-Content -Raw -Path $Config | ConvertFrom-Json

--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"

--- a/runner_scripts/0002_Setup-Directories.ps1
+++ b/runner_scripts/0002_Setup-Directories.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 

--- a/runner_scripts/0007_Install-Go.ps1
+++ b/runner_scripts/0007_Install-Go.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Invoke-OpenTofuInstaller {
@@ -16,7 +16,7 @@ function Invoke-OpenTofuInstaller {
 
 function Install-OpenTofu {
     [CmdletBinding()]
-    param([pscustomobject]$Config)
+    param([object]$Config)
 
     Invoke-LabStep -Config $Config -Body {
         Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"

--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 $scriptRoot = $PSScriptRoot
 Import-Module "$scriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 

--- a/runner_scripts/0100_Enable-WinRM.ps1
+++ b/runner_scripts/0100_Enable-WinRM.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0101_Enable-RemoteDesktop.ps1
+++ b/runner_scripts/0101_Enable-RemoteDesktop.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0102_Configure-Firewall.ps1
+++ b/runner_scripts/0102_Configure-Firewall.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0103_Change-ComputerName.ps1
+++ b/runner_scripts/0103_Change-ComputerName.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -1,9 +1,9 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Install-CA {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    param([pscustomobject]$Config)
+    param([object]$Config)
 
     Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"

--- a/runner_scripts/0105_Install-HyperV.ps1
+++ b/runner_scripts/0105_Install-HyperV.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0106_Install-WAC.ps1
+++ b/runner_scripts/0106_Install-WAC.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 

--- a/runner_scripts/0111_Disable-TCPIP6.ps1
+++ b/runner_scripts/0111_Disable-TCPIP6.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0112_Enable-PXE.ps1
+++ b/runner_scripts/0112_Enable-PXE.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0113_Config-DNS.ps1
+++ b/runner_scripts/0113_Config-DNS.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -1,5 +1,5 @@
 Param(
-    [pscustomobject]$Config,
+    [object]$Config,
     [switch]$AsJson
 )
 
@@ -9,7 +9,7 @@ function Get-SystemInfo {
     [CmdletBinding()]
     param(
         [switch]$AsJson,
-        [pscustomobject]$Config
+        [object]$Config
     )
 
     Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -1,10 +1,10 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 
 function Install-NodeCore {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    param([pscustomobject]$Config)
+    param([object]$Config)
 
     Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 
@@ -23,7 +23,7 @@ function Install-GlobalPackage {
 
 function Install-NodeGlobalPackages {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    param([pscustomobject]$Config)
+    param([object]$Config)
 
     Invoke-LabStep -Config $Config -Body {
     param($Config)

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -1,13 +1,13 @@
 Param(
     [Parameter(Mandatory)]
-    [pscustomobject]$Config
+    [object]$Config
 )
 
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Install-NpmDependencies {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    param([pscustomobject]$Config)
+    param([object]$Config)
 
 
     Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/9999_Reset-Machine.ps1
+++ b/runner_scripts/9999_Reset-Machine.ps1
@@ -1,4 +1,4 @@
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_utility_scripts/ScriptTemplate.ps1
+++ b/runner_utility_scripts/ScriptTemplate.ps1
@@ -2,7 +2,7 @@ if (-not $PSScriptRoot) {
     $PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 }
 
-#Param([pscustomobject]$Config)
+#Param([object]$Config)
 
 if (-not (Get-Module -Name LabRunner)) {
     Import-Module (Join-Path $PSScriptRoot '..\runner_utility_scripts\LabRunner.psd1')
@@ -10,7 +10,7 @@ if (-not (Get-Module -Name LabRunner)) {
 
 
 function Invoke-LabStep {
-    param([scriptblock]$Body, [pscustomobject]$Config)
+    param([scriptblock]$Body, [object]$Config)
     if ($Config -is [string]) {
         if (Test-Path $Config) {
             $Config = Get-Content -Raw -Path $Config | ConvertFrom-Json


### PR DESCRIPTION
## Summary
- relax config type to `[object]` in all runner scripts
- update `Invoke-LabStep` helpers to accept objects or file paths
- refresh docs snippet to match new signature

## Testing
- `pytest -q`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68491f5c990083319d59e28211cfb894