### PR TITLE
Update runner doc parameter usage

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -67,9 +67,14 @@ pwsh -File runner_scripts/0001_Reset-Git.ps1 -Config ./config_files/default-conf
 Step scripts import a small PowerShell module that provides common helpers:
 
 ```powershell
-Param([pscustomobject]$Config)
+Param([object]$Config)
 Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
 ```
+
+The `-Config` parameter can be either a path to a JSON file or a
+PowerShell object that has already been parsed. The runner passes an
+object to each step script, while manual invocation may supply the file
+path as shown above.
 
 `LabRunner` exposes functions like `Invoke-LabStep`, `Write-CustomLog` and
 `Get-Platform` so every script shares the same logging and platform detection


### PR DESCRIPTION
## Summary
- document the generic `[object]` config parameter
- note that step scripts accept a path or parsed object

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration (Import-PowerShellDataFile -Path 'tests/PesterConfiguration.psd1')"`

------
https://chatgpt.com/codex/tasks/task_e_68491f668a5c8331854368bc44339342