### PR TITLE
Handle null Config in Format-Config

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -6,11 +6,15 @@ function Format-Config {
             ValueFromPipelineByPropertyName = $true,
             Mandatory
         )]
-        [AllowNull()]
         [psobject]$Config
     )
 
-    begin { $hasInput = $false }
+    begin {
+        $hasInput = $false
+        if ($PSBoundParameters.ContainsKey('Config') -and $null -eq $Config) {
+            throw [System.ArgumentNullException]::new('Config')
+        }
+    }
 
     process {
         $hasInput = $true


### PR DESCRIPTION
## Summary
- guard against passing null to `Format-Config`
- keep final check in `end` block

## Testing
- `Invoke-Pester tests/Format-Config.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68491f9b94f88331a3237122ca5180fb