### PR TITLE
Fix artifact message wording

### DIFF
--- a/lab_utils/Get-WindowsJobArtifacts.ps1
+++ b/lab_utils/Get-WindowsJobArtifacts.ps1
@@ -66,7 +66,7 @@ if ($useGh) {
         }
 
         if (-not $found) {
-            Write-Host 'No Windows artifacts found in recent runs. Try specifying -RunId to select a specific run.' -ForegroundColor Yellow
+            Write-Host 'No artifacts found in recent Windows runs. Try specifying -RunId to select a specific run.' -ForegroundColor Yellow
             exit 1
         }
     }


### PR DESCRIPTION
## Summary
- standardize "No artifacts" message in Get-WindowsJobArtifacts.ps1

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/Get-WindowsJobArtifacts.Tests.ps1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491fa0331c83318df58dc9eda73b92