### PR TITLE
Update Initialize-OpenTofu repo handling

### DIFF
--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -61,31 +61,13 @@ if ($Config.InitializeOpenTofu -eq $true) {
 if (-not [string]::IsNullOrWhiteSpace($infraRepoUrl)) {
     Write-CustomLog "InfraRepoUrl detected: $infraRepoUrl"
 
-    # If infraRepoPath is already a Git repo, do a pull instead of clone
-    if (Test-Path (Join-Path $infraRepoPath ".git")) {
-        Write-CustomLog "This directory is already a Git repository. Pulling latest changes..."
-        Push-Location $infraRepoPath
-        try {
-            git pull
-        }
-        finally {
-            Pop-Location
-        }
+    if (Test-Path (Join-Path $infraRepoPath '.git')) {
+        Write-CustomLog "Directory exists. Pulling latest changes..."
+        git -C $infraRepoPath pull
     }
     else {
-        # If you want a clean slate each time, uncomment the lines below to remove existing files
-        # Remove-Item -Path (Join-Path $infraRepoPath "*") -Recurse -Force -ErrorAction SilentlyContinue
-
-
-        Write-CustomLog "Cloning $infraRepoUrl to $infraRepoPath..."
-        $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
-        if ($ghCmd) {
-            gh repo clone $infraRepoUrl $infraRepoPath
-        }
-        else {
-            git clone $infraRepoUrl $infraRepoPath
-        }
-        
+        Write-CustomLog "Repository not found. Cloning $infraRepoUrl to $infraRepoPath..."
+        gh repo clone $infraRepoUrl $infraRepoPath
         if ($LASTEXITCODE -ne 0) {
             Write-Error "ERROR: Failed to clone $infraRepoUrl"
             exit 1

--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -63,8 +63,8 @@ InModuleScope LabSetup {
 
         & $script:ScriptPath -Config $config
 
-        Should -Invoke -CommandName git -Times 1 -ParameterFilter { $args[0] -eq 'pull' }
-        Should -Invoke -CommandName git -Times 0 -ParameterFilter { $args[0] -eq 'clone' }
+        Should -Invoke -CommandName git -Times 1 -ParameterFilter { $args[0] -eq '-C' -and $args[2] -eq 'pull' }
+        Should -Invoke -CommandName git -Times 0 -ParameterFilter { $args[2] -eq 'clone' }
         Should -Invoke -CommandName tofu -Times 1 -ParameterFilter { $args[0] -eq 'init' }
 
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- update repo clone logic in `0009_Initialize-OpenTofu.ps1`
- adjust matching Pester test expectations

## Testing
- `Invoke-Pester tests/Initialize-OpenTofu.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68491fa1524883318c60ce844259b48a