### PR TITLE
Improve PFX conversion validation

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -37,25 +37,40 @@ function Convert-PfxToPem {
         [ValidateNotNullOrEmpty()]
         [string]$KeyPath
     )
+    if ([string]::IsNullOrWhiteSpace($PfxPath)) { throw 'PfxPath cannot be null or empty' }
+    if ([string]::IsNullOrWhiteSpace($CertPath)) { throw 'CertPath cannot be null or empty' }
+    if ([string]::IsNullOrWhiteSpace($KeyPath))  { throw 'KeyPath cannot be null or empty' }
+
     if (-not $PSCmdlet.ShouldProcess($PfxPath, 'Convert PFX to PEM')) { return }
     if (-not (Test-Path $PfxPath) -or ((Get-Item -Path $PfxPath -ErrorAction SilentlyContinue).Length -eq 0)) {
         throw "Invalid or unreadable PFX at $PfxPath"
     }
+
     try {
-        $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($PfxPath,$Password,[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
-    } catch {
+        $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
+            $PfxPath,
+            $Password,
+            [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+        )
+
+        $certBytes = $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+        $certB64   = [System.Convert]::ToBase64String($certBytes,'InsertLineBreaks')
+        if ($PSCmdlet.ShouldProcess($CertPath, 'Write certificate PEM')) {
+            "-----BEGIN CERTIFICATE-----`n$certB64`n-----END CERTIFICATE-----" | Set-Content -Path $CertPath
+        }
+
+        $rsa = $cert.GetRSAPrivateKey()
+        $keyBytes = $rsa.ExportPkcs8PrivateKey()
+        $keyB64   = [System.Convert]::ToBase64String($keyBytes,'InsertLineBreaks')
+        if ($PSCmdlet.ShouldProcess($KeyPath, 'Write key PEM')) {
+            "-----BEGIN PRIVATE KEY-----`n$keyB64`n-----END PRIVATE KEY-----" | Set-Content -Path $KeyPath
+        }
+    }
+    catch [System.Security.Cryptography.CryptographicException] {
+        throw "Failed to convert certificate: $($_.Exception.Message)"
+    }
+    catch {
         throw "Invalid or unreadable PFX at $PfxPath"
-    }
-    $certBytes = $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
-    $certB64   = [System.Convert]::ToBase64String($certBytes,'InsertLineBreaks')
-    if ($PSCmdlet.ShouldProcess($CertPath, 'Write certificate PEM')) {
-        "-----BEGIN CERTIFICATE-----`n$certB64`n-----END CERTIFICATE-----" | Set-Content -Path $CertPath
-    }
-    $rsa = $cert.GetRSAPrivateKey()
-    $keyBytes = $rsa.ExportPkcs8PrivateKey()
-    $keyB64   = [System.Convert]::ToBase64String($keyBytes,'InsertLineBreaks')
-    if ($PSCmdlet.ShouldProcess($KeyPath, 'Write key PEM')) {
-        "-----BEGIN PRIVATE KEY-----`n$keyB64`n-----END PRIVATE KEY-----" | Set-Content -Path $KeyPath
     }
 }
 }


### PR DESCRIPTION
## Summary
- check for blank paths in `Convert-PfxToPem`
- wrap certificate conversion in `try/catch`

## Testing
- `Invoke-Pester tests/PrepareHyperVProvider.Tests.ps1` *(fails: `powershell` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491fa3d04c8331a870d3f626fde055