### PR TITLE
Simplify quiet mode handling in runner

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -1,25 +1,15 @@
-[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName='Normal')]
+[CmdletBinding(SupportsShouldProcess)]
 param(
-    [Parameter(ParameterSetName='Normal')]
-    [Parameter(ParameterSetName='Quiet')]
     [string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files' 'default-config.json'),
 
-    [Parameter(ParameterSetName='Normal')]
-    [Parameter(ParameterSetName='Quiet')]
     [switch]$Auto,
 
-    [Parameter(ParameterSetName='Normal')]
-    [Parameter(ParameterSetName='Quiet')]
     [string]$Scripts,
 
-    [Parameter(ParameterSetName='Normal')]
-    [Parameter(ParameterSetName='Quiet')]
     [switch]$Force,
 
-    [Parameter(ParameterSetName='Quiet', Mandatory=$true)]
     [switch]$Quiet,
 
-    [Parameter(ParameterSetName='Normal')]
     [ValidateSet('silent','normal','detailed')]
     [string]$Verbosity = 'normal'
 )


### PR DESCRIPTION
## Summary
- merge `Normal` and `Quiet` parameter sets in `runner.ps1`
- treat `-Quiet` as a simple flag that forces `Verbosity` to `silent`

## Testing
- `Invoke-Pester tests/Runner.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68491fa4755083319f1adcbf88ef091a