### PR TITLE
Ensure runner scripts log start and finish

### DIFF
--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -58,4 +58,5 @@ finally {
         Set-Location $env:TEMP
     }
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -1,6 +1,7 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
+Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
 
 # Determine InfraPath
@@ -57,4 +58,5 @@ else {
         Pop-Location
     }
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0002_Setup-Directories.ps1
+++ b/runner_scripts/0002_Setup-Directories.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -28,4 +28,5 @@ Invoke-LabStep -Config $Config -Body {
             Write-CustomLog "Directory '$dir' already exists; skipping."
         }
     }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 
 function Install-Cosign {
@@ -71,4 +71,5 @@ elseif ($Config.InstallGpg -eq $true) {
 if (-not $Config.InstallCosign -and -not $Config.InstallGpg) {
     Write-CustomLog "No installation option specified. Use -InstallCosign and/or -InstallGpg when running this script."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0007_Install-Go.ps1
+++ b/runner_scripts/0007_Install-Go.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -48,4 +48,5 @@ if ($Config.InstallGo -eq $true) {
 } else {
     Write-CustomLog "InstallGo flag is disabled. Skipping Go installation."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Invoke-OpenTofuInstaller {
     param(
@@ -28,6 +28,7 @@ function Install-OpenTofu {
         } else {
             Write-CustomLog "InstallOpenTofu flag is disabled. Skipping OpenTofu installation."
         }
+        Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
     }
 }
 

--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -1,6 +1,6 @@
 Param([pscustomobject]$Config)
 $scriptRoot = $PSScriptRoot
-Import-Module "$scriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 $installScript      = Join-Path $scriptRoot '0008_Install-OpenTofu.ps1'
 $installerAvailable = Test-Path $installScript
@@ -217,4 +217,5 @@ exit 0
 } else {
     Write-CustomLog "InitializeOpenTofu flag is disabled. Skipping initialization."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 
 if (-not (Get-Command Convert-CerToPem -ErrorAction SilentlyContinue)) {
@@ -426,4 +426,5 @@ You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
     Write-CustomLog "PrepareHyperVHost flag is disabled. Skipping Hyper-V host preparation."
 }
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0100_Enable-WinRM.ps1
+++ b/runner_scripts/0100_Enable-WinRM.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -23,4 +23,5 @@ if ($winrmStatus -and $winrmStatus.Status -eq 'Running') {
     
     Write-CustomLog "WinRM has been enabled."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0101_Enable-RemoteDesktop.ps1
+++ b/runner_scripts/0101_Enable-RemoteDesktop.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -22,4 +22,5 @@ if ($Config.AllowRemoteDesktop -eq $true) {
 else {
     Write-CustomLog "Remote Desktop is NOT enabled by config."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0102_Configure-Firewall.ps1
+++ b/runner_scripts/0102_Configure-Firewall.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -19,4 +19,5 @@ if ($null -ne $Config.FirewallPorts) {
 } else {
     Write-CustomLog "No firewall ports specified."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0103_Change-ComputerName.ps1
+++ b/runner_scripts/0103_Change-ComputerName.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -33,4 +33,5 @@ if ($config.SetComputerName -eq $true) {
 } else {
     Write-CustomLog "SetComputerName flag is disabled. Skipping computer name change."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Install-CA {
     [CmdletBinding(SupportsShouldProcess = $true)]
@@ -78,4 +78,5 @@ Write-CustomLog "Standalone Root CA '$CAName' installation complete."
 }
 }
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 if ($MyInvocation.InvocationName -ne '.') { Install-CA @PSBoundParameters }

--- a/runner_scripts/0105_Install-HyperV.ps1
+++ b/runner_scripts/0105_Install-HyperV.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -41,4 +41,5 @@ if ($Config.InstallHyperV -eq $true) {
 } else {
     Write-CustomLog "InstallHyperV flag is disabled. Skipping Hyper-V installation."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0106_Install-WAC.ps1
+++ b/runner_scripts/0106_Install-WAC.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 
 function Get-WacRegistryInstallation {
@@ -66,4 +66,5 @@ if ($Config.InstallWAC -eq $true) {
 } else {
     Write-CustomLog "InstallWAC flag is disabled. Skipping Windows Admin Center installation."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0111_Disable-TCPIP6.ps1
+++ b/runner_scripts/0111_Disable-TCPIP6.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -12,4 +12,5 @@ if ($Config.DisableTCPIP6 -eq $true) {
 } else {
     Write-CustomLog "DisableTCPIP6 flag is disabled. Skipping IPv6 configuration."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0112_Enable-PXE.ps1
+++ b/runner_scripts/0112_Enable-PXE.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -18,4 +18,5 @@ if ($Config.ConfigPXE -eq $true) {
 } else {
     Write-CustomLog 'ConfigPXE is false. Skipping PXE firewall configuration.'
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0113_Config-DNS.ps1
+++ b/runner_scripts/0113_Config-DNS.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -13,4 +13,5 @@ if ($Config.SetDNSServers -eq $true) {
 } else {
     Write-CustomLog "SetDNSServers flag is disabled. Skipping DNS configuration."
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -12,4 +12,5 @@ Invoke-LabStep -Config $Config -Body {
     } else {
         Write-CustomLog "SetTrustedHosts flag is disabled. Skipping TrustedHosts configuration."
     }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -3,7 +3,7 @@ Param(
     [switch]$AsJson
 )
 
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Get-SystemInfo {
     [CmdletBinding()]
@@ -126,4 +126,5 @@ function Get-SystemInfo {
 
 if ($MyInvocation.InvocationName -ne '.') {
     Get-SystemInfo @PSBoundParameters
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 
 function Install-NodeCore {
@@ -70,4 +70,5 @@ if ($nodeDeps.InstallNode) {
 }
 }
 }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 if ($MyInvocation.InvocationName -ne '.') { Install-NodeCore @PSBoundParameters }

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 
 function Install-GlobalPackage {
@@ -99,6 +99,7 @@ foreach ($pkg in $packages) {
 }
 
 Write-CustomLog "==== Global npm package installation complete ===="
+        Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }
 }
 if ($MyInvocation.InvocationName -ne '.') { Install-NodeGlobalPackages @PSBoundParameters }

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -3,7 +3,7 @@ Param(
     [pscustomobject]$Config
 )
 
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Install-NpmDependencies {
     [CmdletBinding(SupportsShouldProcess = $true)]
@@ -114,4 +114,5 @@ function Install-NpmDependencies {
     }
 }
 
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 if ($MyInvocation.InvocationName -ne '.') { Install-NpmDependencies @PSBoundParameters }

--- a/runner_scripts/9999_Reset-Machine.ps1
+++ b/runner_scripts/9999_Reset-Machine.ps1
@@ -1,5 +1,5 @@
 Param([pscustomobject]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
@@ -28,4 +28,5 @@ Invoke-LabStep -Config $Config -Body {
         Write-CustomLog 'Unknown platform; cannot reset.'
         exit 1
     }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -81,7 +81,7 @@ Describe 'Runner scripts parameter and command checks' -Skip:($SkipNonWindows) {
                 $_.CommandElements[1] -is [System.Management.Automation.Language.StringConstantExpressionAst] -or
                 $_.CommandElements[1] -is [System.Management.Automation.Language.ExpandableStringExpressionAst]
             ) -and
-            ([System.IO.Path]::GetFileName($_.CommandElements[1].Value) -eq 'LabRunner.psd1')
+            ([System.IO.Path]::GetFileName($_.CommandElements[1].Value) -eq 'LabRunner.psm1')
         }
 
         if (-not $found) {
@@ -98,7 +98,7 @@ Describe 'Runner scripts parameter and command checks' -Skip:($SkipNonWindows) {
             $dummy = Join-Path $tempDir 'dummy.ps1'
             @"
 Param([pscustomobject]`$Config)
-Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../runner_utility_scripts/LabRunner.psm1"
 Invoke-LabStep -Config `$Config -Body { Write-Output `$PSScriptRoot }
 "@ | Set-Content -Path $dummy
 


### PR DESCRIPTION
## Summary
- standardize LabRunner imports across runner scripts
- wrap `0001_Reset-Git.ps1` body in `Invoke-LabStep`
- log completion for all runner scripts
- update tests for `.psm1` module

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/RunnerScripts.Tests.ps1"` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68491fa683c48331be73294392667cc1