### PR TITLE
Fix Logger prompt variable expansion

### DIFF
--- a/lab_utils/LabRunner/Logger.ps1
+++ b/lab_utils/LabRunner/Logger.ps1
@@ -42,6 +42,6 @@ function Read-LoggedInput {
     }
 
     $answer = Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt
-    Write-CustomLog "$Prompt: $answer"
+    Write-CustomLog "$($Prompt): $answer"
     return $answer
 }

--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -42,6 +42,6 @@ function Read-LoggedInput {
     }
 
     $answer = Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt
-    Write-CustomLog "$Prompt: $answer"
+    Write-CustomLog "$($Prompt): $answer"
     return $answer
 }


### PR DESCRIPTION
## Summary
- ensure `$Prompt` is expanded correctly when logging input
- apply change in `lab_utils/LabRunner/Logger.ps1` and `runner_utility_scripts/Logger.ps1`

## Testing
- `pytest -q`
- `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684922aa04b8833182bb8bc16ab44ce5