### PR TITLE
Fix closing brace in Reset-Git script

### DIFF
--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -57,4 +57,3 @@ else {
         Pop-Location
     }
 }
-}


### PR DESCRIPTION
## Summary
- remove extra closing brace from `0001_Reset-Git.ps1`

## Testing
- `powershell -NoProfile -Command { Get-Command ./runner_scripts/0001_Reset-Git.ps1 }`
- `Invoke-Pester tests/Reset-Git.Tests.ps1 -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_684922af17a883319a5c729c895151b1