### PR TITLE
Add Copilot CLI to workflows

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -125,3 +125,7 @@ jobs:
                 body
               });
             }
+        - name: Set up Copilot
+          run: npm install -g @githubnext/copilot-cli
+        - name: Copilot remediation tips
+          run: copilot suggest --repo ${{ github.repository }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,8 +55,12 @@ jobs:
         shell: pwsh
         run: |
           Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.24.0 -Force -Scope CurrentUser
-      - name: Install powershell-yaml
-        shell: pwsh
-        run: |
-          Install-Module -Name powershell-yaml -Force -Scope CurrentUser
-      - uses: ./.github/actions/lint
+        - name: Install powershell-yaml
+          shell: pwsh
+          run: |
+            Install-Module -Name powershell-yaml -Force -Scope CurrentUser
+        - uses: ./.github/actions/lint
+        - name: Set up Copilot
+          run: npm install -g @githubnext/copilot-cli
+        - name: Run Copilot suggestions
+          run: copilot suggest --repo ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Individual step scripts can also be invoked this way when debugging:
 pwsh -File runner_scripts/0001_Reset-Git.ps1 -Config ./config_files/default-config.json
 ```
 
+The lint workflow installs the GitHub Copilot CLI and runs `copilot suggest`
+after linting. The command scans the repository and provides additional
+improvement ideas directly in the workflow logs.
+
 
 Clone this repository and apply the lab template:
 


### PR DESCRIPTION
## Summary
- run Copilot CLI after linting
- add Copilot remediation tips to the issue-on-fail workflow
- mention Copilot step in README

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_684922bfe7ac8331ad0ff8a945ec659c