### PR TITLE
Fix admin message quoting in Customize-ISO

### DIFF
--- a/iso_tools/Customize-ISO.ps1
+++ b/iso_tools/Customize-ISO.ps1
@@ -65,12 +65,14 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
     Write-CustomLog $warnMsg1 -Level WARN
     Write-Host $warnMsg1 -ForegroundColor Red
 
-    $warnMsg2 = "Rerun using: Start-Process powershell -Verb RunAs -ArgumentList '-File `\"$scriptPath`\"'"
+    $warnMsg2 = 'Rerun using: Start-Process powershell -Verb RunAs -ArgumentList ''-File "{0}"''' -f $scriptPath
     Write-CustomLog $warnMsg2 -Level WARN
     Write-Host $warnMsg2 -ForegroundColor Yellow
     if ($scriptPath) {
         try {
-            Start-Process -FilePath (Get-Process -Id $PID).Path -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `\"$scriptPath`\"" -Verb RunAs -ErrorAction Stop
+            Start-Process -FilePath (Get-Process -Id $PID).Path `
+                -ArgumentList ('-NoProfile -ExecutionPolicy Bypass -File "{0}"' -f $scriptPath) `
+                -Verb RunAs -ErrorAction Stop
             exit
         } catch {
             Write-Warning "Automatic elevation failed: $_"

--- a/tests/Customize-ISO.Tests.ps1
+++ b/tests/Customize-ISO.Tests.ps1
@@ -7,6 +7,12 @@ Describe 'Customize-ISO.ps1' -Skip:($SkipNonWindows) {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'iso_tools' 'Customize-ISO.ps1'
     }
 
+    It 'parses without errors' {
+        $errs = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($script:ScriptPath, [ref]$null, [ref]$errs) | Out-Null
+        ($errs ? $errs.Count : 0) | Should -Be 0
+    }
+
     It 'honours parameters and logs each step' {
         $temp = Join-Path $TestDrive ([guid]::NewGuid())
         New-Item -ItemType Directory -Path $temp | Out-Null


### PR DESCRIPTION
## Summary
- escape `$scriptPath` correctly in Customize-ISO.ps1
- ensure Customize-ISO.ps1 parses on Windows
- test that Customize-ISO.ps1 parses without errors

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI"`

------
https://chatgpt.com/codex/tasks/task_e_684922b219808331b3a041677a752e20