### PR TITLE
Add issue body parser and CLI command

### DIFF
--- a/docs/python-cli.md
+++ b/docs/python-cli.md
@@ -41,11 +41,13 @@ The `repo` group wraps a few common GitHub tasks. These commands require the
 poetry run labctl repo close-pr 123
 poetry run labctl repo close-issue 42
 poetry run labctl repo view-issue 99
+poetry run labctl repo parse-issue 99
 poetry run labctl repo cleanup
 ```
 
-`view-issue` prints the issue title and body as JSON, while `cleanup` removes
-merged remote branches and keeps the most recent branch per hour.
+`view-issue` prints the issue title and body as JSON, `parse-issue` parses the
+workflow failure issue into a structured JSON object, and `cleanup` removes
+merged remote branches while keeping the most recent branch per hour.
 
 ### `ui`
 Launch a simple Textual interface showing runner scripts, log output and

--- a/py/labctl/cli.py
+++ b/py/labctl/cli.py
@@ -6,7 +6,7 @@ from importlib.resources import files
 import typer
 import yaml
 
-from . import github_utils
+from . import github_utils, issue_parser
 
 
 def default_config_path() -> Path:
@@ -105,6 +105,15 @@ def view_issue(issue_number: int):
     """Output issue details as JSON."""
     data = github_utils.view_issue(issue_number)
     typer.echo(data)
+
+
+@repo_app.command("parse-issue")
+def parse_issue(issue_number: int):
+    """Parse an issue created by the failure workflow."""
+    raw = github_utils.view_issue(issue_number)
+    info = json.loads(raw)
+    parsed = issue_parser.parse_issue_body(info.get("body", ""))
+    typer.echo(json.dumps(parsed))
 
 
 @repo_app.command()

--- a/py/labctl/issue_parser.py
+++ b/py/labctl/issue_parser.py
@@ -1,0 +1,51 @@
+import re
+from typing import Any, Dict, List
+
+
+def parse_issue_body(text: str) -> Dict[str, Any]:
+    """Parse issue body produced by the issue-on-fail workflow."""
+    result: Dict[str, Any] = {
+        "run_url": None,
+        "commit": None,
+        "branch": None,
+        "jobs": [],
+        "tests": [],
+    }
+
+    # First line: Run [url](url) for commit `sha` on branch `branch` failed.
+    first_line = text.strip().splitlines()[0] if text.strip() else ""
+    m = re.search(
+        r"Run \[(?P<url>[^\]]+)\]\([^\)]+\) for commit `(?P<sha>[0-9a-fA-F]+)` on branch `(?P<branch>[^`]+)`",
+        first_line,
+    )
+    if m:
+        result["run_url"] = m.group("url")
+        result["commit"] = m.group("sha")
+        result["branch"] = m.group("branch")
+
+    # Split sections by headings
+    sections: Dict[str, List[str]] = {}
+    current = None
+    for line in text.splitlines():
+        if line.startswith("### "):
+            current = line[4:].strip()
+            sections[current] = []
+            continue
+        if current:
+            sections[current].append(line)
+
+    # Parse jobs
+    for line in sections.get("Failed jobs", []):
+        m = re.search(r"- \[(?P<name>[^\]]+)\]\((?P<url>[^)]+)\) - (?P<status>.+)", line)
+        if m:
+            result["jobs"].append({
+                "name": m.group("name"),
+                "url": m.group("url"),
+                "status": m.group("status"),
+            })
+
+    # Parse failing tests lines
+    tests = [l for l in sections.get("Failing tests", []) if l.strip()]
+    result["tests"] = tests
+
+    return result

--- a/py/tests/test_issue_parser.py
+++ b/py/tests/test_issue_parser.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from labctl.issue_parser import parse_issue_body
+
+
+def test_parse_lint_failure():
+    body = (
+        "Run [https://run](https://run) for commit `deadbeef` on branch `feat` failed.\n\n"
+        "### Failed jobs\n"
+        "- [Lint](https://run/job/1) - failure\n\n"
+        "### Failing tests\n"
+    )
+    data = parse_issue_body(body)
+    assert data["run_url"] == "https://run"
+    assert data["commit"] == "deadbeef"
+    assert data["branch"] == "feat"
+    assert data["jobs"] == [{"name": "Lint", "url": "https://run/job/1", "status": "failure"}]
+    assert data["tests"] == []
+
+
+def test_parse_failing_tests():
+    body = (
+        "Run [https://url](https://url) for commit `abc123` on branch `main` failed.\n\n"
+        "### Failed jobs\n"
+        "- [Pester](https://url/job/2) - failure\n"
+        "- [Pytest](https://url/job/3) - failure\n\n"
+        "### Failing tests\n"
+        "- **Fail.Test**: boom\n"
+        "- **pkg.TestCase.test_fail**: oops\n"
+    )
+    data = parse_issue_body(body)
+    assert len(data["jobs"]) == 2
+    assert data["tests"] == ["- **Fail.Test**: boom", "- **pkg.TestCase.test_fail**: oops"]
+


### PR DESCRIPTION
## Summary
- parse the issue body generated by `issue-on-fail.yml`
- expose a new `repo parse-issue` command
- cover new parser with tests
- document the command in docs

## Testing
- `pip install --quiet -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684929efed588331b9fd4078fc674d2f