### PR TITLE
Replace legacy script paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ provider "hyperv" {
   cacert_path     = ""    # Leave empty if skipping SSL validation
   cert_path       = ""    # Leave empty if skipping SSL validation
   key_path        = ""    # Leave empty if skipping SSL validation
-  script_path     = "C:/Temp/terraform_%RAND%.cmd"
+  script_path     = "C:/Temp/tofu_%RAND%.cmd"
   timeout         = "30s"
 }
 

--- a/config_files/default-config.json
+++ b/config_files/default-config.json
@@ -42,7 +42,7 @@
     "CacertPath": "",
     "CertPath": "",
     "KeyPath": "",
-    "ScriptPath": "C:/Temp/terraform_%RAND%.cmd",
+    "ScriptPath": "C:/Temp/tofu_%RAND%.cmd",
     "Timeout": "30s"
   },
   "WAC": {

--- a/config_files/full-config.json
+++ b/config_files/full-config.json
@@ -49,7 +49,7 @@
     "CacertPath": "",
     "CertPath": "",
     "KeyPath": "",
-    "ScriptPath": "C:/Temp/terraform_%RAND%.cmd",
+    "ScriptPath": "C:/Temp/tofu_%RAND%.cmd",
     "Timeout": "30s"
   },
   "WAC": {

--- a/example-infrastructure/examples_archive/main.tf
+++ b/example-infrastructure/examples_archive/main.tf
@@ -19,6 +19,6 @@ provider "hyperv" {
   cacert_path     = "" # Leave empty if skipping SSL validation
   cert_path       = "" # Leave empty if skipping SSL validation
   key_path        = "" # Leave empty if skipping SSL validation
-  script_path     = "C:/Temp/terraform_%RAND%.cmd"
+  script_path     = "C:/Temp/tofu_%RAND%.cmd"
   timeout         = "30s"
 }

--- a/example-infrastructure/examples_tailiesins/hyperv-provider.example
+++ b/example-infrastructure/examples_tailiesins/hyperv-provider.example
@@ -11,7 +11,7 @@ provider "hyperv" {
   cacert_path     = ""
   cert_path       = ""
   key_path        = ""
-  script_path     = "C:/Temp/terraform_%RAND%.cmd"
+  script_path     = "C:/Temp/tofu_%RAND%.cmd"
   timeout         = "30s"
 }
 
@@ -40,7 +40,7 @@ kerberos_service_principal_name (String) Use Kerberos Service Principal Name for
 key_path (String) The path to the certificate private key to use for authentication for HyperV api calls. Can also be sourced from the HYPERV_KEY_PATH environment variable otherwise defaults to empty string.
 password (String) The password associated with the username to use for HyperV api calls. It can also be sourced from the HYPERV_PASSWORD environment variable`.
 port (Number) The port to run HyperV api calls against. It can also be sourced from the HYPERV_PORT environment variable otherwise defaults to 5986.
-script_path (String) The path used to copy scripts meant for remote execution for HyperV api calls. Can also be sourced from the HYPERV_SCRIPT_PATH environment variable otherwise defaults to C:/Temp/terraform_%RAND%.cmd.
+script_path (String) The path used to copy scripts meant for remote execution for HyperV api calls. Can also be sourced from the HYPERV_SCRIPT_PATH environment variable otherwise defaults to C:/Temp/tofu_%RAND%.cmd.
 timeout (String) The timeout to wait for the connection to become available for HyperV api calls. Should be provided as a string like 30s or 5m. Can also be sourced from the HYPERV_TIMEOUT environment variable otherwise defaults to 30s.
 tls_server_name (String) The TLS server name for the host used for HyperV api calls. It can also be sourced from the HYPERV_TLS_SERVER_NAME environment variable otherwise defaults to empty string.
 use_ntlm (Boolean) Use NTLM for authentication for HyperV api calls. Can also be set via setting the HYPERV_USE_NTLM environment variable to true otherwise defaults to true.

--- a/example-infrastructure/providers.tf
+++ b/example-infrastructure/providers.tf
@@ -15,7 +15,7 @@ provider "hyperv" {
   cert_path       = "certs/host.pem"
   key_path        = "certs/host-key.pem"
 
-  script_path     = "C:/Temp/terraform_%RAND%.cmd"
+  script_path     = "C:/Temp/tofu_%RAND%.cmd"
   timeout         = "30s"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ provider "hyperv" {
   cacert_path     = local.lab.hyperv.cacert_path
   cert_path       = local.lab.hyperv.cert_path
   key_path        = local.lab.hyperv.key_path
-  script_path     = "C:/Temp/terraform_%RAND%.cmd"
+  script_path     = "C:/Temp/tofu_%RAND%.cmd"
   timeout         = "30s"
 }
 

--- a/py/labctl/config_files/default-config.json
+++ b/py/labctl/config_files/default-config.json
@@ -42,7 +42,7 @@
     "CacertPath": "",
     "CertPath": "",
     "KeyPath": "",
-    "ScriptPath": "C:/Temp/terraform_%RAND%.cmd",
+    "ScriptPath": "C:/Temp/tofu_%RAND%.cmd",
     "Timeout": "30s"
   },
   "WAC": {

--- a/py/labctl/config_files/full-config.json
+++ b/py/labctl/config_files/full-config.json
@@ -49,7 +49,7 @@
     "CacertPath": "",
     "CertPath": "",
     "KeyPath": "",
-    "ScriptPath": "C:/Temp/terraform_%RAND%.cmd",
+    "ScriptPath": "C:/Temp/tofu_%RAND%.cmd",
     "Timeout": "30s"
   },
   "WAC": {


### PR DESCRIPTION
## Summary
- reference `tofu_%RAND%.cmd` instead of `terraform_%RAND%.cmd`

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492b41001c8331846fbee6341cbc4f