### PR TITLE
Expand module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,12 @@ The configuration reads variables from `lab_config.yaml`, which you can copy fro
 
 ## Documentation
 
-Detailed guides and module references are located in the [docs](docs/) directory. Start with [docs/index.md](docs/index.md) for an overview.
+Detailed guides and module references are located in the [docs](docs/) directory.
+Start with [docs/index.md](docs/index.md) for an overview. Direct links to the
+Terraform modules:
+
+- [Hyper-V VM module](modules/vm/README.md)
+- [Network switch module](modules/network_switch/README.md)
 
 ## Python CLI
 

--- a/modules/network_switch/README.md
+++ b/modules/network_switch/README.md
@@ -1,10 +1,11 @@
 # Network Switch Module
 
-This module creates a Hyper-V virtual switch. It wraps the `hyperv_network_switch` resource so the switch can be reused by other modules.
+Use this module to create a reusable Hyper‑V virtual switch via the
+`hyperv_network_switch` resource.
 
 ## Provider Requirements
 
-The module depends on the `hyperv` provider from the `taliesins` namespace. Include the following in your configuration:
+Add the `hyperv` provider from the `taliesins` namespace to your configuration:
 
 ```hcl
 terraform {
@@ -18,11 +19,34 @@ terraform {
 ```
 
 ## Inputs
-- `name` - name of the switch
-- `net_adapter_names` - list of adapters
-- `allow_management_os` - whether to allow management OS (default `true`)
-- `switch_type` - switch type (default `External`)
+
+| Variable | Type | Description | Default |
+| -------- | ---- | ----------- | ------- |
+| `name` | string | Name of the switch. | required |
+| `net_adapter_names` | list(string) | Host adapters backing the switch. | required |
+| `allow_management_os` | bool | Allow the management OS to share the NIC. | `true` |
+| `switch_type` | string | Switch type such as `External` or `Internal`. | `"External"` |
 
 ## Outputs
-- `switch_name` - the name of the created switch
-- `switch_resource` - the underlying resource
+
+| Name | Description |
+| ---- | ----------- |
+| `switch_name` | Name of the created switch. |
+| `switch_resource` | The `hyperv_network_switch` resource. |
+
+## Minimal Example
+
+```hcl
+module "wan_switch" {
+  source            = "../../modules/network_switch"
+  name              = "wan"
+  net_adapter_names = ["Ethernet0"]
+}
+```
+
+Use the outputs when attaching VMs:
+
+```hcl
+switch_name        = module.wan_switch.switch_name
+switch_dependency  = module.wan_switch.switch_resource
+```

--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -1,72 +1,46 @@
 # Hyper-V VM Module
 
-This module provisions a Hyper-V virtual machine and its associated VHD.  It is
-intended to replace the repetitive VM resource blocks in the root configuration
-with a single reusable component.
+Provision one or more Hyper-V virtual machines and their accompanying VHD files.
 
-## Required Variables
-- `vm_count` - number of VMs to create
-- `vm_name_prefix` - prefix used for VM names and VHD files
-- `hyperv_vm_path` - base path on the Hyper-V host for storing VHDs
-- `vhd_size_bytes` - size of the VHD to create
-- `iso_path` - installation media attached as a DVD drive
-- `switch_name` - name of the Hyper-V virtual switch for networking
-- `switch_dependency` - resource to depend on for switch creation
-- `memory_startup_bytes`, `memory_maximum_bytes`, `memory_minimum_bytes` - memory settings
-- `processor_count` - number of virtual processors
+## Inputs
 
-## Example Usage
+| Variable | Type | Description |
+| -------- | ---- | ----------- |
+| `vm_count` | number | Number of VMs to create. |
+| `vm_name_prefix` | string | Prefix used for VM names and VHD file paths. |
+| `hyperv_vm_path` | string | Base directory on the Hyper-V host where VHDs are stored. |
+| `vhd_size_bytes` | number | Size of each VHD in bytes. |
+| `iso_path` | string | Path to the installation ISO attached as a DVD drive. |
+| `switch_name` | string | Name of the Hyper-V virtual switch for networking. |
+| `switch_dependency` | any | Resource that ensures the switch exists before VMs are created. |
+| `memory_startup_bytes` | number | Startup memory allocation. |
+| `memory_maximum_bytes` | number | Maximum memory allocation. |
+| `memory_minimum_bytes` | number | Minimum memory allocation. |
+| `processor_count` | number | Number of virtual processors. |
 
-The module requires the `hyperv` provider.  A minimal provider configuration
-looks like the following:
+## Outputs
+
+This module defines no explicit outputs. Access the generated resources directly if needed, for example:
 
 ```hcl
-terraform {
-  required_providers {
-    hyperv = {
-      source  = "taliesins/hyperv"
-      version = ">=1.2.1"
-    }
-  }
-}
-
-provider "hyperv" {
-  host     = var.hyperv_host_name
-  user     = var.hyperv_user
-  password = var.hyperv_password
-  https    = true
-  insecure = true
-}
+module.demo_vm.hyperv_machine_instance.this[0].id
 ```
 
-After the provider is configured you can call the module from a Terraform
-configuration:
+## Minimal Example
 
 ```hcl
 module "demo_vm" {
-  source               = "./modules/hyperv_vm"
+  source               = "../../modules/vm"
   vm_count             = 1
   vm_name_prefix       = "demo"
   hyperv_vm_path       = "D:/VMs/demo"
   vhd_size_bytes       = 50_000_000_000
   iso_path             = var.demo_iso_path
-  switch_name          = hyperv_network_switch.wan.name
-  switch_dependency    = hyperv_network_switch.wan
+  switch_name          = module.switch.switch_name
+  switch_dependency    = module.switch.switch_resource
   memory_startup_bytes = 2147483648
   memory_maximum_bytes = 4294967296
   memory_minimum_bytes = 536870912
   processor_count      = 2
 }
 ```
-
-### Expected Outputs
-
-The module does not define explicit outputs but you can reference the created
-resources directly.  For example, to obtain the IP address of the first VM:
-
-```hcl
-output "vm_ip" {
-  value = module.demo_vm.hyperv_machine_instance.this[0].ip_addresses
-}
-```
-


### PR DESCRIPTION
## Summary
- document VM and switch module variables, outputs and examples
- link module docs from the main README

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests"`

------
https://chatgpt.com/codex/tasks/task_e_68492bcf3ef08331946ec3b289fb8578