### PR TITLE
Fix stray else block in Reset-Git

### DIFF
--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -52,20 +52,3 @@ Invoke-LabStep -Config $Config -Body {
     }
 }
 
-else {
-    Write-CustomLog "Git repository found. Updating repository..."
-    Push-Location $InfraPath
-    try {
-        Write-CustomLog 'git reset --hard'
-        git reset --hard
-        Write-CustomLog 'git clean -fd'
-        git clean -fd
-        Write-CustomLog 'git pull'
-        git pull
-    } catch {
-        Write-Error "An error occurred while updating the repository: $_"
-    } finally {
-        Pop-Location
-    }
-}
-


### PR DESCRIPTION
## Summary
- remove an erroneous `else` block from `0001_Reset-Git.ps1`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68492d138c008331be0672e6c56969d5