### PR TITLE
Fix Copilot workflow action

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install GitHub CLI
-        uses: cli/cli@v2
+        uses: cli/cli@v2.74.1
       - name: Authenticate gh
         run: gh auth login --with-token <<< "$GITHUB_TOKEN"
         env:


### PR DESCRIPTION
## Summary
- reference an actual release for cli/cli action

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68492c54c5ac833194c5968a7225a327