### PR TITLE
Remove GitHub CLI from Copilot workflow

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Install GitHub CLI
-        uses: cli/cli@v2.74.1
       - name: Authenticate gh
         run: gh auth login --with-token <<< "$GITHUB_TOKEN"
         env:


### PR DESCRIPTION
## Summary
- clean up Copilot workflow configuration by dropping the GitHub CLI install step

## Testing
- `poetry run pytest`
- ⚠️ `Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684930cd29d483319364b7f25fc276ad