### PR TITLE
Add fallback for Read-LoggedInput

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -101,6 +101,23 @@ if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
             Write-Host $fmt -ForegroundColor $color
         }
     }
+
+    function Read-LoggedInput {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)][string]$Prompt,
+            [switch]$AsSecureString
+        )
+
+        if ($AsSecureString) {
+            Write-CustomLog "$Prompt (secure input)"
+            return Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt -AsSecureString
+        }
+
+        $answer = Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt
+        Write-CustomLog "$($Prompt): $answer"
+        return $answer
+    }
 }
 
 # Load config helper

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -8,6 +8,12 @@ Describe 'kicker-bootstrap utilities' -Skip:($SkipNonWindows) {
         $content | Should -Match 'function\s+Write-CustomLog'
     }
 
+    It 'defines Read-LoggedInput fallback' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
+        $content = Get-Content $scriptPath -Raw
+        $content | Should -Match 'function\s+Read-LoggedInput'
+    }
+
     It 'invokes runner and propagates exit code using PassThru' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
         $content = Get-Content $scriptPath -Raw


### PR DESCRIPTION
## Summary
- add inline fallback for `Read-LoggedInput`
- check for `Read-LoggedInput` fallback in kicker bootstrap tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684931f06b5c83319a3561178785e737