### PR TITLE
Fix GitHub token auth in automation workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,10 +11,6 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Authenticate gh
-        run: gh auth login --with-token <<< "$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Merge eligible PRs
         run: |
           for pr in $(gh pr list --state open --json number,mergeable -q '.[] | select(.mergeable=="MERGEABLE") | .number'); do

--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -17,10 +17,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Authenticate gh
-        run: gh auth login --with-token <<< "$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Copilot CLI
         run: npm install -g @githubnext/copilot-cli
       - name: Run Copilot suggestions


### PR DESCRIPTION
## Summary
- remove unnecessary `gh auth login` steps from automation workflows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684931ba4c88833185bb2f18e54bb3a4