### PR TITLE
Fix runner.ps1 parameter set error

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -1,7 +1,5 @@
 [CmdletBinding(SupportsShouldProcess)]
 param(
-    [Parameter(ParameterSetName='Normal')]
-    [Parameter(ParameterSetName='Quiet')]
     [string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files/default-config.json'),
     #[string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files' 'default-config.json'),
 


### PR DESCRIPTION
## Summary
- remove unnecessary ParameterSetName attributes from `runner.ps1`
- ensure the runner no longer fails when launched by `kicker-bootstrap.ps1`

## Testing
- `Invoke-Pester`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493396ec8883318daba6d055bf3d1f