### PR TITLE
Add completion log to Reset-Git script

### DIFF
--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -52,3 +52,5 @@ Invoke-LabStep -Config $Config -Body {
     }
 }
 
+Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
+


### PR DESCRIPTION
## Summary
- add missing completion log in `0001_Reset-Git.ps1`

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849339cdbb48331bc1147f5d48bef3a