### PR TITLE
Ensure runner scripts emit start and completion logs

### DIFF
--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -50,5 +50,6 @@ Invoke-LabStep -Config $Config -Body {
             Pop-Location
         }
     }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }
 

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -490,6 +490,8 @@ Write-CustomLog 'hello world'
         Pop-Location
 
         ($script:messages | Where-Object { $_ -match 'hello world' }).Count | Should -Be 1
+        ($script:messages | Where-Object { $_ -like 'Starting *' }).Count | Should -Be 1
+        ($script:messages | Where-Object { $_ -like 'Completed *' }).Count | Should -Be 1
 
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
## Summary
- log completion for Reset-Git runner script
- check start/completion messages in Runner tests
- add completion log check for Reset-Git script

## Testing
- `Invoke-Pester`

------
https://chatgpt.com/codex/tasks/task_e_684933afa33c83319331fe077f60ff2e