### PR TITLE
Run mockable Pester tests on all platforms

### DIFF
--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Cleanup-Files script' {
     BeforeAll {
         $script:scriptPath = Get-RunnerScriptPath '0000_Cleanup-Files.ps1'

--- a/tests/Config-DNS.Tests.ps1
+++ b/tests/Config-DNS.Tests.ps1
@@ -1,8 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe '0113_Config-DNS' {
-    It 'calls Set-DnsClientServerAddress with value from config' -Skip:($SkipNonWindows) {
+    It 'calls Set-DnsClientServerAddress with value from config'  {
         $script = Get-RunnerScriptPath '0113_Config-DNS.ps1'
         $config = [pscustomobject]@{
             SetDNSServers = $true

--- a/tests/Config-TrustedHosts.Tests.ps1
+++ b/tests/Config-TrustedHosts.Tests.ps1
@@ -1,8 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 
-Describe '0114_Config-TrustedHosts' -Skip:($SkipNonWindows) {
+Describe '0114_Config-TrustedHosts'  {
     It 'calls Start-Process with winrm arguments using config value' {
 
         $script = Get-RunnerScriptPath '0114_Config-TrustedHosts.ps1'

--- a/tests/Configure-Firewall.Tests.ps1
+++ b/tests/Configure-Firewall.Tests.ps1
@@ -1,7 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
-Describe '0102_Configure-Firewall' -Skip:($SkipNonWindows) {
+Describe '0102_Configure-Firewall'  {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0102_Configure-Firewall.ps1'
     }

--- a/tests/Customize-ISO.Tests.ps1
+++ b/tests/Customize-ISO.Tests.ps1
@@ -1,8 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 
-Describe 'Customize-ISO.ps1' -Skip:($SkipNonWindows) {
+Describe 'Customize-ISO.ps1'  {
     BeforeAll {
         $script:ScriptPath = Join-Path $PSScriptRoot '..' 'iso_tools' 'Customize-ISO.ps1'
     }

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe '0112_Enable-PXE' {
     BeforeAll {
         $script:scriptPath = Get-RunnerScriptPath '0112_Enable-PXE.ps1'
@@ -8,7 +7,7 @@ Describe '0112_Enable-PXE' {
         . $loggerPath
     }
 
-    It 'logs firewall rules when ConfigPXE is true' -Skip:($SkipNonWindows) {
+    It 'logs firewall rules when ConfigPXE is true'  {
         $Config = [pscustomobject]@{ ConfigPXE = $true }
         $logPath = Join-Path $env:TEMP ('pxe-log-' + [System.Guid]::NewGuid().ToString() + '.txt')
         $script:LogFilePath = $logPath

--- a/tests/Enable-RemoteDesktop.Tests.ps1
+++ b/tests/Enable-RemoteDesktop.Tests.ps1
@@ -1,7 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
-Describe '0101_Enable-RemoteDesktop' -Skip:($SkipNonWindows) {
+Describe '0101_Enable-RemoteDesktop'  {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0101_Enable-RemoteDesktop.ps1'
     }

--- a/tests/Enable-WinRM.Tests.ps1
+++ b/tests/Enable-WinRM.Tests.ps1
@@ -1,7 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
-Describe '0100_Enable-WinRM' -Skip:($SkipNonWindows) {
+Describe '0100_Enable-WinRM'  {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0100_Enable-WinRM.ps1'
     }

--- a/tests/EscapePathArgument.Tests.ps1
+++ b/tests/EscapePathArgument.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'escapePathArgument' {
     BeforeAll {
         $script:scriptPath = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'OpenTofuInstaller.ps1'

--- a/tests/Expand-All.Tests.ps1
+++ b/tests/Expand-All.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Expand-All' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Expand-All.ps1')

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Format-Config' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Format-Config.ps1')

--- a/tests/Get-HyperVProviderVersion.Tests.ps1
+++ b/tests/Get-HyperVProviderVersion.Tests.ps1
@@ -1,8 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 
-Describe 'Get-HyperVProviderVersion' -Skip:($SkipNonWindows) {
+Describe 'Get-HyperVProviderVersion'  {
     It 'parses version from main.tf' {
         $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath

--- a/tests/Get-LabConfig.Tests.ps1
+++ b/tests/Get-LabConfig.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Get-LabConfig' {
 
     It 'returns PSCustomObject for valid JSON and populates Directories' {

--- a/tests/Get-Platform.Tests.ps1
+++ b/tests/Get-Platform.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Get-Platform' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Get-Platform.ps1')

--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -1,7 +1,6 @@
 
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 
 
 Describe '0200_Get-SystemInfo' {

--- a/tests/Get-WindowsJobArtifacts.Tests.ps1
+++ b/tests/Get-WindowsJobArtifacts.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Import-Module (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'LabRunner.psd1') -Force
 
 InModuleScope LabSetup {

--- a/tests/Hypervisor.Tests.ps1
+++ b/tests/Hypervisor.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Hypervisor module' {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'Hypervisor.psm1') -Force

--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Initialize-OpenTofu script' {
     Import-Module (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'LabRunner.psd1') -Force
 InModuleScope LabSetup {

--- a/tests/Install-Go.Tests.ps1
+++ b/tests/Install-Go.Tests.ps1
@@ -1,7 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
-Describe '0007_Install-Go' -Skip:($SkipNonWindows) {
+Describe '0007_Install-Go'  {
     BeforeAll { $script:ScriptPath = Get-RunnerScriptPath '0007_Install-Go.ps1' }
 
     It 'installs Go when enabled' {

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -1,7 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
-Describe '0008_Install-OpenTofu' -Skip:($SkipNonWindows) {
+Describe '0008_Install-OpenTofu'  {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0008_Install-OpenTofu.ps1'
         . $script:ScriptPath

--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -1,7 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
-Describe '0006_Install-ValidationTools' -Skip:($SkipNonWindows) {
+Describe '0006_Install-ValidationTools'  {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0006_Install-ValidationTools.ps1'
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe '0203_Install-npm' {
     AfterEach {
         Remove-Item Function:npm -ErrorAction SilentlyContinue

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -1,7 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
-Describe 'kicker-bootstrap utilities' -Skip:($SkipNonWindows) {
+Describe 'kicker-bootstrap utilities'  {
     It 'defines Write-CustomLog fallback' {
         $scriptPath = Join-Path $PSScriptRoot '..' 'kicker-bootstrap.ps1'
         $content = Get-Content $scriptPath -Raw

--- a/tests/Kickstart-Bootstrap.Tests.ps1
+++ b/tests/Kickstart-Bootstrap.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'kickstart-bootstrap script' {
     It 'exists at repo root' {
         $path = Join-Path $PSScriptRoot '..' 'kickstart-bootstrap.sh'

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Write-CustomLog' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')

--- a/tests/Menu.Tests.ps1
+++ b/tests/Menu.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Get-MenuSelection' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Menu.ps1')

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 $skipNpm = -not (Get-Command npm -ErrorAction SilentlyContinue)
 Describe 'Node installation scripts' -Skip:$skipNpm {
     BeforeAll {

--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -1,6 +1,5 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
 Describe 'Reset-Machine script' {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '9999_Reset-Machine.ps1'
@@ -11,7 +10,7 @@ Describe 'Reset-Machine script' {
         Remove-Variable -Name LogFilePath -Scope Script -ErrorAction SilentlyContinue
     }
 
-    It 'invokes sysprep and configures Remote Desktop on Windows' -Skip:($SkipNonWindows) {
+    It 'invokes sysprep and configures Remote Desktop on Windows'  {
         Mock Get-Platform { 'Windows' }
         $sysprep = 'C:\\Windows\\System32\\Sysprep\\Sysprep.exe'
         Mock Test-Path { $true } -ParameterFilter { $Path -eq $sysprep }

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'runner.ps1 configuration' {
     }
 }
 
-Describe 'runner.ps1 script selection' -Skip:($SkipNonWindows) {
+Describe 'runner.ps1 script selection'  {
     BeforeAll {
         # Use script-scoped variable so PSScriptAnalyzer recognizes cross-block usage
         $script:runnerPath = Join-Path $PSScriptRoot '..' 'runner.ps1'
@@ -427,7 +427,7 @@ Write-Error 'err message'
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
 
-    It 'prompts twice when -Auto is used without -Scripts' -Skip:($SkipNonWindows) {
+    It 'prompts twice when -Auto is used without -Scripts'  {
         $tempDir   = New-RunnerTestEnv
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
         "Param([PSCustomObject]`$Config)
@@ -448,7 +448,7 @@ exit 0" | Set-Content -Path (Join-Path $scriptsDir '0001_Test.ps1')
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
 
-    It 'handles empty or invalid selection by logging and doing nothing' -Skip:($SkipNonWindows) {
+    It 'handles empty or invalid selection by logging and doing nothing'  {
         $tempDir   = New-RunnerTestEnv
         $scriptsDir = Join-Path $tempDir 'runner_scripts'
         $out        = Join-Path $tempDir 'out.txt'
@@ -558,7 +558,7 @@ Describe 'Set-LabConfig' {
         }
     }
 
-    It 'updates selections and saves to JSON' -Skip:($SkipNonWindows) {
+    It 'updates selections and saves to JSON'  {
         $config = @{
             InstallGit = $false
             InstallGo  = $false

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -7,12 +7,11 @@ if (-not (Test-Path $helperPath)) {
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 
-if ($SkipNonWindows) { return }
 
 $scriptDir = Split-Path (Get-RunnerScriptPath '0001_Reset-Git.ps1')
 $scripts = Get-ChildItem $scriptDir -Filter '*.ps1'
 
-Describe 'Runner scripts parameter and command checks' -Skip:($SkipNonWindows) {
+Describe 'Runner scripts parameter and command checks'  {
 
     BeforeAll {
         . (Join-Path $PSScriptRoot 'helpers' 'Get-ScriptAst.ps1')

--- a/tests/Setup-Directories.Tests.ps1
+++ b/tests/Setup-Directories.Tests.ps1
@@ -1,7 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-if ($SkipNonWindows) { return }
-Describe '0002_Setup-Directories' -Skip:($SkipNonWindows) {
+Describe '0002_Setup-Directories'  {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0002_Setup-Directories.ps1'
         . (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')


### PR DESCRIPTION
## Summary
- remove `$SkipNonWindows` guards and skip flags from mockable tests
- allow path helpers to work cross‑platform

## Testing
- `Invoke-Pester` *(fails: Invoke-OpenTofuInstaller not called; Write-CustomLog not called)*

------
https://chatgpt.com/codex/tasks/task_e_684933a376c48331a6be1343c0df9820