### PR TITLE
Fix Pester skip on non‑Windows

### DIFF
--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -1,5 +1,6 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+if ($SkipNonWindows) { return }
 Describe '0008_Install-OpenTofu'  {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0008_Install-OpenTofu.ps1'


### PR DESCRIPTION
## Summary
- skip `Install-OpenTofu.Tests` on Linux and macOS

## Testing
- `Invoke-Pester -Script tests/Install-OpenTofu.Tests.ps1 -PassThru`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684937ea23988331bceea99c732eaa1d