### PR TITLE
Fix Read-LoggedInput tests

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -111,10 +111,10 @@ if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
 
         if ($AsSecureString) {
             Write-CustomLog "$Prompt (secure input)"
-            return Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt -AsSecureString
+            return Read-Host -Prompt $Prompt -AsSecureString
         }
 
-        $answer = Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt
+        $answer = Read-Host -Prompt $Prompt
         Write-CustomLog "$($Prompt): $answer"
         return $answer
     }

--- a/lab_utils/LabRunner/Logger.ps1
+++ b/lab_utils/LabRunner/Logger.ps1
@@ -38,10 +38,10 @@ function Read-LoggedInput {
 
     if ($AsSecureString) {
         Write-CustomLog "$Prompt (secure input)"
-        return Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt -AsSecureString
+        return Read-Host -Prompt $Prompt -AsSecureString
     }
 
-    $answer = Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt
+    $answer = Read-Host -Prompt $Prompt
     Write-CustomLog "$($Prompt): $answer"
     return $answer
 }

--- a/runner_utility_scripts/Logger.ps1
+++ b/runner_utility_scripts/Logger.ps1
@@ -38,10 +38,10 @@ function Read-LoggedInput {
 
     if ($AsSecureString) {
         Write-CustomLog "$Prompt (secure input)"
-        return Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt -AsSecureString
+        return Read-Host -Prompt $Prompt -AsSecureString
     }
 
-    $answer = Microsoft.PowerShell.Utility\Read-Host -Prompt $Prompt
+    $answer = Read-Host -Prompt $Prompt
     Write-CustomLog "$($Prompt): $answer"
     return $answer
 }


### PR DESCRIPTION
## Summary
- make `Read-LoggedInput` call `Read-Host` so it can be mocked

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493b10ff688331b908ae9fbb4bc12c