### PR TITLE
Fix workflow to use gh copilot

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -34,16 +34,12 @@ jobs:
       - name: Authenticate gh
         shell: bash
         run: echo "${{ secrets.GH_PAT_AUTOPILOT }}" | gh auth login --with-token
-      - name: Install Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - name: Install Copilot CLI
-        run: npm install -g @githubnext/github-copilot-cli
+      - name: Install Copilot extension
+        run: gh extension install github/gh-copilot --force
       - name: Run Copilot suggestions
         run: |
           for num in $(gh issue list --state open --json number -q '.[].number'); do
             body=$(gh issue view "$num" --json body -q .body)
             echo "$body" > issue.txt
-            github-copilot-cli suggest --repo ${{ github.repository }} --issue issue.txt || true
+            gh copilot suggest --repo "${{ github.repository }}" --issue issue.txt || true
           done


### PR DESCRIPTION
## Summary
- fix Copilot auto-fix workflow so it installs the `gh-copilot` extension and uses `gh copilot suggest`

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Cannot find drive C)*

------
https://chatgpt.com/codex/tasks/task_e_68493acda20c833192664eef8d10e473