### PR TITLE
Improve Format-Config error handling

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -3,8 +3,7 @@ function Format-Config {
     param(
         [Parameter(
             ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true,
-            Mandatory
+            ValueFromPipelineByPropertyName = $true
         )]
         [psobject]$Config
     )
@@ -12,14 +11,14 @@ function Format-Config {
     begin {
         $hasInput = $false
         if ($PSBoundParameters.ContainsKey('Config') -and $null -eq $Config) {
-            throw [System.ArgumentNullException]::new('Config')
+            throw [System.ArgumentNullException]::new('Config','Config cannot be null.')
         }
     }
 
     process {
         $hasInput = $true
         if ($null -eq $Config) {
-            throw [System.ArgumentNullException]::new('Config')
+            throw [System.ArgumentNullException]::new('Config','Config cannot be null.')
         }
 
         # Serialize the configuration object to indented JSON so nested
@@ -30,7 +29,10 @@ function Format-Config {
 
     end {
         if (-not $hasInput) {
-            throw [System.ArgumentNullException]::new('Config')
+            throw [System.ArgumentException]::new(
+                'A configuration object must be provided via -Config or the pipeline.',
+                'Config'
+            )
         }
     }
 }

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -24,9 +24,14 @@ Describe 'Format-Config' {
         $result | Should -Match '"Foo"\s*:\s*"prop"'
     }
 
-    It 'fails when no Config is provided' {
+    It 'throws when no Config is provided' {
         { Format-Config } |
-            Should -Throw -ErrorType System.Management.Automation.ParameterBindingException
+            Should -Throw -ErrorType System.ArgumentException
+    }
+
+    It 'throws when pipeline is empty' {
+        { @() | Format-Config } |
+            Should -Throw -ErrorType System.ArgumentException
     }
 
     It 'throws when Config is null' {


### PR DESCRIPTION
## Summary
- avoid ParameterBindingException for Format-Config when no input
- clarify message when no config object is provided
- update and expand Format-Config tests for empty input

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494153296c8331a9378c20efe56832