### PR TITLE
Fix Customize-ISO quoting

### DIFF
--- a/iso_tools/Customize-ISO.ps1
+++ b/iso_tools/Customize-ISO.ps1
@@ -65,7 +65,7 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
     Write-CustomLog $warnMsg1 -Level WARN
     Write-Host $warnMsg1 -ForegroundColor Red
 
-    $warnMsg2 = "Rerun using: Start-Process -FilePath (Get-Process -Id `$PID).Path -ArgumentList \"-NoProfile -ExecutionPolicy Bypass -File `\\\"$scriptPath`\\\"\" -Verb RunAs -ErrorAction Stop"
+    $warnMsg2 = "Rerun using: Start-Process -FilePath (Get-Process -Id `$PID).Path -ArgumentList \"-NoProfile -ExecutionPolicy Bypass -File `\"$scriptPath`\"\" -Verb RunAs -ErrorAction Stop"
 
     Write-CustomLog $warnMsg2 -Level WARN
     Write-Host $warnMsg2 -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- fix quoting for `-ArgumentList` in `Customize-ISO.ps1`

## Testing
- `pwsh -NoProfile -Command { . ./iso_tools/Customize-ISO.ps1 -? }`
- `Invoke-Pester` *(fails: Cannot load the module '/workspace/opentofu-lab-automation/lab_utils/LabSetup/LabSetup.psd1' because the module nesting limit has been exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6849414cb0f08331ae869eaea97970e5