### PR TITLE
fix: unset GH_TOKEN during gh auth login

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -18,6 +18,8 @@ jobs:
 
       # Write the token into the gh credential store (Copilot respects this)
       - name: Authenticate gh once
+        env:
+          GH_TOKEN: ''
         run: echo "${{ secrets.GH_PAT_AUTOPILOT }}" | gh auth login --with-token
 
       # Headless defaults – never prompt


### PR DESCRIPTION
## Summary
- prevent gh auth step from inheriting GH_TOKEN

## Testing
- `poetry run pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849424e83588331967420eb9dc805db