### PR TITLE
Ensure Expand-All loads logging utilities

### DIFF
--- a/lab_utils/Expand-All.ps1
+++ b/lab_utils/Expand-All.ps1
@@ -1,3 +1,6 @@
+# ensure logging utilities are available
+. (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+
 function Expand-All {
     
     # Expand-All -ZipFile "C:\path\to\your\archive.zip"


### PR DESCRIPTION
## Summary
- make sure Expand-All.ps1 loads Logger.ps1 so the logging helpers are available

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849425df6248331b998140d85b058e1