### PR TITLE
Fix extra brace in HyperV provider script

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -391,7 +391,6 @@ if (Test-Path $destinationBinary) { Remove-Item $destinationBinary -Force }
 Copy-Item -Path $providerExePath -Destination $destinationBinary -Force -Verbose
 
 Write-CustomLog "Hyper-V provider installed at: $destinationBinary"
-}
 
 # ------------------------------
 # 5) Update Provider Config File (providers.tf)


### PR DESCRIPTION
## Summary
- fix stray `}` in `Prepare-HyperVProvider.ps1`
- run linters and tests

## Testing
- `Invoke-ScriptAnalyzer -Path 'runner_scripts/0010_Prepare-HyperVProvider.ps1'`
- `Invoke-Pester` *(fails: Could not find Mock for command Invoke-WebRequest)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6849414fd7348331a4a48e6375ff0fe4