### PR TITLE
Fix quoting in Customize-ISO

### DIFF
--- a/iso_tools/Customize-ISO.ps1
+++ b/iso_tools/Customize-ISO.ps1
@@ -65,7 +65,7 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
     Write-CustomLog $warnMsg1 -Level WARN
     Write-Host $warnMsg1 -ForegroundColor Red
 
-    $warnMsg2 = "Rerun using: Start-Process -FilePath (Get-Process -Id `$PID).Path -ArgumentList \"-NoProfile -ExecutionPolicy Bypass -File `\"$scriptPath`\"\" -Verb RunAs -ErrorAction Stop"
+    $warnMsg2 = 'Rerun using: Start-Process -FilePath (Get-Process -Id `$PID).Path -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"{0}`"" -Verb RunAs -ErrorAction Stop' -f $scriptPath
 
     Write-CustomLog $warnMsg2 -Level WARN
     Write-Host $warnMsg2 -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- escape quotes correctly in `Customize-ISO.ps1`

## Testing
- `Invoke-Pester tests/Customize-ISO.Tests.ps1 -Output Detailed -FullNameFilter 'Customize-ISO.ps1.parses without errors'`
- `Invoke-Pester tests/Customize-ISO.Tests.ps1 -Output Detailed` *(fails: Could not find Command Mount-DiskImage)*

------
https://chatgpt.com/codex/tasks/task_e_684943d3ad888331bc5cadb1a0a2793e