### PR TITLE
Fix closing brace in Hyper-V provider prep

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -426,6 +426,5 @@ You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
 } else {
     Write-CustomLog "PrepareHyperVHost flag is disabled. Skipping Hyper-V host preparation."
 }
-}
     Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }


### PR DESCRIPTION
## Summary
- remove stray closing brace from `0010_Prepare-HyperVProvider.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('runner_scripts/0010_Prepare-HyperVProvider.ps1',[ref]$null,[ref]$null) | Out-Null; if ($?) { 'Parsed OK' } else { 'Failed' }"`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/PrepareHyperVProvider.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_684943dc19748331b71d798b5f1a8ae9