### PR TITLE
Expose Start-Process call in installer

### DIFF
--- a/runner_utility_scripts/OpenTofuInstaller.ps1
+++ b/runner_utility_scripts/OpenTofuInstaller.ps1
@@ -578,6 +578,7 @@ function installStandalone() {
                 $wrapperCmd = "& $scriptCommand $($argList -join ' ') > $($outLog | escapePathArgument) 2> $($errLog | escapePathArgument)"
                 Set-Content -Path $wrapper -Value $wrapperCmd -Encoding utf8
 
+                $global:startProcessCalled = $true
                 $subprocess = Start-Process `
                     -Verb RunAs `
                     -WorkingDirectory (Get-Location) `


### PR DESCRIPTION
## Summary
- mark when elevated Start-Process is invoked

## Testing
- `Invoke-Pester tests/OpenTofuInstaller.Tests.ps1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684943e1b4988331b17be30456f8f611