### PR TITLE
Fix Quiet vs Verbosity parameter conflict

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -1,5 +1,12 @@
-[CmdletBinding(SupportsShouldProcess)]
+[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName='Verbose')]
 param(
+    [Parameter(ParameterSetName='Quiet')]
+    [switch]$Quiet,
+
+    [Parameter(ParameterSetName='Verbose')]
+    [ValidateSet('silent','normal','detailed')]
+    [string]$Verbosity = 'normal',
+
     [string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files/default-config.json'),
     #[string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files' 'default-config.json'),
 
@@ -8,12 +15,7 @@ param(
 
     [string]$Scripts,
 
-    [switch]$Force,
-
-    [switch]$Quiet,
-
-    [ValidateSet('silent','normal','detailed')]
-    [string]$Verbosity = 'normal'
+    [switch]$Force
 )
 
 


### PR DESCRIPTION
## Summary
- use parameter sets to avoid mixing `-Quiet` and `-Verbosity`
- keep quiet behavior by setting verbosity to `silent`

## Testing
- `Invoke-Pester tests/Runner.Tests.ps1` *(fails: Parameter set cannot be resolved using the specified named parameters)*

------
https://chatgpt.com/codex/tasks/task_e_684943e353e483318adc4872564d1664