### PR TITLE
Adjust cosign download call

### DIFF
--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -24,16 +24,18 @@ function Install-Cosign {
             }
         }
 
-        try {
-            if ($PSCmdlet.ShouldProcess($destination, 'Download cosign')) {
-                # Download the cosign executable
-                Invoke-WebRequest -Uri $Config.CosignURL -OutFile $destination -UseBasicParsing
-                Write-CustomLog "Cosign downloaded and installed at $destination"
+        if (-not (Test-Path $destination)) {
+            try {
+                if ($PSCmdlet.ShouldProcess($destination, 'Download cosign')) {
+                    # Download the cosign executable
+                    LabSetup\Invoke-WebRequest -Uri $Config.CosignURL -OutFile $destination -UseBasicParsing
+                    Write-CustomLog "Cosign downloaded and installed at $destination"
+                }
             }
-        }
-        catch {
-            Write-Error "Failed to download cosign from $Config.CosignURL. Please check your internet connection and try again."
-            return
+            catch {
+                Write-Error "Failed to download cosign from $Config.CosignURL. Please check your internet connection and try again."
+                return
+            }
         }
 
         # Add the installation folder to the user's PATH if not already present


### PR DESCRIPTION
## Summary
- qualify Invoke-WebRequest in 0006_Install-ValidationTools
- add Test-Path guard around the cosign download

## Testing
- `pwsh -NoLogo -NoProfile -Command "& { Import-Module Pester; Import-Module '$PWD/lab_utils/LabSetup/LabSetup.psd1'; Invoke-Pester 'tests/Install-ValidationTools.Tests.ps1' }"` *(fails: Could not find Mock for command Invoke-WebRequest)*

------
https://chatgpt.com/codex/tasks/task_e_684943e087808331a96e4c220238cb8a