### PR TITLE
Module-qualified Invoke-WebRequest

### DIFF
--- a/lab_utils/LabSetup/LabSetup.psd1
+++ b/lab_utils/LabSetup/LabSetup.psd1
@@ -3,5 +3,5 @@
     ModuleVersion = '0.1.0'
     GUID = 'c0000000-0000-4000-8000-000000000001'
     Author = 'OpenTofu'
-    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Get-Platform','Invoke-LabWebRequest','Invoke-LabNpm')
+    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Get-Platform','Invoke-LabWebRequest','Invoke-WebRequest','Invoke-LabNpm')
 }

--- a/lab_utils/LabSetup/LabSetup.psm1
+++ b/lab_utils/LabSetup/LabSetup.psm1
@@ -29,4 +29,4 @@ function Invoke-LabStep {
     }
 }
 
-Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform, Invoke-LabWebRequest, Invoke-LabNpm
+Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Get-Platform, Invoke-LabWebRequest, Invoke-WebRequest, Invoke-LabNpm

--- a/lab_utils/Network.ps1
+++ b/lab_utils/Network.ps1
@@ -8,6 +8,18 @@ function Invoke-LabWebRequest {
     Invoke-WebRequest @PSBoundParameters
 }
 
+# Provide a module-scoped wrapper so tests can mock Invoke-WebRequest via
+# -ModuleName LabSetup. This delegates to the built-in cmdlet.
+function Invoke-WebRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Uri,
+        [string]$OutFile,
+        [switch]$UseBasicParsing
+    )
+    Microsoft.PowerShell.Utility\Invoke-WebRequest @PSBoundParameters
+}
+
 function Invoke-LabNpm {
     [CmdletBinding()]
     param(

--- a/runner_scripts/0007_Install-Go.ps1
+++ b/runner_scripts/0007_Install-Go.ps1
@@ -1,5 +1,6 @@
 Param([object]$Config)
 Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabSetup/LabSetup.psd1"
 
 # Param([pscustomobject]$Config)
 # Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
@@ -43,7 +44,7 @@ if ($Config.InstallGo -eq $true) {
 
     $ProgressPreference = 'SilentlyContinue'
     Write-CustomLog "Downloading Go from $installerUrl"
-    Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
+    LabSetup\Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
 
     Write-CustomLog "Installing Go silently..."
     Start-Process msiexec.exe -Wait -ArgumentList "/i `"$installerPath`" /qn /L*v `"$env:TEMP\GoInstall.log`""

--- a/tests/Install-Go.Tests.ps1
+++ b/tests/Install-Go.Tests.ps1
@@ -1,5 +1,7 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabSetup' 'LabSetup.psd1') -Force
+InModuleScope LabSetup {
 Describe '0007_Install-Go'  {
     BeforeAll { $script:ScriptPath = Get-RunnerScriptPath '0007_Install-Go.ps1' }
 
@@ -34,4 +36,5 @@ Describe '0007_Install-Go'  {
         Should -Invoke -CommandName Invoke-WebRequest -Times 0
         Should -Invoke -CommandName Start-Process -Times 0
     }
+}
 }


### PR DESCRIPTION
## Summary
- call Invoke-WebRequest via the LabSetup module
- expose an Invoke-WebRequest wrapper in LabSetup
- update tests to import LabSetup in scope

## Testing
- `Invoke-Pester tests/Install-Go.Tests.ps1 -CI` *(fails: Expected Invoke-WebRequest to be mocked)*

------
https://chatgpt.com/codex/tasks/task_e_684943de40008331b85ecc6b30729e98