### PR TITLE
Check Read-LoggedInput before Expand-All definition

### DIFF
--- a/lab_utils/Expand-All.ps1
+++ b/lab_utils/Expand-All.ps1
@@ -1,5 +1,11 @@
 # ensure logging utilities are available
-. (Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1')
+if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
+    $logger = Join-Path $PSScriptRoot '..' 'runner_utility_scripts' 'Logger.ps1'
+    if (Test-Path $logger) { . $logger }
+    if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
+        function Read-LoggedInput { param($Prompt) Read-Host $Prompt }
+    }
+}
 
 function Expand-All {
     


### PR DESCRIPTION
## Summary
- ensure `Read-LoggedInput` is available when importing `Expand-All.ps1`
- fall back to a minimal implementation if the logger script is missing

## Testing
- `Invoke-Pester tests/Expand-All.Tests.ps1` *(fails: Could not find Command Read-LoggedInput)*

------
https://chatgpt.com/codex/tasks/task_e_684943d5c8488331bae0f4c086b76f7d