### PR TITLE
Fix Copilot workflow authentication

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -16,7 +16,7 @@ jobs:
 
       # Authenticate gh with the PAT
       - name: Authenticate gh
-        run: echo "${{ secrets.GH_PAT_AUTOPILOT }}" | gh auth login --with-token
+        run: echo "${{ secrets.GH_PAT_AUTOPILOT }}" | gh auth login --hostname github.com --git-protocol https --with-token
         
       - uses: actions/checkout@v4
 
@@ -24,7 +24,7 @@ jobs:
       - name: Authenticate gh once
         env:
           GH_TOKEN: ''
-        run: echo "${{ secrets.GH_PAT_AUTOPILOT }}" | gh auth login --with-token
+        run: echo "${{ secrets.GH_PAT_AUTOPILOT }}" | gh auth login --hostname github.com --git-protocol https --with-token
 
       # Headless defaults – never prompt
       - name: Pre-seed Copilot config


### PR DESCRIPTION
## Summary
- ensure gh CLI authenticates non-interactively in copilot workflow

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `bash: pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684947ad9b80833195d269ec2e3e2cec