### PR TITLE
Fix Customize-ISO mount path removal

### DIFF
--- a/iso_tools/Customize-ISO.ps1
+++ b/iso_tools/Customize-ISO.ps1
@@ -55,7 +55,9 @@ param(
 # Derived path to the WIM file inside the extracted ISO
 $WIMFile = Join-Path $ExtractPath "sources\install.wim"
 
-Remove-Item -Recurse -Force $MountPath
+if (Test-Path $MountPath) {
+    Remove-Item -Recurse -Force $MountPath
+}
 
 # Ensure running as Administrator
 if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {


### PR DESCRIPTION
## Summary
- avoid failure in `Customize-ISO.ps1` when mount directory does not exist

## Testing
- `pytest`
- `pwsh` was unavailable so Pester tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_68494890ff948331a364762c8cc717de