### PR TITLE
Fix Format-Config null handling

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -3,16 +3,30 @@ function Format-Config {
     param(
         [Parameter(Mandatory, ValueFromPipeline = $true,
                    ValueFromPipelineByPropertyName = $true)]
-        [ValidateNotNullOrEmpty()]
+        [AllowNull()]
         [pscustomobject]$Config
     )
 
     begin {
         $hasInput = $false
+
+        # Preserve validation behavior when -Config $null is passed explicitly
+        if ($PSBoundParameters.ContainsKey('Config') -and $null -eq $Config) {
+            throw [System.Management.Automation.ParameterBindingValidationException]::new(
+                "Cannot validate argument on parameter 'Config'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+            )
+        }
     }
 
     process {
         $hasInput = $true
+
+        if ($null -eq $Config) {
+            throw [System.ArgumentException]::new(
+                'A configuration object must be provided via -Config or the pipeline.',
+                'Config'
+            )
+        }
 
         # Serialize the configuration object to indented JSON so nested
         # properties are easier to read in the console output.  Depth 10


### PR DESCRIPTION
## Summary
- allow `Format-Config` to receive `$null` so pipeline can bind
- throw `ParameterBindingValidationException` when `-Config $null` is passed explicitly
- throw `ArgumentException` for `$null` from the pipeline

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `bash: pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684948c64ca08331997105dc99ef9fdd