### PR TITLE
Add module & guard for Expand-All

### DIFF
--- a/lab_utils/Expand-All.psm1
+++ b/lab_utils/Expand-All.psm1
@@ -1,0 +1,2 @@
+. "$PSScriptRoot/Expand-All.ps1"
+Export-ModuleMember -Function Expand-All

--- a/tests/Expand-All.Tests.ps1
+++ b/tests/Expand-All.Tests.ps1
@@ -2,7 +2,11 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Expand-All' {
     BeforeAll {
-        . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Expand-All.ps1')
+        $modulePath = Join-Path $PSScriptRoot '..' 'lab_utils' 'Expand-All.psm1'
+        if (-not (Test-Path $modulePath)) {
+            throw "Required module is missing: $modulePath"
+        }
+        Import-Module $modulePath -Force
     }
     BeforeEach {
         Mock-WriteLog


### PR DESCRIPTION
## Summary
- verify path for Expand-All utility in test suite
- add guard and import module in `Expand-All.Tests.ps1`
- ship new `Expand-All.psm1` exporting the function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_68494a815f8483319cc01fb29f4e0f23