### PR TITLE
Switch Format-Config to ArgumentException

### DIFF
--- a/lab_utils/Format-Config.ps1
+++ b/lab_utils/Format-Config.ps1
@@ -3,7 +3,6 @@ function Format-Config {
     param(
         [Parameter(Mandatory, ValueFromPipeline = $true,
                    ValueFromPipelineByPropertyName = $true)]
-        [ValidateNotNullOrEmpty()]
         [pscustomobject]$Config
     )
 
@@ -13,6 +12,13 @@ function Format-Config {
 
     process {
         $hasInput = $true
+
+        if ($null -eq $Config) {
+            throw [System.ArgumentException]::new(
+                'A configuration object must be provided via -Config or the pipeline.',
+                'Config'
+            )
+        }
 
         # Serialize the configuration object to indented JSON so nested
         # properties are easier to read in the console output.  Depth 10

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Format-Config' {
             Format-Config -Config $null
             $false | Should -BeTrue
         } catch {
-            $_.Exception | Should -BeOfType [System.Management.Automation.ParameterBindingException]
+            $_.Exception | Should -BeOfType [System.ArgumentException]
         }
     }
 
@@ -43,7 +43,7 @@ Describe 'Format-Config' {
     }
 
     It 'throws when Config is null' {
-        { Format-Config -Config $null } | Should -Throw
+        { Format-Config -Config $null } | Should -Throw -ErrorType [System.ArgumentException]
     }
 
     It 'is a terminating error when Config is null' {
@@ -51,7 +51,7 @@ Describe 'Format-Config' {
             Format-Config -Config $null
             $false | Should -BeTrue
         } catch {
-            $_.Exception | Should -BeOfType [System.Management.Automation.ParameterBindingException]
+            $_.Exception | Should -BeOfType [System.ArgumentException]
         }
     }
 


### PR DESCRIPTION
## Summary
- have `Format-Config` throw `ArgumentException` for null input
- update tests for the new exception type

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494a7c83608331bcafcdf8171ef129