### PR TITLE
Fix Copilot workflow auth

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -18,7 +18,16 @@ jobs:
 
       # Authenticate gh with the PAT
       - name: Authenticate gh
-        run: echo "${{ secrets.GH_PAT_AUTOPILOT }}" | gh auth login --hostname github.com --git-protocol https --with-token
+        run: |
+          if [ -z "${{ secrets.GH_PAT_AUTOPILOT }}" ]; then
+            echo "Error: GH_PAT_AUTOPILOT secret is not set."
+            exit 1
+          fi
+
+          echo "${{ secrets.GH_PAT_AUTOPILOT }}" | gh auth login --hostname github.com --git-protocol https --with-token || {
+            echo "GitHub CLI authentication failed."
+            exit 1
+          }
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- handle missing `GH_PAT_AUTOPILOT` secret in Copilot workflow
- surface authentication errors to make failures obvious

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494c2ef904833184daddc16ab7e112