### PR TITLE
Ensure ISO paths exist

### DIFF
--- a/iso_tools/Customize-ISO.ps1
+++ b/iso_tools/Customize-ISO.ps1
@@ -52,6 +52,14 @@ param(
     [int]$WIMIndex = 3
 )
 
+# Ensure target paths exist for extraction and mounting
+if (-not (Test-Path $ExtractPath)) {
+    New-Item -Path $ExtractPath -ItemType Directory | Out-Null
+}
+if (-not (Test-Path $MountPath)) {
+    New-Item -Path $MountPath -ItemType Directory | Out-Null
+}
+
 # Derived path to the WIM file inside the extracted ISO
 $WIMFile = Join-Path $ExtractPath "sources\install.wim"
 

--- a/tests/Customize-ISO.Tests.ps1
+++ b/tests/Customize-ISO.Tests.ps1
@@ -49,6 +49,8 @@ Describe 'Customize-ISO.ps1'  {
         Should -Invoke -CommandName dism -Times 1 -ParameterFilter { $dismArgs[0] -eq '/Mount-Image' -and $dismArgs[1] -eq "/ImageFile:$wimFile" -and $dismArgs[2] -eq "/Index:$index" -and $dismArgs[3] -eq "/MountDir:$mount" }
         Should -Invoke -CommandName dism -Times 1 -ParameterFilter { $dismArgs[0] -eq '/Unmount-Image' -and $dismArgs[1] -eq "/MountDir:$mount" -and $dismArgs[2] -eq '/Commit' }
         Should -Invoke -CommandName Start-Process -Times 1 -ParameterFilter { $FilePath -eq $oscExe -and $ArgumentList[-1] -eq "`"$outIso`"" }
+        Should -Invoke -CommandName New-Item -Times 1 -ParameterFilter { $ItemType -eq 'Directory' -and $Path -eq $extract }
+        Should -Invoke -CommandName New-Item -Times 1 -ParameterFilter { $ItemType -eq 'Directory' -and $Path -eq $mount }
 
         Should -Invoke -CommandName Write-CustomLog -Times 1 -ParameterFilter { $Message -eq 'Mounting Windows ISO...' }
         Should -Invoke -CommandName Write-CustomLog -Times 1 -ParameterFilter { $Message -eq "Extracting ISO contents to $extract..." }


### PR DESCRIPTION
## Summary
- ensure `$ExtractPath` and `$MountPath` exist before use
- update tests to verify directory creation

## Testing
- `Invoke-Pester -Script tests/Customize-ISO.Tests.ps1` *(fails: Could not find Command Mount-DiskImage)*

------
https://chatgpt.com/codex/tasks/task_e_68494a82523883319b60fd8db1451f7c