### PR TITLE
Fix Copilot workflow auth

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -16,20 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Authenticate gh with the PAT
-      - name: Authenticate gh
-        run: |
-          if [ -z "${{ secrets.GH_PAT_AUTOPILOT }}" ]; then
-            echo "Error: GH_PAT_AUTOPILOT secret is not set."
-            exit 1
-          fi
-
-          echo "${{ secrets.GH_PAT_AUTOPILOT }}" | gh auth login --hostname github.com --git-protocol https --with-token || {
-            echo "GitHub CLI authentication failed."
-            exit 1
-          }
-
-      - uses: actions/checkout@v4
+      # 'gh' will authenticate automatically via GH_TOKEN
 
       # Headless defaults – never prompt
       - name: Pre-seed Copilot config


### PR DESCRIPTION
## Summary
- remove redundant `gh auth login` step from Copilot workflow

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Could not find Command Get-NetIPAddress)*

------
https://chatgpt.com/codex/tasks/task_e_68494d31ba5c8331b84fb3379b7c8954