### PR TITLE
Fix LabRunner imports

### DIFF
--- a/runner_scripts/0000_Cleanup-Files.ps1
+++ b/runner_scripts/0000_Cleanup-Files.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"

--- a/runner_scripts/0001_Reset-Git.ps1
+++ b/runner_scripts/0001_Reset-Git.ps1
@@ -1,5 +1,5 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 

--- a/runner_scripts/0002_Setup-Directories.ps1
+++ b/runner_scripts/0002_Setup-Directories.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 

--- a/runner_scripts/0007_Install-Go.ps1
+++ b/runner_scripts/0007_Install-Go.ps1
@@ -1,9 +1,9 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 Import-Module "$PSScriptRoot/../lab_utils/LabSetup/LabSetup.psd1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0008_Install-OpenTofu.ps1
+++ b/runner_scripts/0008_Install-OpenTofu.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Invoke-OpenTofuInstaller {

--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -1,6 +1,6 @@
 Param([object]$Config)
 $scriptRoot = $PSScriptRoot
-Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 $installScript      = Join-Path $scriptRoot '0008_Install-OpenTofu.ps1'
 $installerAvailable = Test-Path $installScript

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 

--- a/runner_scripts/0100_Enable-WinRM.ps1
+++ b/runner_scripts/0100_Enable-WinRM.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0101_Enable-RemoteDesktop.ps1
+++ b/runner_scripts/0101_Enable-RemoteDesktop.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0102_Configure-Firewall.ps1
+++ b/runner_scripts/0102_Configure-Firewall.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0103_Change-ComputerName.ps1
+++ b/runner_scripts/0103_Change-ComputerName.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0104_Install-CA.ps1
+++ b/runner_scripts/0104_Install-CA.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Install-CA {

--- a/runner_scripts/0105_Install-HyperV.ps1
+++ b/runner_scripts/0105_Install-HyperV.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0106_Install-WAC.ps1
+++ b/runner_scripts/0106_Install-WAC.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 

--- a/runner_scripts/0111_Disable-TCPIP6.ps1
+++ b/runner_scripts/0111_Disable-TCPIP6.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0112_Enable-PXE.ps1
+++ b/runner_scripts/0112_Enable-PXE.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0113_Config-DNS.ps1
+++ b/runner_scripts/0113_Config-DNS.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0114_Config-TrustedHosts.ps1
+++ b/runner_scripts/0114_Config-TrustedHosts.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {

--- a/runner_scripts/0200_Get-SystemInfo.ps1
+++ b/runner_scripts/0200_Get-SystemInfo.ps1
@@ -3,7 +3,7 @@ Param(
     [switch]$AsJson
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Get-SystemInfo {
     [CmdletBinding()]

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 

--- a/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/runner_scripts/0202_Install-NodeGlobalPackages.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 

--- a/runner_scripts/0203_Install-npm.ps1
+++ b/runner_scripts/0203_Install-npm.ps1
@@ -3,7 +3,7 @@ Param(
     [object]$Config
 )
 
-Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 function Install-NpmDependencies {
     [CmdletBinding(SupportsShouldProcess = $true)]

--- a/runner_scripts/9999_Reset-Machine.ps1
+++ b/runner_scripts/9999_Reset-Machine.ps1
@@ -1,8 +1,8 @@
 Param([object]$Config)
-Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 # Param([pscustomobject]$Config)
-# Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psm1')
+# Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psm1"
 
 Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {


### PR DESCRIPTION
## Summary
- load LabRunner.psm1 directly in runner scripts

## Testing
- `Invoke-Pester` *(fails: Cannot install OpenTofu because the installer script is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68494ae44b3083318ed9f16ee531c5f1