### PR TITLE
Fix runner test for module manifest

### DIFF
--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -80,7 +80,7 @@ Describe 'Runner scripts parameter and command checks'  {
                 $_.CommandElements[1] -is [System.Management.Automation.Language.StringConstantExpressionAst] -or
                 $_.CommandElements[1] -is [System.Management.Automation.Language.ExpandableStringExpressionAst]
             ) -and
-            ([System.IO.Path]::GetFileName($_.CommandElements[1].Value) -eq 'LabRunner.psm1')
+            ([System.IO.Path]::GetFileName($_.CommandElements[1].Value) -in @('LabRunner.psm1', 'LabRunner.psd1'))
         }
 
         if (-not $found) {


### PR DESCRIPTION
## Summary
- relax RunnerScripts tests to accept `LabRunner.psd1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684952a3dcb08331ac550e3469a223e3