### PR TITLE
Fix Join-Path compatibility for Windows PowerShell

### DIFF
--- a/kicker-bootstrap.ps1
+++ b/kicker-bootstrap.ps1
@@ -50,7 +50,7 @@ $isWindowsOS = [System.Environment]::OSVersion.Platform -eq 'Win32NT'
 
 # Ensure the logger utility is available even when this script is executed
 # standalone. If the logger script is missing, download it from the repository.
-$loggerDir  = Join-Path $scriptRoot 'lab_utils' 'LabRunner'
+$loggerDir  = Join-Path (Join-Path $scriptRoot 'lab_utils') 'LabRunner'
 $loggerPath = Join-Path $loggerDir 'Logger.ps1'
 if (-not (Test-Path $loggerPath)) {
     if (-not (Test-Path $loggerDir)) {

--- a/lab_utils/Get-LabConfig.ps1
+++ b/lab_utils/Get-LabConfig.ps1
@@ -38,7 +38,7 @@ function Get-LabConfig {
 
         $dirs['RepoRoot']       = $repoRoot.Path
         $dirs['RunnerScripts']  = Join-Path $repoRoot 'runner_scripts'
-        $dirs['UtilityScripts'] = Join-Path $repoRoot 'lab_utils' 'LabRunner'
+        $dirs['UtilityScripts'] = Join-Path (Join-Path $repoRoot 'lab_utils') 'LabRunner'
         $dirs['ConfigFiles']    = Join-Path $repoRoot 'config_files'
         $dirs['InfraRepo']      = if ($config.InfraRepoPath) { $config.InfraRepoPath } else { 'C:\\Temp\\base-infra' }
 

--- a/runner.ps1
+++ b/runner.ps1
@@ -8,7 +8,7 @@ param(
     [string]$Verbosity = 'normal',
 
     [string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files/default-config.json'),
-    #[string]$ConfigFile = (Join-Path $PSScriptRoot 'config_files' 'default-config.json'),
+    #[string]$ConfigFile = (Join-Path (Join-Path $PSScriptRoot 'config_files') 'default-config.json'),
 
 
     [switch]$Auto,
@@ -56,13 +56,13 @@ $script:ConsoleLevel    = $script:VerbosityLevels[$Verbosity]
 
 # ─── Load helpers ──────────────────────────────────────────────────────────────
 if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
-    . (Join-Path $PSScriptRoot 'lab_utils' 'LabRunner' 'Logger.ps1')
+    . (Join-Path (Join-Path (Join-Path $PSScriptRoot 'lab_utils') 'LabRunner') 'Logger.ps1')
 }
 $env:LAB_CONSOLE_LEVEL = $script:VerbosityLevels[$Verbosity]
-. (Join-Path $PSScriptRoot 'lab_utils' 'Get-LabConfig.ps1')
-. (Join-Path $PSScriptRoot 'lab_utils' 'Format-Config.ps1')
-. (Join-Path $PSScriptRoot 'lab_utils' 'Get-Platform.ps1')
-$menuPath = Join-Path $PSScriptRoot 'lab_utils' 'Menu.ps1'
+. (Join-Path (Join-Path $PSScriptRoot 'lab_utils') 'Get-LabConfig.ps1')
+. (Join-Path (Join-Path $PSScriptRoot 'lab_utils') 'Format-Config.ps1')
+. (Join-Path (Join-Path $PSScriptRoot 'lab_utils') 'Get-Platform.ps1')
+$menuPath = Join-Path (Join-Path $PSScriptRoot 'lab_utils') 'Menu.ps1'
 if (-not (Test-Path $menuPath)) {
     Write-Error "Menu module not found at $menuPath"
     exit 1
@@ -138,7 +138,7 @@ function Set-NestedConfigValue {
 function Apply-RecommendedDefaults {
     param([hashtable]$ConfigObject)
 
-    $recommendedPath = Join-Path $PSScriptRoot 'config_files' 'recommended-config.json'
+    $recommendedPath = Join-Path (Join-Path $PSScriptRoot 'config_files') 'recommended-config.json'
     if (-not (Test-Path $recommendedPath)) { return $ConfigObject }
     try {
         $recommended = Get-Content -Raw -Path $recommendedPath | ConvertFrom-Json


### PR DESCRIPTION
## Summary
- ensure Join-Path statements only use two parameters
- update runner and bootstrap scripts to work on Windows PowerShell 5.1
- keep Get-LabConfig consistent with new approach

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849532a25f88331835ad5186d89e50f