### PR TITLE
Update Copilot workflow token

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -11,7 +11,7 @@ jobs:
   copilot-suggest:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.GH_PAT_AUTOPILOT }}
+      GH_TOKEN: ${{ secrets.COPILOT_OAUTH_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The lint workflow installs the GitHub Copilot CLI and runs `github-copilot-cli s
 after linting. The command scans the repository and provides additional
 improvement ideas directly in the workflow logs.
 
+The optional [Copilot Auto Fix workflow](docs/copilot-auto-fix.md) can comment
+on issues with suggested patches. It requires a GitHub CLI token with the
+`copilot` scope stored as the repository secret `COPILOT_OAUTH_TOKEN`.
+
 
 Clone this repository and apply the lab template:
 

--- a/docs/copilot-auto-fix.md
+++ b/docs/copilot-auto-fix.md
@@ -1,0 +1,20 @@
+# Copilot Auto Fix Workflow
+
+The workflow `.github/workflows/copilot-auto-fix.yml` uses the GitHub Copilot CLI extension via `gh`. It requires an OAuth token with the `copilot` scope.
+
+1. Install and authenticate the [GitHub CLI](https://cli.github.com/):
+
+   ```bash
+   gh auth login --web
+   ```
+
+2. Refresh your token with the additional scope and print it:
+
+   ```bash
+   gh auth refresh -s copilot
+   gh auth token
+   ```
+
+3. Add the token as the repository secret **`COPILOT_OAUTH_TOKEN`**.
+
+The workflow reads the secret and sets the `GH_TOKEN` environment variable so that Copilot can suggest fixes for open issues.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,5 +4,6 @@ nav:
   - Runner: docs/runner.md
   - Lab Utils: docs/lab_utils.md
   - ISO Tools: docs/iso_tools.md
+  - Copilot Auto Fix: docs/copilot-auto-fix.md
   - Python CLI: docs/python-cli.md
   - Troubleshooting: docs/troubleshooting.md


### PR DESCRIPTION
## Summary
- use new COPILOT_OAUTH_TOKEN secret in Copilot workflow
- document how to generate the token and configure the workflow
- add Copilot docs page and mkdocs navigation entry

## Testing
- `pytest -q`
- *(failed to run `Invoke-Pester` – `pwsh` not available)*

------
https://chatgpt.com/codex/tasks/task_e_68495552d8c88331aba176386e56e884