### PR TITLE
Add labctl commands to Phase 1 roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,13 @@
 
 * Flesh out provider‑specific classes in both PowerShell and Python.
 * Map shared config schema across languages.
+* Useful `labctl` subcommands:
+  * `labctl hv facts` – display hypervisor configuration details.
+  * `labctl hv deploy` – deploy a host or VM using the config.
+  * `labctl repo cleanup` – remove merged branches from the remote.
+  * `labctl ui` – launch the Textual user interface.
+
+See `py/README.md` for detailed instructions on installing and running the CLI.
 
 ---
 


### PR DESCRIPTION
## Summary
- outline common `labctl` subcommands in Phase 1 section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684957dee1e08331948bb27654338a91