### PR TITLE
Add troubleshooting reference to Windows artifact docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,9 @@ gh run list --limit 20
 * **.github/workflows/ci.yml** – Windows job definition
 * **docs/testing.md** – general test guidelines
 
+For step-by-step examples of reading `testResults.xml` and `coverage.xml`, see
+[docs/troubleshooting.md](docs/troubleshooting.md).
+
 ---
 
 *Last updated {{DATE}}; keep this page in sync with CI changes.*


### PR DESCRIPTION
## Summary
- cross-link troubleshooting guide from Windows artifact section
- detail where to find info on interpreting `testResults.xml` and `coverage.xml`

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684957e087c48331b4e825338da29f78