### PR TITLE
Add self-hosted runner guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Welcome! This folder collects notes and guides for working with the project.
 
 - [labctl Python CLI](python-cli.md)
 - [Runner script usage](runner.md)
+- [Self-hosted GitHub runner](self-hosted-runner.md)
 
 
 

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -5,21 +5,10 @@ This repository can use your own machine to execute workflow jobs. The following
 1. **Create a folder and download the runner**
 
    ```powershell
+   $runnerVersion = "2.325.0"
+   $runnerChecksum = "8601aa56828c084b29bdfda574af1fcde0943ce275fdbafb3e6d4a8611245b1b"
    mkdir actions-runner; cd actions-runner
-   Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v2.325.0/actions-runner-win-x64-2.325.0.zip -OutFile actions-runner-win-x64-2.325.0.zip
-   ```
-
-   Optionally validate the package hash:
-
-   ```powershell
-   if((Get-FileHash -Path actions-runner-win-x64-2.325.0.zip -Algorithm SHA256).Hash.ToUpper() -ne '8601aa56828c084b29bdfda574af1fcde0943ce275fdbafb3e6d4a8611245b1b'.ToUpper()){ throw 'Computed checksum did not match' }
-   ```
-
-   Extract the archive:
-
-   ```powershell
-   Add-Type -AssemblyName System.IO.Compression.FileSystem
-   [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/actions-runner-win-x64-2.325.0.zip", "$PWD")
+   Invoke-WebRequest -Uri "https://github.com/actions/runner/releases/download/v$runnerVersion/actions-runner-win-x64-$runnerVersion.zip" -OutFile "actions-runner-win-x64-$runnerVersion.zip"
    ```
 
 2. **Configure the runner**

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -1,0 +1,41 @@
+# Self-hosted GitHub Actions Runner
+
+This repository can use your own machine to execute workflow jobs. The following steps are adapted from the GitHub runner setup page.
+
+1. **Create a folder and download the runner**
+
+   ```powershell
+   mkdir actions-runner; cd actions-runner
+   Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v2.325.0/actions-runner-win-x64-2.325.0.zip -OutFile actions-runner-win-x64-2.325.0.zip
+   ```
+
+   Optionally validate the package hash:
+
+   ```powershell
+   if((Get-FileHash -Path actions-runner-win-x64-2.325.0.zip -Algorithm SHA256).Hash.ToUpper() -ne '8601aa56828c084b29bdfda574af1fcde0943ce275fdbafb3e6d4a8611245b1b'.ToUpper()){ throw 'Computed checksum did not match' }
+   ```
+
+   Extract the archive:
+
+   ```powershell
+   Add-Type -AssemblyName System.IO.Compression.FileSystem
+   [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/actions-runner-win-x64-2.325.0.zip", "$PWD")
+   ```
+
+2. **Configure the runner**
+
+   ```powershell
+   ./config.cmd --url https://github.com/wizzense/opentofu-lab-automation --token <token>
+   ```
+
+   Replace `<token>` with the registration token from the repository settings.
+
+3. **Start the runner**
+
+   ```powershell
+   ./run.cmd
+   ```
+
+   Leave this terminal open while jobs are running, or install the runner as a service.
+
+Use `runs-on: self-hosted` in a workflow job to target your machine.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: OpenTofu Lab Automation
 nav:
   - Home: docs/index.md
   - Runner: docs/runner.md
+  - Self-hosted Runner: docs/self-hosted-runner.md
   - Lab Utils: docs/lab_utils.md
   - ISO Tools: docs/iso_tools.md
   - Copilot Auto Fix: docs/copilot-auto-fix.md


### PR DESCRIPTION
## Summary
- document how to set up a self-hosted GitHub Actions runner
- link new guide from the docs index and mkdocs navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684959bdf5188331aa749793a9168357