### PR TITLE
Fix drive letter retrieval in Customize-ISO

### DIFF
--- a/iso_tools/Customize-ISO.ps1
+++ b/iso_tools/Customize-ISO.ps1
@@ -100,7 +100,7 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 # Step 1: Mount the Windows ISO
 Write-CustomLog "Mounting Windows ISO..."
 $ISO = Mount-DiskImage -ImagePath $ISOPath -PassThru
-$DriveLetter = ($ISO | Get-Volume).DriveLetter + ":"
+$DriveLetter = (Get-Volume -DiskImage $ISO).DriveLetter + ":"
 
 # Step 2: Extract ISO contents
 Write-CustomLog "Extracting ISO contents to $ExtractPath..."


### PR DESCRIPTION
## Summary
- fix Get-Volume invocation so Customize-ISO can determine the mounted ISO drive letter

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Could not find Command Get-NetIPAddress)*

------
https://chatgpt.com/codex/tasks/task_e_6849583438348331a6d485501be3dfb8