### PR TITLE
Add Poetry installer PowerShell step

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ Terraform modules:
 The optional `labctl` command line utility lives in the [py](py/) folder.
 It requires Python 3.10 or newer (see [py/pyproject.toml](py/pyproject.toml)).
 Install its dependencies with [Poetry](https://python-poetry.org/) and run the
-subcommands via `poetry run`:
+subcommands via `poetry run`. Set `InstallPoetry` in your configuration to have
+`runner.ps1` execute `0204_Install-Poetry.ps1` automatically. You can override
+the version with `PoetryVersion`.
 
 
 ```bash

--- a/config_files/default-config.json
+++ b/config_files/default-config.json
@@ -16,6 +16,8 @@
   "InstallHyperV": false,
   "InstallWAC": false,
   "InstallGo": false,
+  "InstallPoetry": false,
+  "PoetryVersion": "latest",
   "InstallOpenTofu": false,
   "OpenTofuVersion": "latest",
   "InitializeOpenTofu": false,

--- a/config_files/full-config.json
+++ b/config_files/full-config.json
@@ -23,6 +23,8 @@
   "InstallHyperV": true,
   "InstallWAC": true,
   "InstallGo": true,
+  "InstallPoetry": true,
+  "PoetryVersion": "latest",
   "InstallOpenTofu": true,
   "OpenTofuVersion": "latest",
   "InitializeOpenTofu": true,

--- a/py/README.md
+++ b/py/README.md
@@ -4,7 +4,8 @@ This folder houses the Python CLI used for cross-platform tasks.
 
 ## Installing dependencies
 
-Install [Poetry](https://python-poetry.org/) and run:
+Install [Poetry](https://python-poetry.org/) or execute
+`runner_scripts/0204_Install-Poetry.ps1` to bootstrap it automatically, then run:
 
 ```bash
 cd py

--- a/runner_scripts/0204_Install-Poetry.ps1
+++ b/runner_scripts/0204_Install-Poetry.ps1
@@ -15,16 +15,20 @@ function Install-Poetry {
             $installerUrl = 'https://install.python-poetry.org'
             $installerPath = Join-Path $env:TEMP 'install-poetry.py'
 
-            Invoke-LabWebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
+            try {
+                Invoke-LabWebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
 
-            $args = @()
-            if ($Config.PoetryVersion) {
-                $args += '--version'
-                $args += $Config.PoetryVersion
+                $args = @()
+                if ($Config.PoetryVersion) {
+                    $args += '--version'
+                    $args += $Config.PoetryVersion
+                }
+                Write-CustomLog 'Executing Poetry installer...'
+                python $installerPath @args
             }
-            Write-CustomLog 'Executing Poetry installer...'
-            python $installerPath @args
-            Remove-Item $installerPath -Force
+            finally {
+                Remove-Item $installerPath -Force
+            }
         }
         else {
             Write-CustomLog 'InstallPoetry flag is disabled. Skipping Poetry installation.'

--- a/runner_scripts/0204_Install-Poetry.ps1
+++ b/runner_scripts/0204_Install-Poetry.ps1
@@ -1,0 +1,37 @@
+Param([object]$Config)
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+
+Write-CustomLog "Starting $MyInvocation.MyCommand"
+
+function Install-Poetry {
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param([object]$Config)
+
+    Invoke-LabStep -Config $Config -Body {
+        param($Config)
+        Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
+
+        if ($Config.InstallPoetry -eq $true) {
+            $installerUrl = 'https://install.python-poetry.org'
+            $installerPath = Join-Path $env:TEMP 'install-poetry.py'
+
+            Invoke-LabWebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
+
+            $args = @()
+            if ($Config.PoetryVersion) {
+                $args += '--version'
+                $args += $Config.PoetryVersion
+            }
+            Write-CustomLog 'Executing Poetry installer...'
+            python $installerPath @args
+            Remove-Item $installerPath -Force
+        }
+        else {
+            Write-CustomLog 'InstallPoetry flag is disabled. Skipping Poetry installation.'
+        }
+
+        Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') { Install-Poetry @PSBoundParameters }

--- a/tests/Install-Poetry.Tests.ps1
+++ b/tests/Install-Poetry.Tests.ps1
@@ -1,0 +1,38 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+Describe '0204_Install-Poetry' {
+    BeforeAll {
+        $script:ScriptPath = Get-RunnerScriptPath '0204_Install-Poetry.ps1'
+        . $script:ScriptPath
+    }
+
+    It 'invokes installer when enabled' {
+        $cfg = [pscustomobject]@{ InstallPoetry = $true; PoetryVersion = '1.8.2' }
+        Mock Invoke-LabWebRequest {}
+        function python { param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Args) }
+        Mock python {}
+        Mock-WriteLog
+
+        Install-Poetry -Config $cfg
+
+        Should -Invoke -CommandName Invoke-LabWebRequest -Times 1 -ParameterFilter { $Uri -eq 'https://install.python-poetry.org' }
+        Should -Invoke -CommandName python -Times 1
+    }
+
+    It 'skips when InstallPoetry is false' {
+        $cfg = [pscustomobject]@{ InstallPoetry = $false }
+        Mock Invoke-LabWebRequest {}
+        function python { param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Args) }
+        Mock python {}
+        Mock-WriteLog
+
+        Install-Poetry -Config $cfg
+
+        Should -Invoke -CommandName Invoke-LabWebRequest -Times 0
+        Should -Invoke -CommandName python -Times 0
+    }
+
+    AfterEach {
+        Remove-Item function:python -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary
- add `0204_Install-Poetry.ps1` for installing Poetry
- introduce `InstallPoetry` and `PoetryVersion` settings
- document Poetry installer usage
- show Poetry bootstrap option in Python README
- test Poetry installation logic with Pester

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Could not find Command Get-Service)*

------
https://chatgpt.com/codex/tasks/task_e_68495ed6314c833184e0ef82b7b2973c