### PR TITLE
Add Sysinternals installation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ The runner script can run the following:
 
 0009_Initialize-OpenTofu.ps1 - setups up opentofu and the lab-infra repo in C:\temp\base-infra
 
+0205_Install-Sysinternals.ps1 - downloads the Sysinternals Suite to the path specified by `SysinternalsPath` and verifies `PsInfo.exe`
+
 0010_Prepare-HyperVHost.ps1 - configures Hyper-V and downloads the provider from the registry
 
 - Enables hyper-v if not enabled

--- a/config_files/full-config.json
+++ b/config_files/full-config.json
@@ -32,10 +32,12 @@
   "CosignURL": "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-windows-amd64.exe",
   "CosignPath": "C:\\temp\\cosign",
   "InstallGPG": true,
+  "InstallSysinternals": true,
+  "SysinternalsPath": "C:\\Sysinternals",
   "CertificateAuthority": {
-    "CommonName": "default-lab-RootCA",
-    "ValidityYears": 5
-  },
+      "CommonName": "default-lab-RootCA",
+      "ValidityYears": 5
+    },
   "HyperV": {
     "User": "",
     "Password": "",

--- a/runner_scripts/0205_Install-Sysinternals.ps1
+++ b/runner_scripts/0205_Install-Sysinternals.ps1
@@ -19,7 +19,12 @@ Invoke-LabStep -Config $Config -Body {
     $zipUrl  = 'https://download.sysinternals.com/files/SysinternalsSuite.zip'
     $zipPath = Join-Path $env:TEMP ("SysinternalsSuite_{0}.zip" -f (New-Guid))
     Write-CustomLog "Downloading Sysinternals Suite from $zipUrl to $zipPath"
-    Invoke-LabWebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+    try {
+        Invoke-LabWebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+    } catch {
+        Write-CustomLog "Error: Failed to download Sysinternals Suite from $zipUrl. $_"
+        throw
+    }
 
     Write-CustomLog "Extracting to $destDir"
     Expand-Archive -Path $zipPath -DestinationPath $destDir -Force

--- a/runner_scripts/0205_Install-Sysinternals.ps1
+++ b/runner_scripts/0205_Install-Sysinternals.ps1
@@ -1,0 +1,35 @@
+Param([object]$Config)
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+Import-Module "$PSScriptRoot/../lab_utils/LabSetup/LabSetup.psd1"
+
+Write-CustomLog "Starting $MyInvocation.MyCommand"
+Invoke-LabStep -Config $Config -Body {
+    Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
+
+    if (-not $Config.InstallSysinternals) {
+        Write-CustomLog "InstallSysinternals flag is disabled. Skipping installation."
+        return
+    }
+
+    $destDir = if ($Config.SysinternalsPath) { $Config.SysinternalsPath } else { 'C:\\Sysinternals' }
+    if (-not (Test-Path $destDir)) {
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+    }
+
+    $zipUrl  = 'https://download.sysinternals.com/files/SysinternalsSuite.zip'
+    $zipPath = Join-Path $env:TEMP 'SysinternalsSuite.zip'
+    Write-CustomLog "Downloading Sysinternals Suite from $zipUrl"
+    Invoke-LabWebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+
+    Write-CustomLog "Extracting to $destDir"
+    Expand-Archive -Path $zipPath -DestinationPath $destDir -Force
+    Remove-Item $zipPath -Force
+
+    $psInfo = Join-Path $destDir 'PsInfo.exe'
+    if (Test-Path $psInfo) {
+        Write-CustomLog 'Verifying PsInfo.exe'
+        & $psInfo | Out-Null
+    }
+
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
+}

--- a/runner_scripts/0205_Install-Sysinternals.ps1
+++ b/runner_scripts/0205_Install-Sysinternals.ps1
@@ -17,8 +17,8 @@ Invoke-LabStep -Config $Config -Body {
     }
 
     $zipUrl  = 'https://download.sysinternals.com/files/SysinternalsSuite.zip'
-    $zipPath = Join-Path $env:TEMP 'SysinternalsSuite.zip'
-    Write-CustomLog "Downloading Sysinternals Suite from $zipUrl"
+    $zipPath = Join-Path $env:TEMP ("SysinternalsSuite_{0}.zip" -f (New-Guid))
+    Write-CustomLog "Downloading Sysinternals Suite from $zipUrl to $zipPath"
     Invoke-LabWebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
 
     Write-CustomLog "Extracting to $destDir"

--- a/tests/Install-Sysinternals.Tests.ps1
+++ b/tests/Install-Sysinternals.Tests.ps1
@@ -1,0 +1,32 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabSetup' 'LabSetup.psd1') -Force
+InModuleScope LabSetup {
+Describe '0205_Install-Sysinternals' {
+    BeforeAll { $script:ScriptPath = Get-RunnerScriptPath '0205_Install-Sysinternals.ps1' }
+
+    It 'downloads and extracts when enabled' {
+        $dest = Join-Path $env:TEMP ([guid]::NewGuid())
+        $cfg  = [pscustomobject]@{ InstallSysinternals = $true; SysinternalsPath = $dest }
+        Mock Invoke-LabWebRequest {}
+        Mock Expand-Archive {}
+        Mock New-Item {}
+        Mock Test-Path { $false } -ParameterFilter { $Path -eq $dest }
+        Mock Remove-Item {}
+        Mock-WriteLog
+        & $script:ScriptPath -Config $cfg
+        Should -Invoke -CommandName Invoke-LabWebRequest -Times 1
+        Should -Invoke -CommandName Expand-Archive -Times 1 -ParameterFilter { $DestinationPath -eq $dest }
+    }
+
+    It 'skips when InstallSysinternals is false' {
+        $cfg = [pscustomobject]@{ InstallSysinternals = $false }
+        Mock Invoke-LabWebRequest {}
+        Mock Expand-Archive {}
+        Mock-WriteLog
+        & $script:ScriptPath -Config $cfg
+        Should -Invoke -CommandName Invoke-LabWebRequest -Times 0
+        Should -Invoke -CommandName Expand-Archive -Times 0
+    }
+}
+}


### PR DESCRIPTION
## Summary
- install Sysinternals Suite via new runner script
- provide config options `InstallSysinternals` and `SysinternalsPath`
- document script usage in README
- cover new logic with Pester tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495ed7a988833188c46437b3df4420