### PR TITLE
Fix logging output for runner

### DIFF
--- a/runner.ps1
+++ b/runner.ps1
@@ -312,9 +312,6 @@ function Invoke-Scripts {
                     Write-Error $line.ToString()
                 } elseif ($line -is [System.Management.Automation.WarningRecord]) {
                     Write-Warning $line.ToString()
-                } elseif ($line -match '^\[\d{4}-\d{2}-\d{2} .*\] \[(INFO|WARN|ERROR)\]') {
-                    # Already logged by Write-CustomLog within the script
-                    continue
                 } else {
                     Write-CustomLog $line.ToString()
                 }


### PR DESCRIPTION
## Summary
- stream script log lines directly to console

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499dd4576c8331a8f8507e22358f9e