### PR TITLE
Fix Windows Pester test for Customize-ISO

### DIFF
--- a/tests/Customize-ISO.Tests.ps1
+++ b/tests/Customize-ISO.Tests.ps1
@@ -30,7 +30,8 @@ Describe 'Customize-ISO.ps1'  {
         New-Item -ItemType File -Path $unattend | Out-Null
 
         Mock-WriteLog
-        Mock Mount-DiskImage { [pscustomobject]@{ DevicePath = $iso } } -ParameterFilter { $ImagePath -eq $iso -and $PassThru }
+        $diskImage = New-CimInstance -ClassName MSFT_DiskImage -Property @{ DevicePath = $iso } -ClientOnly
+        Mock Mount-DiskImage { $diskImage } -ParameterFilter { $ImagePath -eq $iso -and $PassThru }
         Mock Get-Volume { [pscustomobject]@{ DriveLetter = 'Z' } }
         Mock Dismount-DiskImage {} -ParameterFilter { $ImagePath -eq $iso }
         function dism { param([Parameter(ValueFromRemainingArguments=$true)][string[]]$dismArgs) }


### PR DESCRIPTION
## Summary
- fix Customize-ISO test to use a `CimInstance` when mocking `Mount-DiskImage`

## Testing
- `pwsh -NoLogo -NoProfile -Command "echo test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499eb8765c8331bdad0b673f232c46