### PR TITLE
Fix Expand-All Pester tests

### DIFF
--- a/lab_utils/Expand-All.ps1
+++ b/lab_utils/Expand-All.ps1
@@ -1,19 +1,19 @@
-# ensure logging utilities are available
-if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
-    $logger = Join-Path $PSScriptRoot '..' 'LabRunner' 'Logger.ps1'
-    if (Test-Path $logger) { . $logger }
-    if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
-        function Read-LoggedInput { param($Prompt) Read-Host $Prompt }
-    }
-}
-
 function Expand-All {
-    
+
     # Expand-All -ZipFile "C:\path\to\your\archive.zip"
 
     param(
         [string]$ZipFile
     )
+
+    # Ensure logging helpers are available for each invocation
+    if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
+        $logger = Join-Path $PSScriptRoot '..' 'LabRunner' 'Logger.ps1'
+        if (Test-Path $logger) { . $logger }
+        if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
+            function Read-LoggedInput { param($Prompt) Read-Host $Prompt }
+        }
+    }
 
     if ($ZipFile) {
         # Expand a specific zip file if provided


### PR DESCRIPTION
## Summary
- load logger helper inside `Expand-All`

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499ed4f50883318ad7a416552e054e