### PR TITLE
Ensure installers clean up temp files

### DIFF
--- a/lab_utils/LabRunner/LabRunner.psd1
+++ b/lab_utils/LabRunner/LabRunner.psd1
@@ -4,5 +4,5 @@
     GUID = 'c0000000-0000-4000-8000-000000000001'
     NestedModules = @('../LabSetup/LabSetup.psd1')
     Author = 'OpenTofu'
-    FunctionsToExport = @('Invoke-LabStep','Write-CustomLog','Read-LoggedInput','Get-Platform','Invoke-LabWebRequest','Invoke-LabNpm')
+    FunctionsToExport = @('Invoke-LabStep','Invoke-LabDownload','Write-CustomLog','Read-LoggedInput','Get-Platform','Invoke-LabWebRequest','Invoke-LabNpm')
 }

--- a/runner_scripts/0007_Install-Go.ps1
+++ b/runner_scripts/0007_Install-Go.ps1
@@ -39,16 +39,13 @@ if ($Config.InstallGo -eq $true) {
     }
 
     Write-CustomLog "Installing Go version $goVersion for architecture $goArch..."
-    $installerPath = "$env:TEMP\GoInstaller.msi"
-
     $ProgressPreference = 'SilentlyContinue'
-    Write-CustomLog "Downloading Go from $installerUrl"
-    LabSetup\Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
-
-    Write-CustomLog "Installing Go silently..."
-    Start-Process msiexec.exe -Wait -ArgumentList "/i `"$installerPath`" /qn /L*v `"$env:TEMP\GoInstall.log`""
-
-    Write-CustomLog "Go installation complete."
+    Invoke-LabDownload -Uri $installerUrl -Prefix 'GoInstaller' -Extension '.msi' -Action {
+        param($installerPath)
+        Write-CustomLog "Installing Go silently..."
+        Start-Process msiexec.exe -Wait -ArgumentList "/i `"$installerPath`" /qn /L*v `"$env:TEMP\GoInstall.log`""
+        Write-CustomLog "Go installation complete."
+    }
 } else {
     Write-CustomLog "InstallGo flag is disabled. Skipping Go installation."
 }

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -374,10 +374,11 @@ $arch = if ($info.OsArchitecture -match '64') { 'amd64' } else { '386' }
 $registryEndpoint = "https://registry.terraform.io/v1/providers/taliesins/hyperv/$providerVersion/download/$os/$arch"
 Write-CustomLog "Querying provider registry: $registryEndpoint"
 $downloadInfo = Invoke-RestMethod -Uri $registryEndpoint
-$zipPath  = Join-Path $env:TEMP "hyperv_provider_$($providerVersion).zip"
-Invoke-WebRequest -Uri $downloadInfo.download_url -OutFile $zipPath
 $tempDir = Join-Path $env:TEMP "hyperv_provider_$($providerVersion)"
-Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+Invoke-LabDownload -Uri $downloadInfo.download_url -Prefix 'hyperv_provider' -Extension '.zip' -Action {
+    param($zipPath)
+    Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+}
 
 $providerExePath = Join-Path $tempDir "terraform-provider-hyperv_${providerVersion}.exe"
 $hypervProviderDir = Join-Path $infraRepoPath ".terraform\providers\registry.opentofu.org\taliesins\hyperv\$providerVersion\${os}_${arch}"

--- a/runner_scripts/0106_Install-WAC.ps1
+++ b/runner_scripts/0106_Install-WAC.ps1
@@ -56,17 +56,13 @@ if ($Config.InstallWAC -eq $true) {
 
     # Download the Windows Admin Center MSI
     $downloadUrl = "https://aka.ms/wacdownload"
-    $installerPath = "$env:TEMP\WindowsAdminCenter.msi"
-
     $ProgressPreference = 'SilentlyContinue'
-
-    Write-CustomLog "Downloading WAC from $downloadUrl"
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $installerPath -UseBasicParsing
-
-    Write-CustomLog "Installing WAC silently on port $installPort"
-    Start-Process msiexec.exe -Wait -ArgumentList "/i `"$installerPath`" /qn /L*v `"$env:TEMP\WacInstall.log`" SME_PORT=$installPort ACCEPT_EULA=1"
-
-    Write-CustomLog "WAC installation complete."
+    Invoke-LabDownload -Uri $downloadUrl -Prefix 'WindowsAdminCenter' -Extension '.msi' -Action {
+        param($installerPath)
+        Write-CustomLog "Installing WAC silently on port $installPort"
+        Start-Process msiexec.exe -Wait -ArgumentList "/i `"$installerPath`" /qn /L*v `"$env:TEMP\WacInstall.log`" SME_PORT=$installPort ACCEPT_EULA=1"
+        Write-CustomLog "WAC installation complete."
+    }
 } else {
     Write-CustomLog "InstallWAC flag is disabled. Skipping Windows Admin Center installation."
 }

--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -56,12 +56,10 @@ if ($nodeDeps.InstallNode) {
             $url = "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
         }
 
-        $installerPath = Join-Path $env:TEMP "node-installer.msi"
-        Write-CustomLog "Downloading Node.js from: $url"
-        Invoke-LabWebRequest -Uri $url -OutFile $installerPath -UseBasicParsing
-
-        Start-Process msiexec.exe -ArgumentList "/i `"$installerPath`" /quiet /norestart" -Wait -NoNewWindow
-        Remove-Item $installerPath -Force
+        Invoke-LabDownload -Uri $url -Prefix 'node-installer' -Extension '.msi' -Action {
+            param($installerPath)
+            Start-Process msiexec.exe -ArgumentList "/i `"$installerPath`" /quiet /norestart" -Wait -NoNewWindow
+        }
 
         if (Get-Command node -ErrorAction SilentlyContinue) {
             Write-CustomLog "Node.js installed successfully."

--- a/runner_scripts/0204_Install-Poetry.ps1
+++ b/runner_scripts/0204_Install-Poetry.ps1
@@ -13,11 +13,8 @@ function Install-Poetry {
 
         if ($Config.InstallPoetry -eq $true) {
             $installerUrl = 'https://install.python-poetry.org'
-            $installerPath = Join-Path $env:TEMP 'install-poetry.py'
-
-            try {
-                Invoke-LabWebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
-
+            Invoke-LabDownload -Uri $installerUrl -Prefix 'install-poetry' -Extension '.py' -Action {
+                param($installerPath)
                 $args = @()
                 if ($Config.PoetryVersion) {
                     $args += '--version'
@@ -25,9 +22,6 @@ function Install-Poetry {
                 }
                 Write-CustomLog 'Executing Poetry installer...'
                 python $installerPath @args
-            }
-            finally {
-                Remove-Item $installerPath -Force
             }
         }
         else {

--- a/runner_scripts/0205_Install-Sysinternals.ps1
+++ b/runner_scripts/0205_Install-Sysinternals.ps1
@@ -17,18 +17,11 @@ Invoke-LabStep -Config $Config -Body {
     }
 
     $zipUrl  = 'https://download.sysinternals.com/files/SysinternalsSuite.zip'
-    $zipPath = Join-Path $env:TEMP ("SysinternalsSuite_{0}.zip" -f (New-Guid))
-    Write-CustomLog "Downloading Sysinternals Suite from $zipUrl to $zipPath"
-    try {
-        Invoke-LabWebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
-    } catch {
-        Write-CustomLog "Error: Failed to download Sysinternals Suite from $zipUrl. $_"
-        throw
+    Invoke-LabDownload -Uri $zipUrl -Prefix 'SysinternalsSuite' -Extension '.zip' -Action {
+        param($zipPath)
+        Write-CustomLog "Extracting to $destDir"
+        Expand-Archive -Path $zipPath -DestinationPath $destDir -Force
     }
-
-    Write-CustomLog "Extracting to $destDir"
-    Expand-Archive -Path $zipPath -DestinationPath $destDir -Force
-    Remove-Item $zipPath -Force
 
     $psInfo = Join-Path $destDir 'PsInfo.exe'
     if (Test-Path $psInfo) {

--- a/runner_scripts/0206_Install-Python.ps1
+++ b/runner_scripts/0206_Install-Python.ps1
@@ -11,10 +11,10 @@ function Install-Python {
         if ($Config.InstallPython -eq $true) {
             if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
                 $url = 'https://www.python.org/ftp/python/3.12.3/python-3.12.3-amd64.exe'
-                $installer = Join-Path $env:TEMP 'python-installer.exe'
-                Invoke-LabWebRequest -Uri $url -OutFile $installer -UseBasicParsing
-                Start-Process -FilePath $installer -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait
-                Remove-Item $installer -Force
+                Invoke-LabDownload -Uri $url -Prefix 'python-installer' -Extension '.exe' -Action {
+                    param($installer)
+                    Start-Process -FilePath $installer -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait
+                }
             } else {
                 Write-CustomLog 'Python already installed.'
             }

--- a/runner_scripts/0207_Install-Git.ps1
+++ b/runner_scripts/0207_Install-Git.ps1
@@ -11,10 +11,10 @@ function Install-Git {
         if ($Config.InstallGit -eq $true) {
             if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
                 $url = 'https://github.com/git-for-windows/git/releases/download/v2.48.1.windows.1/Git-2.48.1-64-bit.exe'
-                $installer = Join-Path $env:TEMP 'git-installer.exe'
-                Invoke-LabWebRequest -Uri $url -OutFile $installer -UseBasicParsing
-                Start-Process -FilePath $installer -ArgumentList '/SILENT' -Wait
-                Remove-Item $installer -Force
+                Invoke-LabDownload -Uri $url -Prefix 'git-installer' -Extension '.exe' -Action {
+                    param($installer)
+                    Start-Process -FilePath $installer -ArgumentList '/SILENT' -Wait
+                }
             } else {
                 Write-CustomLog 'Git already installed.'
             }

--- a/runner_scripts/0208_Install-DockerDesktop.ps1
+++ b/runner_scripts/0208_Install-DockerDesktop.ps1
@@ -11,10 +11,10 @@ function Install-DockerDesktop {
         if ($Config.InstallDockerDesktop -eq $true) {
             if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
                 $url = 'https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe'
-                $installer = Join-Path $env:TEMP 'docker-desktop-installer.exe'
-                Invoke-LabWebRequest -Uri $url -OutFile $installer -UseBasicParsing
-                Start-Process -FilePath $installer -ArgumentList 'install --quiet' -Wait
-                Remove-Item $installer -Force
+                Invoke-LabDownload -Uri $url -Prefix 'docker-desktop-installer' -Extension '.exe' -Action {
+                    param($installer)
+                    Start-Process -FilePath $installer -ArgumentList 'install --quiet' -Wait
+                }
             } else {
                 Write-CustomLog 'Docker Desktop already installed.'
             }

--- a/runner_scripts/0209_Install-7Zip.ps1
+++ b/runner_scripts/0209_Install-7Zip.ps1
@@ -11,10 +11,10 @@ function Install-7Zip {
         if ($Config.Install7Zip -eq $true) {
             if (-not (Get-Command 7z -ErrorAction SilentlyContinue)) {
                 $url = 'https://www.7-zip.org/a/7z2301-x64.exe'
-                $installer = Join-Path $env:TEMP '7zip.exe'
-                Invoke-LabWebRequest -Uri $url -OutFile $installer -UseBasicParsing
-                Start-Process -FilePath $installer -ArgumentList '/S' -Wait
-                Remove-Item $installer -Force
+                Invoke-LabDownload -Uri $url -Prefix '7zip' -Extension '.exe' -Action {
+                    param($installer)
+                    Start-Process -FilePath $installer -ArgumentList '/S' -Wait
+                }
             } else {
                 Write-CustomLog '7-Zip already installed.'
             }

--- a/runner_scripts/0210_Install-VSCode.ps1
+++ b/runner_scripts/0210_Install-VSCode.ps1
@@ -11,10 +11,10 @@ function Install-VSCode {
         if ($Config.InstallVSCode -eq $true) {
             if (-not (Get-Command code -ErrorAction SilentlyContinue)) {
                 $url = 'https://update.code.visualstudio.com/latest/win32-x64-user/stable'
-                $installer = Join-Path $env:TEMP 'vscode.exe'
-                Invoke-LabWebRequest -Uri $url -OutFile $installer -UseBasicParsing
-                Start-Process -FilePath $installer -ArgumentList '/verysilent /suppressmsgboxes /mergetasks=!runcode' -Wait
-                Remove-Item $installer -Force
+                Invoke-LabDownload -Uri $url -Prefix 'vscode' -Extension '.exe' -Action {
+                    param($installer)
+                    Start-Process -FilePath $installer -ArgumentList '/verysilent /suppressmsgboxes /mergetasks=!runcode' -Wait
+                }
             } else {
                 Write-CustomLog 'VS Code already installed.'
             }

--- a/runner_scripts/0211_Install-VSBuildTools.ps1
+++ b/runner_scripts/0211_Install-VSBuildTools.ps1
@@ -11,10 +11,10 @@ function Install-VSBuildTools {
         if ($Config.InstallVSBuildTools -eq $true) {
             if (-not (Get-Command vswhere -ErrorAction SilentlyContinue)) {
                 $url = 'https://aka.ms/vs/17/release/vs_BuildTools.exe'
-                $installer = Join-Path $env:TEMP 'vs_buildtools.exe'
-                Invoke-LabWebRequest -Uri $url -OutFile $installer -UseBasicParsing
-                Start-Process -FilePath $installer -ArgumentList '--quiet --wait --norestart --nocache --installPath C:\BuildTools' -Wait
-                Remove-Item $installer -Force
+                Invoke-LabDownload -Uri $url -Prefix 'vs_buildtools' -Extension '.exe' -Action {
+                    param($installer)
+                    Start-Process -FilePath $installer -ArgumentList '--quiet --wait --norestart --nocache --installPath C:\BuildTools' -Wait
+                }
             } else {
                 Write-CustomLog 'VS Build Tools already installed.'
             }

--- a/runner_scripts/0212_Install-AzureCLI.ps1
+++ b/runner_scripts/0212_Install-AzureCLI.ps1
@@ -11,10 +11,10 @@ function Install-AzureCLI {
         if ($Config.InstallAzureCLI -eq $true) {
             if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
                 $url = 'https://aka.ms/installazurecliwindows'
-                $msi = Join-Path $env:TEMP 'azure-cli.msi'
-                Invoke-LabWebRequest -Uri $url -OutFile $msi -UseBasicParsing
-                Start-Process msiexec.exe -ArgumentList "/i `"$msi`" /quiet /norestart" -Wait -NoNewWindow
-                Remove-Item $msi -Force
+                Invoke-LabDownload -Uri $url -Prefix 'azure-cli' -Extension '.msi' -Action {
+                    param($msi)
+                    Start-Process msiexec.exe -ArgumentList "/i `"$msi`" /quiet /norestart" -Wait -NoNewWindow
+                }
             } else {
                 Write-CustomLog 'Azure CLI already installed.'
             }

--- a/runner_scripts/0213_Install-AWSCLI.ps1
+++ b/runner_scripts/0213_Install-AWSCLI.ps1
@@ -11,10 +11,10 @@ function Install-AWSCLI {
         if ($Config.InstallAWSCLI -eq $true) {
             if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
                 $url = 'https://awscli.amazonaws.com/AWSCLIV2.msi'
-                $msi = Join-Path $env:TEMP 'awscli.msi'
-                Invoke-LabWebRequest -Uri $url -OutFile $msi -UseBasicParsing
-                Start-Process msiexec.exe -ArgumentList "/i `"$msi`" /quiet /norestart" -Wait -NoNewWindow
-                Remove-Item $msi -Force
+                Invoke-LabDownload -Uri $url -Prefix 'awscli' -Extension '.msi' -Action {
+                    param($msi)
+                    Start-Process msiexec.exe -ArgumentList "/i `"$msi`" /quiet /norestart" -Wait -NoNewWindow
+                }
             } else {
                 Write-CustomLog 'AWS CLI already installed.'
             }

--- a/runner_scripts/0214_Install-Packer.ps1
+++ b/runner_scripts/0214_Install-Packer.ps1
@@ -11,12 +11,12 @@ function Install-Packer {
         if ($Config.InstallPacker -eq $true) {
             if (-not (Get-Command packer -ErrorAction SilentlyContinue)) {
                 $url = 'https://releases.hashicorp.com/packer/1.10.2/packer_1.10.2_windows_amd64.zip'
-                $zip = Join-Path $env:TEMP 'packer.zip'
                 $dest = Join-Path $env:ProgramFiles 'Packer'
-                Invoke-LabWebRequest -Uri $url -OutFile $zip -UseBasicParsing
-                if (-not (Test-Path $dest)) { New-Item -ItemType Directory -Path $dest -Force | Out-Null }
-                Expand-Archive -Path $zip -DestinationPath $dest -Force
-                Remove-Item $zip -Force
+                Invoke-LabDownload -Uri $url -Prefix 'packer' -Extension '.zip' -Action {
+                    param($zip)
+                    if (-not (Test-Path $dest)) { New-Item -ItemType Directory -Path $dest -Force | Out-Null }
+                    Expand-Archive -Path $zip -DestinationPath $dest -Force
+                }
             } else {
                 Write-CustomLog 'Packer already installed.'
             }

--- a/tests/Invoke-LabDownload.Tests.ps1
+++ b/tests/Invoke-LabDownload.Tests.ps1
@@ -1,0 +1,18 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psd1') -Force
+
+Describe 'Invoke-LabDownload' {
+    BeforeEach {
+        Mock Invoke-LabWebRequest {}
+        Mock Start-Process {}
+        Mock Remove-Item {}
+    }
+
+    It 'downloads and executes action with cleanup' {
+        Invoke-LabDownload -Uri 'http://example.com/file.exe' -Prefix 'test' -Action { param($p) Start-Process $p -Wait }
+        Should -Invoke -CommandName Invoke-LabWebRequest -Times 1
+        Should -Invoke -CommandName Start-Process -Times 1
+        Should -Invoke -CommandName Remove-Item -Times 1
+    }
+}


### PR DESCRIPTION
## Summary
- add Invoke-LabDownload helper for installers
- simplify installer scripts to use the helper
- cover new helper with tests

## Testing
- `Invoke-Pester` *(fails: pwsh not installed)*
- `pytest -q` *(fails: missing Typer module)*

------
https://chatgpt.com/codex/tasks/task_e_68499d2cca3483318662b3f24e724334