### PR TITLE
Fix Windows validate job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_wrapper: false
       - name: Init and validate
         shell: pwsh
         working-directory: example-infrastructure


### PR DESCRIPTION
## Summary
- disable the OpenTofu wrapper on Windows to allow PowerShell
  validation

## Testing
- `poetry run pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a0074538833198cb63e393b22827