### PR TITLE
Fix Cleanup-Files test on Windows

### DIFF
--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -1,7 +1,12 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+$helperPath = Join-Path $PSScriptRoot 'helpers' 'Get-ScriptAst.ps1'
+if (-not (Test-Path $helperPath)) {
+    throw "Required helper script is missing: $helperPath"
+}
 Describe 'Cleanup-Files script' {
     BeforeAll {
+        . $helperPath
         $script:scriptPath = Get-RunnerScriptPath '0000_Cleanup-Files.ps1'
         $script:ast = Get-ScriptAst $script:scriptPath
     }


### PR DESCRIPTION
## Summary
- ensure `Get-ScriptAst` helper is available during `Cleanup-Files.Tests.ps1`

## Testing
- `Invoke-Pester -CI -Script tests/Cleanup-Files.Tests.ps1` *(fails: ArgumentException)*

------
https://chatgpt.com/codex/tasks/task_e_68499e89061c8331b282783b6ae73db0