### PR TITLE
Add profile setup script

### DIFF
--- a/config_files/default-config.json
+++ b/config_files/default-config.json
@@ -36,6 +36,7 @@
   "InstallAWSCLI": false,
   "InstallPacker": false,
   "InstallChocolatey": false,
+  "SetupLabProfile": false,
   "CertificateAuthority": {
     "CommonName": "default-lab-RootCA",
     "ValidityYears": 5

--- a/config_files/full-config.json
+++ b/config_files/full-config.json
@@ -43,6 +43,7 @@
   "InstallAWSCLI": true,
   "InstallPacker": true,
   "InstallChocolatey": true,
+  "SetupLabProfile": true,
   "InstallSysinternals": true,
   "SysinternalsPath": "C:\\Sysinternals",
 

--- a/runner_scripts/0216_Set-LabProfile.ps1
+++ b/runner_scripts/0216_Set-LabProfile.ps1
@@ -1,0 +1,34 @@
+Param([object]$Config)
+Import-Module "$PSScriptRoot/../lab_utils/LabRunner/LabRunner.psd1"
+
+Write-CustomLog "Starting $MyInvocation.MyCommand"
+
+function Set-LabProfile {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param([object]$Config)
+
+    Invoke-LabStep -Config $Config -Body {
+        param($Config)
+        Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
+        if ($Config.SetupLabProfile -eq $true) {
+            $profilePath = $PROFILE.CurrentUserAllHosts
+            $profileDir  = Split-Path $profilePath
+            if (-not (Test-Path $profileDir)) {
+                New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+            }
+            $repoRoot = Resolve-Path -Path (Join-Path $PSScriptRoot '..')
+            $content = @"
+# OpenTofu Lab Automation profile
+`$env:PATH = \"$repoRoot;`$env:PATH\"
+`$env:PSModulePath = \"$repoRoot\lab_utils;`$env:PSModulePath\"
+"@
+            Set-Content -Path $profilePath -Value $content -Encoding utf8
+            Write-CustomLog "Profile written to $profilePath"
+        } else {
+            Write-CustomLog 'SetupLabProfile flag is disabled. Skipping profile creation.'
+        }
+    }
+    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
+}
+
+if ($MyInvocation.InvocationName -ne '.') { Set-LabProfile @PSBoundParameters }

--- a/tests/Set-LabProfile.Tests.ps1
+++ b/tests/Set-LabProfile.Tests.ps1
@@ -1,0 +1,19 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
+Describe '0216_Set-LabProfile' {
+    BeforeAll {
+        $script:ScriptPath = Get-RunnerScriptPath '0216_Set-LabProfile.ps1'
+    }
+    It 'writes profile when flag enabled' {
+        $cfg = [pscustomobject]@{ SetupLabProfile = $true }
+        Mock Set-Content {}
+        & $script:ScriptPath -Config $cfg
+        Should -Invoke -CommandName Set-Content -Times 1
+    }
+    It 'skips when flag disabled' {
+        $cfg = [pscustomobject]@{ SetupLabProfile = $false }
+        Mock Set-Content {}
+        & $script:ScriptPath -Config $cfg
+        Should -Invoke -CommandName Set-Content -Times 0
+    }
+}


### PR DESCRIPTION
## Summary
- allow setting up a user PowerShell profile for lab commands
- cover new script with Pester tests
- wire profile flag into default and full configs

## Testing
- `Invoke-Pester -Path tests/Set-LabProfile.Tests.ps1`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68499f0240188331858e20582b116538