### PR TITLE
Fix Script Analyzer path list

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -30,8 +30,8 @@ runs:
           'PSReviewUnusedParameter',
           'PSUseDeclaredVarsMoreThanAssignments'
         )
-        $files = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1,*.psd1 -File | ForEach-Object { $_.FullName }
-        $results = Invoke-ScriptAnalyzer -Path $files -Severity Error,Warning -ExcludeRule $rulesToExclude
+        $files = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1,*.psd1 -File | Select-Object -ExpandProperty FullName
+        $results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -ExcludeRule $rulesToExclude
         $results | Format-Table
         if ($results | Where-Object Severity -eq 'Error') {
           Write-Error 'ScriptAnalyzer errors detected'


### PR DESCRIPTION
## Summary
- fix file list creation in lint action so ScriptAnalyzer accepts array input

## Testing
- `pytest`
- `Invoke-Pester` *(fails: cannot find `Get-Service` cmdlet, prompts for input)*

------
https://chatgpt.com/codex/tasks/task_e_68499fe4670c83318c7dfd726b71a142