### PR TITLE
Add Custom ScriptAnalyzer step

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -37,6 +37,10 @@ runs:
           Write-Error 'ScriptAnalyzer errors detected'
           exit 1
         }
+    - name: Run Custom Script Analyzer
+      shell: pwsh
+      run: |
+        ./scripts/CustomLint.ps1
     - name: Run ruff
       shell: bash
       run: ruff check .

--- a/.scriptanalyzersettings.psd1
+++ b/.scriptanalyzersettings.psd1
@@ -1,0 +1,11 @@
+@{
+    Rules = @{
+        IncludeRules = @(
+            'PSAvoidGlobalVars'
+        )
+        ExcludeRules = @(
+            'PSUseShouldProcessForStateChangingFunctions',
+            'PSAvoidUsingWriteHost'
+        )
+    }
+}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ The lint workflow installs the GitHub Copilot CLI and runs `github-copilot-cli s
 after linting. The command scans the repository and provides additional
 improvement ideas directly in the workflow logs.
 
+`scripts/CustomLint.ps1` performs an additional pass with project specific
+rules defined in `.scriptanalyzersettings.psd1`. Run it locally to check your
+PowerShell files before pushing:
+
+```powershell
+pwsh -File scripts/CustomLint.ps1 -Target ./runner_scripts
+```
+
+The script exits with code `1` when Script Analyzer reports any errors.
+
 The optional [Copilot Auto Fix workflow](docs/copilot-auto-fix.md) can comment
 on issues with suggested patches. It requires a GitHub CLI token with the
 `copilot` scope stored as the repository secret `COPILOT_OAUTH_TOKEN`.

--- a/scripts/CustomLint.ps1
+++ b/scripts/CustomLint.ps1
@@ -1,0 +1,22 @@
+[CmdletBinding()]
+param(
+    [string]$Target = '.',
+    [string]$SettingsPath = (Join-Path $PSScriptRoot '..' '.scriptanalyzersettings.psd1')
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $SettingsPath)) {
+    throw "Settings file not found: $SettingsPath"
+}
+
+$files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
+    ForEach-Object { $_.FullName }
+
+$results = Invoke-ScriptAnalyzer -Path $files -Severity Error,Warning -Settings $SettingsPath
+$results | Format-Table
+
+if ($results | Where-Object Severity -eq 'Error') {
+    Write-Error 'ScriptAnalyzer errors detected'
+    exit 1
+}

--- a/tests/CustomLint.Tests.ps1
+++ b/tests/CustomLint.Tests.ps1
@@ -1,0 +1,25 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+
+Describe 'CustomLint.ps1' {
+    BeforeAll {
+        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'scripts' 'CustomLint.ps1'
+    }
+
+    It 'parses without errors' {
+        $errs = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($script:ScriptPath, [ref]$null, [ref]$errs) | Out-Null
+        ($errs ? $errs.Count : 0) | Should -Be 0
+    }
+
+    It 'returns exit code 1 when analyzer reports errors' {
+        Mock Invoke-ScriptAnalyzer { [pscustomobject]@{ Severity = 'Error' } }
+        & $script:ScriptPath -Target $PSScriptRoot > $null
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It 'returns exit code 0 when no errors' {
+        Mock Invoke-ScriptAnalyzer { @() }
+        & $script:ScriptPath -Target $PSScriptRoot > $null
+        $LASTEXITCODE | Should -Be 0
+    }
+}


### PR DESCRIPTION
## Summary
- add project settings for Script Analyzer
- create `CustomLint.ps1` helper
- run the helper in the lint action
- document the new script in README
- test the helper with Pester

## Testing
- `pytest -q`
- `Invoke-Pester -CI` *(fails: `CommandNotFoundException: Could not find Command Get-Service`)*

------
https://chatgpt.com/codex/tasks/task_e_6849a12e5a6c8331a0bf9e51727439b7