### PR TITLE
Fix helper sourcing in Cleanup-Files tests

### DIFF
--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -1,11 +1,11 @@
 . (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
-$helperPath = Join-Path $PSScriptRoot 'helpers' 'Get-ScriptAst.ps1'
-if (-not (Test-Path $helperPath)) {
-    throw "Required helper script is missing: $helperPath"
-}
 Describe 'Cleanup-Files script' {
     BeforeAll {
+        $helperPath = Join-Path $PSScriptRoot 'helpers' 'Get-ScriptAst.ps1'
+        if (-not (Test-Path $helperPath)) {
+            throw "Required helper script is missing: $helperPath"
+        }
         . $helperPath
         $script:scriptPath = Get-RunnerScriptPath '0000_Cleanup-Files.ps1'
         $script:ast = Get-ScriptAst $script:scriptPath


### PR DESCRIPTION
## Summary
- ensure the helper script path is resolved within the `BeforeAll` block so Pester can dot-source it properly

## Testing
- `Invoke-Pester -Script tests/Cleanup-Files.Tests.ps1 -Output Detailed` *(fails: 2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849a2adbf108331828a9ff46696a5f3