### PR TITLE
Parse Hyper-V provider version from config

### DIFF
--- a/config_files/default-config.json
+++ b/config_files/default-config.json
@@ -54,6 +54,7 @@
     "CacertPath": "",
     "CertPath": "",
     "KeyPath": "",
+    "ProviderVersion": "1.2.1",
     "ScriptPath": "C:/Temp/tofu_%RAND%.cmd",
     "Timeout": "30s"
   },

--- a/config_files/full-config.json
+++ b/config_files/full-config.json
@@ -64,6 +64,7 @@
     "CacertPath": "",
     "CertPath": "",
     "KeyPath": "",
+    "ProviderVersion": "1.2.1",
     "ScriptPath": "C:/Temp/tofu_%RAND%.cmd",
     "Timeout": "30s"
   },

--- a/docs/hyperv-provider.md
+++ b/docs/hyperv-provider.md
@@ -26,3 +26,15 @@ Each argument can instead be sourced from environment variables such as `HYPERV_
 
 The `runner_scripts/0010_Prepare-HyperVHost.ps1` script installs the provider and converts the generated certificates into PEM files so that `providers.tf` works without additional steps.
 
+## Provider version
+
+Specify the Hyper-V provider version in your lab configuration under the `HyperV` section:
+
+```json
+"HyperV": {
+  "ProviderVersion": "1.2.1"
+}
+```
+
+If omitted, the scripts fall back to `1.2.1`.
+

--- a/py/labctl/config_files/default-config.json
+++ b/py/labctl/config_files/default-config.json
@@ -42,6 +42,7 @@
     "CacertPath": "",
     "CertPath": "",
     "KeyPath": "",
+    "ProviderVersion": "1.2.1",
     "ScriptPath": "C:/Temp/tofu_%RAND%.cmd",
     "Timeout": "30s"
   },

--- a/py/labctl/config_files/full-config.json
+++ b/py/labctl/config_files/full-config.json
@@ -49,6 +49,7 @@
     "CacertPath": "",
     "CertPath": "",
     "KeyPath": "",
+    "ProviderVersion": "1.2.1",
     "ScriptPath": "C:/Temp/tofu_%RAND%.cmd",
     "Timeout": "30s"
   },

--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -83,28 +83,16 @@ if (-not (Get-Command Get-HyperVProviderVersion -ErrorAction SilentlyContinue)) 
 function Get-HyperVProviderVersion {
     [CmdletBinding()]
     param(
-        [string]$MainTfPath
+        [pscustomobject]$Config
     )
 
     $defaultVersion = '1.2.1'
-    $searchPaths = @()
 
-    if ($MainTfPath) { $searchPaths += $MainTfPath }
-    $searchPaths += Join-Path $PSScriptRoot '..\example-infrastructure\main.tf'
-    $searchPaths += Join-Path $PSScriptRoot '..\main.tf'
-
-    foreach ($path in $searchPaths) {
-        if (Test-Path $path) {
-            $content = Get-Content -Path $path -Raw
-            if ($content -match 'hyperv\s*=\s*\{[^\}]*?version\s*=\s*"([^"]+)"') {
-                return $matches[1]
-            }
-            Write-Warning "Failed to parse hyperv provider version from $path"
-            return $defaultVersion
-        }
+    if ($Config -and $Config.HyperV -and $Config.HyperV.ProviderVersion) {
+        return $Config.HyperV.ProviderVersion
     }
 
-    Write-Warning "main.tf not found. Using default Hyper-V provider version $defaultVersion"
+    Write-Warning "Hyper-V provider version not specified. Using default $defaultVersion"
     return $defaultVersion
 }
 }
@@ -427,4 +415,5 @@ You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
     Write-CustomLog "PrepareHyperVHost flag is disabled. Skipping Hyper-V host preparation."
 }
     Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
+}
 }

--- a/tests/Get-HyperVProviderVersion.Tests.ps1
+++ b/tests/Get-HyperVProviderVersion.Tests.ps1
@@ -2,35 +2,16 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 
 Describe 'Get-HyperVProviderVersion'  {
-    It 'parses version from main.tf' {
+    It 'uses version from config' {
         $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
-        $tf = [System.IO.Path]::ChangeExtension(
-            [System.IO.Path]::Combine(
-                [System.IO.Path]::GetTempPath(),
-                ([guid]::NewGuid()).ToString()),
-            '.tf')
-        @'
-terraform {
-  required_providers {
-    hyperv = {
-      source  = "taliesins/hyperv"
-      version = "9.9.9"
-    }
-  }
-}
-'@ | Set-Content -Path $tf
-        try {
-            Get-HyperVProviderVersion -MainTfPath $tf | Should -Be '9.9.9'
-        } finally {
-            Remove-Item $tf -ErrorAction SilentlyContinue
-        }
+        $cfg = [pscustomobject]@{ HyperV = @{ ProviderVersion = '9.9.9' } }
+        Get-HyperVProviderVersion -Config $cfg | Should -Be '9.9.9'
     }
 
-    It 'falls back to repository paths when missing' {
+    It 'falls back to default when not specified' {
         $scriptPath = Get-RunnerScriptPath '0010_Prepare-HyperVProvider.ps1'
         . $scriptPath
-        $tf = Join-Path $env:TEMP ([guid]::NewGuid()).ToString() + '.tf'
-        Get-HyperVProviderVersion -MainTfPath $tf | Should -Be '1.2.1'
+        Get-HyperVProviderVersion -Config ([pscustomobject]@{}) | Should -Be '1.2.1'
     }
 }


### PR DESCRIPTION
## Summary
- parse Hyper-V provider version from `HyperV.ProviderVersion` field
- add `ProviderVersion` to example config files
- document provider version setting
- update `Get-HyperVProviderVersion` tests
- fix missing closing brace in script

## Testing
- `pytest -q`
- *Pester tests could not run: `pwsh` not found*


------
https://chatgpt.com/codex/tasks/task_e_6849a30462e08331a3082c869fa704fa