### PR TITLE
Fix Initialize-OpenTofu installer exception

### DIFF
--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -152,13 +152,11 @@ if (-not $tofuCmd) {
         if ($installerAvailable -and (Get-Command Invoke-OpenTofuInstaller -ErrorAction SilentlyContinue)) {
             Invoke-OpenTofuInstaller -CosignPath $cosign -OpenTofuVersion $version
         } else {
-            Write-Error "Cannot install OpenTofu because the installer script '$installScript' is missing."
-            exit 1
+            throw "Cannot install OpenTofu because the installer script '$installScript' is missing."
         }
         $tofuCmd = Get-Command tofu -ErrorAction SilentlyContinue
         if (-not $tofuCmd) {
-            Write-Error "Tofu still not found after installation. Please ensure OpenTofu is installed and in PATH."
-            exit 1
+            throw "Tofu still not found after installation. Please ensure OpenTofu is installed and in PATH."
         }
     }
 }

--- a/runner_scripts/0009_Initialize-OpenTofu.ps1
+++ b/runner_scripts/0009_Initialize-OpenTofu.ps1
@@ -152,7 +152,7 @@ if (-not $tofuCmd) {
         if ($installerAvailable -and (Get-Command Invoke-OpenTofuInstaller -ErrorAction SilentlyContinue)) {
             Invoke-OpenTofuInstaller -CosignPath $cosign -OpenTofuVersion $version
         } else {
-            throw "Cannot install OpenTofu because the installer script '$installScript' is missing."
+            throw [System.InvalidOperationException]::new("Cannot install OpenTofu because the installer script '$installScript' is missing.")
         }
         $tofuCmd = Get-Command tofu -ErrorAction SilentlyContinue
         if (-not $tofuCmd) {


### PR DESCRIPTION
## Summary
- make Initialize-OpenTofu throw when installer is missing

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script tests/Initialize-OpenTofu.Tests.ps1 -PassThru"` *(fails: Could not find Command Invoke-OpenTofuInstaller)*

------
https://chatgpt.com/codex/tasks/task_e_6849a368c8b48331bccbd79d196069e7