### PR TITLE
Fix missing export for Invoke-LabDownload

### DIFF
--- a/lab_utils/LabRunner/LabRunner.psm1
+++ b/lab_utils/LabRunner/LabRunner.psm1
@@ -70,4 +70,4 @@ function Invoke-LabDownload {
     }
 }
 
-Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Read-LoggedInput, Get-Platform, Invoke-LabWebRequest, Invoke-LabNpm
+Export-ModuleMember -Function Invoke-LabStep, Invoke-LabDownload, Write-CustomLog, Read-LoggedInput, Get-Platform, Invoke-LabWebRequest, Invoke-LabNpm


### PR DESCRIPTION
## Summary
- export `Invoke-LabDownload` from LabRunner module

## Testing
- `pytest`
- `Invoke-Pester` *(fails: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849a370978c8331a3cc4acd89c139c4