### PR TITLE
Fix missing brace in Hyper-V provider script

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -428,3 +428,4 @@ You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
 }
     Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }
+}


### PR DESCRIPTION
## Summary
- close `if ($MyInvocation.InvocationName -ne '.')` in `0010_Prepare-HyperVProvider.ps1`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a3b5bdb48331a20e2b49ca15c232