### PR TITLE
Fix temp dir creation conflict in Runner tests

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'runner.ps1 script selection'  {
                 Set-Content -Path (Join-Path $utils 'Logger.ps1')
 
             $labs = Join-Path $root 'lab_utils'
-            New-Item -ItemType Directory -Path $labs | Out-Null
+            New-Item -ItemType Directory -Path $labs -Force | Out-Null
             'function Get-LabConfig { param([string]$Path) Get-Content -Raw $Path | ConvertFrom-Json }' |
                 Set-Content -Path (Join-Path $labs 'Get-LabConfig.ps1')
             'function Format-Config { param($Config) $Config | ConvertTo-Json -Depth 5 }' |


### PR DESCRIPTION
## Summary
- ensure lab_utils directory creation uses `-Force`
- helps `New-RunnerTestEnv` avoid directory existence errors

## Testing
- `pytest`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849a3bece908331bb70d318b5087a80