### PR TITLE
Fix Windows test setup path and script parsing

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -426,5 +426,6 @@ You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
 } else {
     Write-CustomLog "PrepareHyperVHost flag is disabled. Skipping Hyper-V host preparation."
 }
-    Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
+Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
+}
 }

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -40,13 +40,13 @@ Describe 'runner.ps1 script selection'  {
             $rsDir = Join-Path $root 'runner_scripts'
             New-Item -ItemType Directory -Path $rsDir | Out-Null
 
-            $utils = Join-Path $root 'lab_utils' 'LabRunner'
+            $labs = Join-Path $root 'lab_utils'
+            New-Item -ItemType Directory -Path $labs -Force | Out-Null
+
+            $utils = Join-Path $labs 'LabRunner'
             New-Item -ItemType Directory -Path $utils -Force | Out-Null
             'function Write-CustomLog { param([string]$Message,[string]$Level) }' |
                 Set-Content -Path (Join-Path $utils 'Logger.ps1')
-
-            $labs = Join-Path $root 'lab_utils'
-            New-Item -ItemType Directory -Path $labs | Out-Null
             'function Get-LabConfig { param([string]$Path) Get-Content -Raw $Path | ConvertFrom-Json }' |
                 Set-Content -Path (Join-Path $labs 'Get-LabConfig.ps1')
             'function Format-Config { param($Config) $Config | ConvertTo-Json -Depth 5 }' |


### PR DESCRIPTION
## Summary
- correct lab_utils directory creation in `Runner.Tests.ps1`
- close conditional block in `0010_Prepare-HyperVProvider.ps1`

## Testing
- `Invoke-Pester` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a3fd765883319a12a946f8f9934e