### PR TITLE
Fix closing brace in Install-NodeCore script

### DIFF
--- a/runner_scripts/0201_Install-NodeCore.ps1
+++ b/runner_scripts/0201_Install-NodeCore.ps1
@@ -74,7 +74,7 @@ if ($nodeDeps.InstallNode) {
 } else {
     Write-CustomLog "InstallNode flag is disabled. Skipping Node.js installation."
 }
-}
-}
+    }
     Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
+}
 if ($MyInvocation.InvocationName -ne '.') { Install-NodeCore @PSBoundParameters }


### PR DESCRIPTION
## Summary
- fix closing brace placement in `0201_Install-NodeCore.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a47263248331a5c0efc8439860cd