### PR TITLE
Fix Read-Host mock for secure input

### DIFF
--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -61,7 +61,7 @@ Describe 'Read-LoggedInput' {
     It 'handles secure strings without logging value' {
         Mock Write-CustomLog {}
         $sec = New-Object System.Security.SecureString
-        function global:Read-Host { param($Prompt,$AsSecureString) $sec }
+        function global:Read-Host { param($Prompt, [switch]$AsSecureString) $sec }
         Read-LoggedInput -Prompt 'Secret' -AsSecureString | Should -Be $sec
         Should -Invoke -CommandName Write-CustomLog -Times 1 -ParameterFilter { $Message -eq 'Secret (secure input)' }
     }


### PR DESCRIPTION
## Summary
- update Logger.Tests to mock `Read-Host` with `[switch]$AsSecureString`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/Logger.Tests.ps1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a5a3f93883318a76acac318f118c