### PR TITLE
Fix secure string mock in Logger test

### DIFF
--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -60,9 +60,9 @@ Describe 'Read-LoggedInput' {
     }
     It 'handles secure strings without logging value' {
         Mock Write-CustomLog {}
-        $sec = New-Object System.Security.SecureString
-        function global:Read-Host { param($Prompt,$AsSecureString) $sec }
-        Read-LoggedInput -Prompt 'Secret' -AsSecureString | Should -Be $sec
+        $sec = [System.Security.SecureString]::new()
+        function global:Read-Host { param([string]$Prompt,[System.Security.SecureString]$AsSecureString) $AsSecureString }
+        Read-LoggedInput -Prompt 'Secret' -AsSecureString $sec | Should -Be $sec
         Should -Invoke -CommandName Write-CustomLog -Times 1 -ParameterFilter { $Message -eq 'Secret (secure input)' }
     }
 }

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -61,8 +61,8 @@ Describe 'Read-LoggedInput' {
     It 'handles secure strings without logging value' {
         Mock Write-CustomLog {}
         $sec = [System.Security.SecureString]::new()
-        function global:Read-Host { param([string]$Prompt,[System.Security.SecureString]$AsSecureString) $AsSecureString }
-        Read-LoggedInput -Prompt 'Secret' -AsSecureString $sec | Should -Be $sec
+        function global:Read-Host { param([string]$Prompt, [switch]$AsSecureString) if ($AsSecureString) { return $sec } 'val' }
+        Read-LoggedInput -Prompt 'Secret' -AsSecureString | Should -Be $sec
         Should -Invoke -CommandName Write-CustomLog -Times 1 -ParameterFilter { $Message -eq 'Secret (secure input)' }
     }
 }


### PR DESCRIPTION
## Summary
- adjust `Read-LoggedInput` test to pass a secure string value
- reran the relevant `Invoke-Pester` test script

## Testing
- `Invoke-Pester tests/Logger.Tests.ps1` *(fails: ParameterBindingException)*

------
https://chatgpt.com/codex/tasks/task_e_6849a48361a883319147e522e39735d9