### PR TITLE
Fix node and expand tests

### DIFF
--- a/tests/Expand-All.Tests.ps1
+++ b/tests/Expand-All.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Expand-All' {
         New-Item -ItemType File -Path $zipPath | Out-Null
 
         Mock Expand-Archive {}
-        Mock Read-LoggedInput { 'y' }
+        Mock Read-LoggedInput { 'y' } -ModuleName Expand-All
 
         Expand-All -ZipFile $zipPath
 
@@ -41,7 +41,7 @@ Describe 'Expand-All' {
         $zip2 = Join-Path $subDir 'b.zip'
 
         Mock Expand-Archive {}
-        Mock Read-LoggedInput { 'y' }
+        Mock Read-LoggedInput { 'y' } -ModuleName Expand-All
         Mock Get-ChildItem {
             @(
                 [pscustomobject]@{ FullName = $zip1; DirectoryName = $temp; BaseName = 'a' },
@@ -67,7 +67,7 @@ Describe 'Expand-All' {
         $zipPath = Join-Path $TestDrive 'missing.zip'
 
         Mock Expand-Archive {}
-        Mock Read-LoggedInput {}
+        Mock Read-LoggedInput {} -ModuleName Expand-All
 
         Expand-All -ZipFile $zipPath
 
@@ -84,7 +84,7 @@ Describe 'Expand-All' {
         New-Item -ItemType File -Path $zipPath | Out-Null
 
         Mock Expand-Archive {}
-        Mock Read-LoggedInput { 'n' }
+        Mock Read-LoggedInput { 'n' } -ModuleName Expand-All
 
         Expand-All -ZipFile $zipPath
 

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Node installation scripts' -Skip:$skipNpm {
     It 'uses Node_Dependencies.Node.InstallerUrl when installing Node' {
         $cfg = @{ Node_Dependencies = @{ InstallNode=$true; Node = @{ InstallerUrl = 'http://example.com/node.msi' } } }
         $core = Get-RunnerScriptPath '0201_Install-NodeCore.ps1'
-        Mock Invoke-LabWebRequest -ModuleName LabSetup {}
+        Mock Invoke-LabWebRequest -ModuleName LabRunner {}
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command { @{Name='node'} } -ParameterFilter { $Name -eq 'node' }
@@ -42,7 +42,7 @@ Describe 'Node installation scripts' -Skip:$skipNpm {
     It 'does nothing when InstallNode is $false' {
         $cfg = @{ Node_Dependencies = @{ InstallNode = $false } }
         $core = Get-RunnerScriptPath '0201_Install-NodeCore.ps1'
-        Mock Invoke-LabWebRequest -ModuleName LabSetup {}
+        Mock Invoke-LabWebRequest -ModuleName LabRunner {}
         Mock Start-Process {}
         Mock Remove-Item {}
         Mock Get-Command {}
@@ -64,7 +64,7 @@ Describe 'Node installation scripts' -Skip:$skipNpm {
             $null = $testArgs
         }
         . $global
-        Mock Invoke-LabNpm -ModuleName LabSetup {}
+        Mock Invoke-LabNpm -ModuleName LabRunner {}
         $WhatIfPreference = $false
         Install-NodeGlobalPackages -Config $cfg
         Should -Invoke -CommandName Invoke-LabNpm -Times 1 -ParameterFilter { ($testArgs -join ' ') -eq 'install -g yarn' }
@@ -81,7 +81,7 @@ Describe 'Node installation scripts' -Skip:$skipNpm {
             $null = $testArgs
         }
         . $global
-        Mock Invoke-LabNpm -ModuleName LabSetup {}
+        Mock Invoke-LabNpm -ModuleName LabRunner {}
         $WhatIfPreference = $false
         Install-NodeGlobalPackages -Config $cfg
         Should -Invoke -CommandName Invoke-LabNpm -Times 1 -ParameterFilter { ($testArgs -join ' ') -eq 'install -g yarn' }
@@ -110,7 +110,7 @@ Describe 'Node installation scripts' -Skip:$skipNpm {
         $global = Get-RunnerScriptPath '0202_Install-NodeGlobalPackages.ps1'
 
         function Invoke-LabNpm { param([Parameter(ValueFromRemainingArguments = $true)][string[]]$testArgs) }
-        Mock Invoke-LabNpm -ModuleName LabSetup {}
+        Mock Invoke-LabNpm -ModuleName LabRunner {}
         . $global
         Install-NodeGlobalPackages -Config @{ Node_Dependencies = @{ InstallYarn=$false; InstallVite=$false; InstallNodemon=$false } } -WhatIf
         Should -Invoke -CommandName Invoke-LabNpm -Times 0
@@ -126,7 +126,7 @@ Describe 'Node installation scripts' -Skip:$skipNpm {
             $null = $testArgs
         }
         $npmPath = Get-RunnerScriptPath '0203_Install-npm.ps1'
-        Mock Invoke-LabNpm -ModuleName LabSetup {}
+        Mock Invoke-LabNpm -ModuleName LabRunner {}
 
 
         . $npmPath -Config $cfg


### PR DESCRIPTION
## Summary
- fix `Read-LoggedInput` mock scope for Expand-All tests
- use LabRunner module when mocking Node installer helpers

## Testing
- `Invoke-Pester -Script tests/Expand-All.Tests.ps1,tests/NodeScripts.Tests.ps1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a47e88c883319a94a47b6ec6cfed