### PR TITLE
Export Invoke-LabDownload

### DIFF
--- a/lab_utils/LabRunner/LabRunner.psm1
+++ b/lab_utils/LabRunner/LabRunner.psm1
@@ -70,4 +70,4 @@ function Invoke-LabDownload {
     }
 }
 
-Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Read-LoggedInput, Get-Platform, Invoke-LabWebRequest, Invoke-LabNpm
+Export-ModuleMember -Function Invoke-LabStep, Write-CustomLog, Read-LoggedInput, Get-Platform, Invoke-LabWebRequest, Invoke-LabNpm, Invoke-LabDownload


### PR DESCRIPTION
## Summary
- export `Invoke-LabDownload` from LabRunner

## Testing
- `Invoke-Pester tests/Invoke-LabDownload.Tests.ps1` *(fails: Cannot bind argument to parameter 'Path' because it is null)*

------
https://chatgpt.com/codex/tasks/task_e_6849a476e624833194d3a7957f753d57