### PR TITLE
Fix missing brace in Prepare-HyperVProvider

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -428,3 +428,5 @@ You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
 }
     Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }
+
+}


### PR DESCRIPTION
## Summary
- close the outer `if` block in `Prepare-HyperVProvider.ps1`

## Testing
- `Invoke-Pester -Output Detailed -Path tests/RunnerScripts.Tests.ps1` *(fails: The term '=' is not recognized as a cmdlet)*

------
https://chatgpt.com/codex/tasks/task_e_6849a451910c833195c1cbe098850954