### PR TITLE
Fix closing brace in HyperV prep script

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -428,3 +428,4 @@ You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
 }
     Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }
+}


### PR DESCRIPTION
## Summary
- fix brace balance in `0010_Prepare-HyperVProvider.ps1`

## Testing
- `Invoke-Pester tests/Get-HyperVProviderVersion.Tests.ps1 -EnableExit` *(fails: ParameterBindingValidationException)*

------
https://chatgpt.com/codex/tasks/task_e_6849a46ef1288331af8fac54e383b435