### PR TITLE
Fix test overrides for menu selection

### DIFF
--- a/tests/Menu.Tests.ps1
+++ b/tests/Menu.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'Get-MenuSelection' {
     }
     It 'returns all items when user types all' {
         $items = @('0001_Test.ps1','0002_Other.ps1')
-        function global:Read-LoggedInput { param($Prompt) 'all' }
+        function Read-LoggedInput { param($Prompt) 'all' }
         $sel = Get-MenuSelection -Items $items -AllowAll
         $sel | Should -Be $items
     }
@@ -18,7 +18,7 @@ Describe 'Get-MenuSelection' {
         $items = @('0001_Test.ps1','0002_Other.ps1')
         $responses = @('0002')
         $script:i = 0
-        function global:Read-LoggedInput { param($Prompt) $responses[$script:i++] }
+        function Read-LoggedInput { param($Prompt) $responses[$script:i++] }
         $sel = Get-MenuSelection -Items $items
         $sel | Should -Be @('0002_Other.ps1')
     }


### PR DESCRIPTION
## Summary
- scope `Read-LoggedInput` overrides to shadow `Logger.ps1`
- update tests to use script-scoped overrides

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script tests/Menu.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_6849a5a685f48331b5a38c2d1ae60e3c