### PR TITLE
Fix OpenTofu installer test mocks

### DIFF
--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -31,7 +31,7 @@ if ($IsLinux -or $IsMacOS) { return }
         $zipPath = Join-Path $temp 'tofu_0.0.0_windows_amd64.zip'
         'dummy' | Set-Content $zipPath
         $hash = (Get-FileHash -Algorithm SHA256 $zipPath).Hash
-        Mock Invoke-WebRequest -ModuleName LabSetup {
+        Mock Invoke-WebRequest {
             param([string]$Uri, [string]$OutFile)
             if ($Uri -match 'SHA256SUMS$') {
                 "${hash}  tofu_0.0.0_windows_amd64.zip" | Set-Content $OutFile
@@ -76,7 +76,7 @@ if ($IsLinux -or $IsMacOS) { return }
         $zipPath = Join-Path $temp 'tofu_0.0.0_windows_amd64.zip'
         'dummy' | Set-Content $zipPath
         $hash = (Get-FileHash -Algorithm SHA256 $zipPath).Hash
-        Mock Invoke-WebRequest -ModuleName LabSetup {
+        Mock Invoke-WebRequest {
             param([string]$Uri, [string]$OutFile)
             if ($Uri -match 'SHA256SUMS$') {
                 "${hash}  tofu_0.0.0_windows_amd64.zip" | Set-Content $OutFile


### PR DESCRIPTION
## Summary
- mock the built-in `Invoke-WebRequest` instead of the one from LabSetup

## Testing
- `Invoke-Pester` *(fails: ParameterBindingValidationException)*

------
https://chatgpt.com/codex/tasks/task_e_6849a5c1ca7483318012cc3fa4d448ae