### PR TITLE
Fix Windows runner tests

### DIFF
--- a/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -428,3 +428,4 @@ You can now run 'tofu plan'/'tofu apply' in $infraRepoPath.
 }
     Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }
+}

--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'runner.ps1 script selection'  {
                 Set-Content -Path (Join-Path $utils 'Logger.ps1')
 
             $labs = Join-Path $root 'lab_utils'
-            New-Item -ItemType Directory -Path $labs | Out-Null
+            New-Item -ItemType Directory -Path $labs -Force | Out-Null
             'function Get-LabConfig { param([string]$Path) Get-Content -Raw $Path | ConvertFrom-Json }' |
                 Set-Content -Path (Join-Path $labs 'Get-LabConfig.ps1')
             'function Format-Config { param($Config) $Config | ConvertTo-Json -Depth 5 }' |


### PR DESCRIPTION
## Summary
- fix helper that creates test environment directories
- close missing brace in Prepare-HyperVProvider script

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: Could not find Command Get-Service)*

------
https://chatgpt.com/codex/tasks/task_e_6849a441e2088331af3bab81ff856604