### PR TITLE
Mock cosign download during tests

### DIFF
--- a/runner_scripts/0006_Install-ValidationTools.ps1
+++ b/runner_scripts/0006_Install-ValidationTools.ps1
@@ -28,7 +28,7 @@ function Install-Cosign {
             try {
                 if ($PSCmdlet.ShouldProcess($destination, 'Download cosign')) {
                     # Download the cosign executable
-                    LabSetup\Invoke-WebRequest -Uri $Config.CosignURL -OutFile $destination -UseBasicParsing
+                    Invoke-LabWebRequest -Uri $Config.CosignURL -OutFile $destination -UseBasicParsing
                     Write-CustomLog "Cosign downloaded and installed at $destination"
                 }
             }
@@ -40,6 +40,7 @@ function Install-Cosign {
 
         # Add the installation folder to the user's PATH if not already present
         $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+        if (-not $userPath) { $userPath = '' }
         if (-not $userPath.Contains($installDir)) {
             if ($PSCmdlet.ShouldProcess('User PATH', 'Update environment variable')) {
                 [Environment]::SetEnvironmentVariable("PATH", "$userPath;$installDir", "User")

--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -4,20 +4,27 @@ Describe '0006_Install-ValidationTools'  {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0006_Install-ValidationTools.ps1'
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'Logger.ps1')
+        Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psd1') -Force
+        if (-not $env:TEMP) { $env:TEMP = [System.IO.Path]::GetTempPath() }
+    }
+
+    AfterEach {
+        [Environment]::SetEnvironmentVariable('PATH',$null,'User')
     }
 
     It 'downloads cosign when InstallCosign is true' {
         $cfg = [pscustomobject]@{
             InstallCosign = $true
-            CosignURL     = 'http://example.com/cosign.exe'
+            CosignURL     = 'http://dummy.local/cosign.exe'
             CosignPath    = Join-Path $env:TEMP ([guid]::NewGuid())
         }
-        Mock Invoke-WebRequest -ModuleName LabSetup {}
+        [Environment]::SetEnvironmentVariable('PATH','dummy','User')
+        Mock Invoke-LabWebRequest {}
         Mock New-Item {}
         Mock Test-Path { $false }
         Mock-WriteLog
         & $script:ScriptPath -Config $cfg
-        Should -Invoke -CommandName Invoke-WebRequest -Times 1 -ParameterFilter { $Uri -eq $cfg.CosignURL }
+        Should -Invoke -CommandName Invoke-LabWebRequest -Times 1 -ParameterFilter { $Uri -eq $cfg.CosignURL }
     }
 
     It 'checks for gpg when InstallGpg is true' {

--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -9,7 +9,7 @@ Describe '0006_Install-ValidationTools'  {
     }
 
     AfterEach {
-        [Environment]::SetEnvironmentVariable('PATH',$null,'User')
+        [Environment]::SetEnvironmentVariable('PATH',$null,'Process')
     }
 
     It 'downloads cosign when InstallCosign is true' {


### PR DESCRIPTION
## Summary
- mock `Invoke-LabWebRequest` in the validation tools tests
- set a temp path during tests and load `LabRunner`
- safely handle missing user PATH in script

## Testing
- `Invoke-Pester -Script tests/Install-ValidationTools.Tests.ps1 -PassThru`
- `Invoke-Pester -Configuration $cfg -WarningAction SilentlyContinue` *(fails: `Tests Passed: 214, Failed: 98`)*

------
https://chatgpt.com/codex/tasks/task_e_6849a491bb088331b604401579d2141f