### PR TITLE
Fix Initialize-OpenTofu test scope

### DIFF
--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -2,7 +2,7 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe 'Initialize-OpenTofu script' {
     Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psd1') -Force
-InModuleScope LabSetup {
+InModuleScope LabRunner {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0009_Initialize-OpenTofu.ps1'
     }


### PR DESCRIPTION
## Summary
- update Initialize-OpenTofu tests to use the LabRunner scope

## Testing
- `pwsh -NoLogo -NoProfile -Command 'function Invoke-OpenTofuInstaller {}; Import-Module Pester -MinimumVersion 5.0; if (-not (Get-PSDrive C -ErrorAction SilentlyContinue)) { New-PSDrive -Name C -PSProvider FileSystem -Root /tmp }; Invoke-Pester -Path tests/Initialize-OpenTofu.Tests.ps1 -CI'`

------
https://chatgpt.com/codex/tasks/task_e_6849a524f4a8833191316223f8a663e7