### PR TITLE
Load LabRunner in validation tests

### DIFF
--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -2,6 +2,7 @@
 . (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 Describe '0006_Install-ValidationTools'  {
     BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'LabRunner.psd1') -Force
         $script:ScriptPath = Get-RunnerScriptPath '0006_Install-ValidationTools.ps1'
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabRunner' 'Logger.ps1')
     }


### PR DESCRIPTION
## Summary
- load `LabRunner` module in `Install-ValidationTools.Tests.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/Install-ValidationTools.Tests.ps1 -CI"` *(fails: Could not find Mock for command Invoke-WebRequest)*

------
https://chatgpt.com/codex/tasks/task_e_6849a5a1d8e883319b9ec96f83d4331b