### PR TITLE
Fix CustomLint script pipeline

### DIFF
--- a/scripts/CustomLint.ps1
+++ b/scripts/CustomLint.ps1
@@ -11,10 +11,10 @@ if (-not (Test-Path $SettingsPath)) {
 }
 
 $files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
-    ForEach-Object { $_.FullName }
+    Select-Object -ExpandProperty FullName
 
-$results = Invoke-ScriptAnalyzer -Path $files -Severity Error,Warning -Settings $SettingsPath
-$results | Format-Table
+$results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
+$results | Format-Table | Out-String | Write-Host
 
 if ($results | Where-Object Severity -eq 'Error') {
     Write-Error 'ScriptAnalyzer errors detected'

--- a/scripts/CustomLint.ps1
+++ b/scripts/CustomLint.ps1
@@ -14,7 +14,7 @@ $files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File
     Select-Object -ExpandProperty FullName
 
 $results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
-$results | Format-Table | Out-String | Write-Host
+$results | Format-Table | Out-String | Write-Output
 
 if ($results | Where-Object Severity -eq 'Error') {
     Write-Error 'ScriptAnalyzer errors detected'


### PR DESCRIPTION
## Summary
- pipe `Get-ChildItem` results into `Invoke-ScriptAnalyzer`
- use `Select-Object -ExpandProperty FullName`
- format lint output before writing to host

## Testing
- `pytest -q`
- ❌ `Invoke-Pester` *(fails: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849ab5306c08331b5b42b60da62560e