### PR TITLE
Improve test mocks and linting

### DIFF
--- a/scripts/CustomLint.ps1
+++ b/scripts/CustomLint.ps1
@@ -16,7 +16,31 @@ $files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File
 $results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
 $results | Format-Table | Out-String | Write-Output
 
+$failed = $false
 if ($results | Where-Object Severity -eq 'Error') {
     Write-Error 'ScriptAnalyzer errors detected'
-    exit 1
+    $failed = $true
 }
+
+# Enforce ParameterFilter on Invoke-WebRequest mocks
+$mockIssues = @()
+foreach ($file in $files) {
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$null, [ref]$null)
+    $calls = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] -and $n.GetCommandName() -eq 'Mock' }, $true)
+    foreach ($c in $calls) {
+        $first = $c.CommandElements[1]
+        if ($first -and $first.Extent.Text -match 'Invoke-WebRequest') {
+            $hasFilter = $c.CommandElements | Where-Object { $_ -is [System.Management.Automation.Language.CommandParameterAst] -and $_.ParameterName -eq 'ParameterFilter' }
+            if (-not $hasFilter) {
+                $mockIssues += "$file:$($c.Extent.StartLineNumber) Mock Invoke-WebRequest missing -ParameterFilter"
+            }
+        }
+    }
+}
+if ($mockIssues) {
+    $mockIssues | ForEach-Object { Write-Warning $_ }
+    Write-Error 'Mock lint errors detected'
+    $failed = $true
+}
+
+if ($failed) { exit 1 }

--- a/tests/Configure-Firewall.Tests.ps1
+++ b/tests/Configure-Firewall.Tests.ps1
@@ -3,18 +3,17 @@
 Describe '0102_Configure-Firewall'  {
     BeforeAll {
         $script:ScriptPath = Get-RunnerScriptPath '0102_Configure-Firewall.ps1'
+        Mock New-NetFirewallRule {}
     }
 
     It 'creates firewall rules for each port when ports are specified' {
         $cfg = [pscustomobject]@{ FirewallPorts = @(80, 443) }
-        Mock New-NetFirewallRule {}
         & $script:ScriptPath -Config $cfg
         Should -Invoke -CommandName New-NetFirewallRule -Times 2
     }
 
     It 'skips when no FirewallPorts are provided' {
         $cfg = [pscustomobject]@{ FirewallPorts = $null }
-        Mock New-NetFirewallRule {}
         & $script:ScriptPath -Config $cfg
         Should -Invoke -CommandName New-NetFirewallRule -Times 0
     }

--- a/tests/CustomLint.Tests.ps1
+++ b/tests/CustomLint.Tests.ps1
@@ -17,6 +17,14 @@ Describe 'CustomLint.ps1' {
         $LASTEXITCODE | Should -Be 1
     }
 
+    It 'fails when Invoke-WebRequest mock lacks ParameterFilter' {
+        Mock Invoke-ScriptAnalyzer { @() }
+        $temp = Join-Path $TestDrive 'bad.ps1'
+        "Mock Invoke-WebRequest {}" | Set-Content $temp
+        & $script:ScriptPath -Target $TestDrive > $null
+        $LASTEXITCODE | Should -Be 1
+    }
+
     It 'returns exit code 0 when no errors' {
         Mock Invoke-ScriptAnalyzer { @() }
         & $script:ScriptPath -Target $PSScriptRoot > $null

--- a/tests/Install-Go.Tests.ps1
+++ b/tests/Install-Go.Tests.ps1
@@ -4,13 +4,15 @@ Import-Module (Join-Path $PSScriptRoot '..' 'lab_utils' 'LabSetup' 'LabSetup.psd
 InModuleScope LabSetup {
 Describe '0007_Install-Go'  {
     BeforeAll { $script:ScriptPath = Get-RunnerScriptPath '0007_Install-Go.ps1' }
+    BeforeEach {
+        Mock Start-Process {}
+        Mock-WriteLog
+    }
 
     It 'installs Go when enabled' {
         $cfg = [pscustomobject]@{ InstallGo = $true; Go = @{ InstallerUrl = 'http://example.com/go1.21.0.windows-amd64.msi' } }
         Mock Get-Command {} -ParameterFilter { $Name -eq 'go' }
-        Mock Invoke-WebRequest -ModuleName LabSetup {}
-        Mock Start-Process {}
-        Mock-WriteLog
+        Mock Invoke-WebRequest -ModuleName LabSetup {} -ParameterFilter { $Uri -eq $cfg.Go.InstallerUrl }
         & $script:ScriptPath -Config $cfg
         Should -Invoke -CommandName Invoke-WebRequest -Times 1 -ParameterFilter { $Uri -eq $cfg.Go.InstallerUrl }
         Should -Invoke -CommandName Start-Process -Times 1 -ParameterFilter { $FilePath -eq 'msiexec.exe' }
@@ -18,9 +20,7 @@ Describe '0007_Install-Go'  {
 
     It 'skips when InstallGo is false' {
         $cfg = [pscustomobject]@{ InstallGo = $false; Go = @{ InstallerUrl = 'http://example.com/go1.21.0.windows-amd64.msi' } }
-        Mock Invoke-WebRequest -ModuleName LabSetup {}
-        Mock Start-Process {}
-        Mock-WriteLog
+        Mock Invoke-WebRequest -ModuleName LabSetup {} -ParameterFilter { $Uri -eq $cfg.Go.InstallerUrl }
         & $script:ScriptPath -Config $cfg
         Should -Invoke -CommandName Invoke-WebRequest -Times 0
         Should -Invoke -CommandName Start-Process -Times 0
@@ -29,9 +29,7 @@ Describe '0007_Install-Go'  {
     It 'does nothing when Go is already installed' {
         $cfg = [pscustomobject]@{ InstallGo = $true; Go = @{ InstallerUrl = 'http://example.com/go1.21.0.windows-amd64.msi' } }
         Mock Get-Command { @{ Name = 'go' } } -ParameterFilter { $Name -eq 'go' }
-        Mock Invoke-WebRequest -ModuleName LabSetup {}
-        Mock Start-Process {}
-        Mock-WriteLog
+        Mock Invoke-WebRequest -ModuleName LabSetup {} -ParameterFilter { $Uri -eq $cfg.Go.InstallerUrl }
         & $script:ScriptPath -Config $cfg
         Should -Invoke -CommandName Invoke-WebRequest -Times 0
         Should -Invoke -CommandName Start-Process -Times 0

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -6,6 +6,10 @@ Describe '0008_Install-OpenTofu'  {
         $script:ScriptPath = Get-RunnerScriptPath '0008_Install-OpenTofu.ps1'
         . $script:ScriptPath
     }
+    BeforeEach {
+        Mock Invoke-OpenTofuInstaller {}
+        Mock-WriteLog
+    }
 
     It 'calls OpenTofuInstaller when enabled' {
         $cfg = [pscustomobject]@{
@@ -14,8 +18,6 @@ Describe '0008_Install-OpenTofu'  {
             OpenTofuVersion = '1.9.1'
         }
 
-        Mock Invoke-OpenTofuInstaller {}
-        Mock-WriteLog
         
         Install-OpenTofu -Config $cfg
 
@@ -27,8 +29,6 @@ Describe '0008_Install-OpenTofu'  {
 
     It 'skips install when flag is false' {
         $cfg = [pscustomobject]@{ InstallOpenTofu = $false }
-        Mock Invoke-OpenTofuInstaller {}
-        Mock-WriteLog
 
         Install-OpenTofu -Config $cfg
 


### PR DESCRIPTION
## Summary
- consolidate repeated mocks to a `BeforeAll` or `BeforeEach`
- require `Invoke-WebRequest` mocks to use `-ParameterFilter`
- add a custom lint check for missing filters
- test the new lint behaviour

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6849ae5b27988331a7493ad51197b537