### PR TITLE
Fix Python path refresh after install

### DIFF
--- a/runner_scripts/0206_Install-Python.ps1
+++ b/runner_scripts/0206_Install-Python.ps1
@@ -14,6 +14,11 @@ function Install-Python {
                 Invoke-LabDownload -Uri $url -Prefix 'python-installer' -Extension '.exe' -Action {
                     param($installer)
                     Start-Process -FilePath $installer -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait
+                    # Refresh PATH for the current session so subsequent scripts can find python
+                    $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+                    $machinePath = [Environment]::GetEnvironmentVariable('PATH', 'Machine')
+                    $env:PATH = ($userPath, $machinePath -join ';')
+                    Write-CustomLog 'PATH refreshed with new Python location.'
                 }
             } else {
                 Write-CustomLog 'Python already installed.'

--- a/runner_scripts/0206_Install-Python.ps1
+++ b/runner_scripts/0206_Install-Python.ps1
@@ -17,7 +17,7 @@ function Install-Python {
                     # Refresh PATH for the current session so subsequent scripts can find python
                     $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
                     $machinePath = [Environment]::GetEnvironmentVariable('PATH', 'Machine')
-                    $env:PATH = ($userPath, $machinePath -join ';')
+                    $env:PATH = (($userPath, $machinePath) -join ';')
                     Write-CustomLog 'PATH refreshed with new Python location.'
                 }
             } else {


### PR DESCRIPTION
## Summary
- refresh PATH environment variable during Python install

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: 80 tests failed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b74935d083318f75855aee691f66