### PR TITLE
Add repo index command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ See `py/README.md` for detailed instructions on installing and running the CLI.
 
 2. **Coverage**
    • Add or update Pester/pytest tests for every functional change, covering success and failure paths.
+   • Run `labctl repo index` whenever paths to scripts or config files change.
 
 ### Pester test tips
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,14 @@ cd py && pytest
 The `task test` shortcut (defined in InvokeBuild) wraps these commands and
 executes the same steps as the CI pipeline.
 
+Whenever paths to scripts or config files change, run:
+
+```bash
+poetry run labctl repo index
+```
+
+This regenerates the packaged index used by the CLI.
+
 When adding Windows‑specific tests, guard them with
 `-Skip:($IsLinux -or $IsMacOS)` so the suite succeeds across all platforms.
 

--- a/py/labctl/cli.py
+++ b/py/labctl/cli.py
@@ -6,7 +6,7 @@ from importlib.resources import files
 import typer
 import yaml
 
-from . import github_utils, issue_parser
+from . import github_utils, issue_parser, update_index
 
 
 def default_config_path() -> Path:
@@ -114,6 +114,13 @@ def parse_issue(issue_number: int):
     info = json.loads(raw)
     parsed = issue_parser.parse_issue_body(info.get("body", ""))
     typer.echo(json.dumps(parsed))
+
+
+@repo_app.command()
+def index() -> None:
+    """Update the repository file index."""
+    path = update_index.update_index()
+    logger.info("Updated index at %s", path)
 
 
 @repo_app.command()

--- a/py/labctl/update_index.py
+++ b/py/labctl/update_index.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+
+def update_index() -> Path:
+    """Generate repo file index for packaging helpers."""
+    repo_root = Path(__file__).resolve().parents[2]
+    data = {
+        "config_files": sorted(
+            str(p.relative_to(repo_root))
+            for p in (repo_root / "config_files").glob("*.json")
+        ),
+        "runner_scripts": sorted(
+            str(p.relative_to(repo_root))
+            for p in (repo_root / "runner_scripts").glob("*.ps1")
+        ),
+    }
+    index_path = repo_root / "py" / "labctl" / "config_files" / "index.json"
+    index_path.write_text(json.dumps(data, indent=2))
+    return index_path

--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from labctl.cli import app, default_config_path, load_config
+from labctl import update_index
 
 
 def test_default_config_packaged():
@@ -64,3 +65,17 @@ def test_ui_help():
     runner = CliRunner()
     result = runner.invoke(app, ["ui", "--help"])
     assert result.exit_code == 0
+
+
+def test_repo_index(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_update():
+        called["ran"] = True
+        return tmp_path / "index.json"
+
+    monkeypatch.setattr(update_index, "update_index", fake_update)
+    runner = CliRunner()
+    result = runner.invoke(app, ["repo", "index"])
+    assert result.exit_code == 0
+    assert called.get("ran")


### PR DESCRIPTION
## Summary
- add `labctl repo index` subcommand that runs new `update_index.py`
- create `update_index.py` helper to generate file index
- test new command
- document running `labctl repo index` when paths change

## Testing
- `ruff check py/labctl/update_index.py py/labctl/cli.py py/tests/test_cli.py`
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b7dce5e88331bcbe5c5e52ebb2f7