### PR TITLE
Fix missing closing brace in Runner.Tests.ps1

### DIFF
--- a/tests/Runner.Tests.ps1
+++ b/tests/Runner.Tests.ps1
@@ -494,6 +494,8 @@ Write-CustomLog 'hello world'
 
     }
 
+}
+
 Describe 'Set-LabConfig' {
     BeforeAll {
         . (Join-Path $PSScriptRoot '..' 'lab_utils' 'Menu.ps1')


### PR DESCRIPTION
## Summary
- fix missing `}` in `Runner.Tests.ps1`

## Testing
- `pytest -q`
- ❌ `Invoke-Pester` *(failed: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849b9266368833199787f15ae674004