### PR TITLE
Add changelog and automation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,27 @@
+name: Changelog
+
+on:
+  push:
+    branches: [ main ]
+  release:
+    types: [ published ]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install towncrier
+        run: pip install towncrier
+      - name: Generate changelog
+        run: towncrier build --yes
+      - name: Commit changelog
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "[skip ci] Update changelog" || echo "No changes"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Initial changelog setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,5 +39,12 @@ executes the same steps as the CI pipeline.
 When adding Windows‑specific tests, guard them with
 `-Skip:($IsLinux -or $IsMacOS)` so the suite succeeds across all platforms.
 
+## Changelog entries
+
+This project uses [towncrier](https://github.com/twisted/towncrier) to manage the
+changelog. For each pull request, create a news fragment under `newsfragments/`
+describing your change. Run `towncrier create` and commit the generated file.
+The changelog is automatically updated on merges to `main`.
+
 ## CI failure issues
 executes the same steps as the lint, Pester and Pytest workflows.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+This project maintains a changelog following the [Keep a Changelog](https://keepachangelog.com/) format.
+
+See the repository root [CHANGELOG.md](../CHANGELOG.md) for the latest entries.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,3 +8,4 @@ nav:
   - Copilot Auto Fix: docs/copilot-auto-fix.md
   - Python CLI: docs/python-cli.md
   - Troubleshooting: docs/troubleshooting.md
+  - Changelog: docs/changelog.md


### PR DESCRIPTION
## Summary
- document the changelog format and create a docs page
- link the changelog in the MkDocs nav
- automate changelog generation via towncrier
- guide contributors on adding changelog entries

## Testing
- `mkdocs build`
- `poetry run pytest`
- `pwsh -NoLogo -NoProfile -File run_pester.ps1` *(fails: CommandNotFoundException for `New-NetFirewallRule`)*

------
https://chatgpt.com/codex/tasks/task_e_6849b8c3993c83318aadba024fa1196b