### PR TITLE
Add towncrier configuration

### DIFF
--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,9 @@
+[tool.towncrier]
+package = "labctl"
+package_dir = "py"
+filename = "CHANGELOG.md"
+directory = "newsfragments"
+
+# Start new entries under the 'Unreleased' heading
+start_string = "## [Unreleased]"
+issue_format = "#{issue}"


### PR DESCRIPTION
## Summary
- add `towncrier.toml` at repo root
- create empty `newsfragments/` directory for changelog fragments

## Testing
- `pytest -q`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bd420cec8331921656dbf0652e57