### PR TITLE
Fix YAML indentation in lint action

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -20,9 +20,9 @@ runs:
     - name: Install ruff
       shell: bash
       run: pip install "ruff>=0.1"
-      - name: Run Script Analyzer
-        shell: pwsh
-        run: |
+    - name: Run Script Analyzer
+      shell: pwsh
+      run: |
           $settings = Join-Path $PWD 'PSScriptAnalyzerSettings.psd1'
           $files = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1,*.psd1 -File | Select-Object -ExpandProperty FullName
           $results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $settings


### PR DESCRIPTION
## Summary
- fix indentation in `.github/actions/lint/action.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer' before installing deps; after installing dependencies 4 tests fail)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849be48987483319ca5f284c0c9394c