### PR TITLE
Add yamllint to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,14 @@ jobs:
         shell: pwsh
         run: |
           Install-Module -Name powershell-yaml -Force -Scope CurrentUser
+      - name: Install yamllint
+        shell: bash
+        run: pip install yamllint
       - uses: ./.github/actions/lint
+      - name: Run yamllint
+        shell: bash
+        run: |
+          yamllint .github/workflows $(git ls-files '*.yml' '*.yaml')
       - name: Set up Copilot
         run: npm install -g @githubnext/github-copilot-cli
       - name: Run Copilot suggestions


### PR DESCRIPTION
## Summary
- install yamllint in lint workflow
- run yamllint over workflow files and other YAML
- ensure yamllint checks happen before Copilot suggestions

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Cleanup-Files script...)*
- `python3 -m pytest -q` *(fails: test_path_index.py)*

------
https://chatgpt.com/codex/tasks/task_e_6849be7f74b0833184c68dd0de38fe99