### PR TITLE
Fix indentation in package-labctl workflow

### DIFF
--- a/.github/workflows/package-labctl.yml
+++ b/.github/workflows/package-labctl.yml
@@ -31,16 +31,16 @@ jobs:
       - name: Create installer
         run: |
           $iss = @"
-[Setup]
-AppName=labctl
-AppVersion=0.1.0
-DefaultDirName={pf}\labctl
-OutputDir=dist
-OutputBaseFilename=labctl-installer
-DisableProgramGroupPage=yes
-[Files]
-Source: "py\dist\labctl.exe"; DestDir: "{app}"; Flags: ignoreversion
-"@
+            [Setup]
+            AppName=labctl
+            AppVersion=0.1.0
+            DefaultDirName={pf}\labctl
+            OutputDir=dist
+            OutputBaseFilename=labctl-installer
+            DisableProgramGroupPage=yes
+            [Files]
+            Source: "py\dist\labctl.exe"; DestDir: "{app}"; Flags: ignoreversion
+          "@
           $iss | Out-File installer.iss -Encoding ASCII
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer.iss
       - name: Upload installer


### PR DESCRIPTION
## Summary
- fix indentation in the "Create installer" step of `package-labctl.yml`

## Testing
- `python - <<'EOF'
import yaml
yaml.safe_load(open('.github/workflows/package-labctl.yml'))
EOF
`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849be8193088331a97b51ab0e84238d