### PR TITLE
Fix lint cache reuse

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,9 @@ jobs:
       - name: Install PSScriptAnalyzer
         shell: pwsh
         run: |
-          Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.24.0 -Force -Scope CurrentUser
+          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer -RequiredVersion 1.24.0)) {
+            Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.24.0 -Scope CurrentUser -Force
+          }
       - name: Install powershell-yaml
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- avoid reinstalling PSScriptAnalyzer when cached

## Testing
- `Invoke-Pester` *(fails: Cleanup-Files script and others)*
- `pytest -q` *(fails: test_path_index)*

------
https://chatgpt.com/codex/tasks/task_e_6849bf5ca3f08331bcf8d3943ddf87a5