### PR TITLE
Fix pytest job by installing dev dependencies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Ensure coverage directory
         run: mkdir -p coverage
       - name: Run pytest
+        env:
+          POETRY_VIRTUALENVS_IN_PROJECT: 'true'
         run: |
           cd py
           poetry run pytest --junitxml=../coverage/junit.xml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,7 +41,7 @@ jobs:
           POETRY_VIRTUALENVS_IN_PROJECT: 'true'
         run: |
           cd py
-          poetry install
+          poetry install --with dev
       - name: Ensure coverage directory
         run: mkdir -p coverage
       - name: Run pytest


### PR DESCRIPTION
## Summary
- install dev dependencies for the `pytest` workflow so `pytest` is available

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError & assertion errors)*
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c0dec35883318ba3867aeb61ff87