### PR TITLE
Fix PSScriptAnalyzer settings path

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -23,9 +23,9 @@ runs:
     - name: Run Script Analyzer
       shell: pwsh
       run: |
-          $settings = Join-Path $PWD 'PSScriptAnalyzerSettings.psd1'
-          $files = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1,*.psd1 -File | Select-Object -ExpandProperty FullName
-          $results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $settings
+          $settingsPath = Join-Path $env:GITHUB_WORKSPACE 'PSScriptAnalyzerSettings.psd1'
+          $files = Get-ChildItem -Path $env:GITHUB_WORKSPACE -Recurse -Include *.ps1,*.psm1,*.psd1 -File | Select-Object -ExpandProperty FullName
+          $results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $settingsPath
           $results | Format-Table
           if ($results | Where-Object Severity -eq 'Error') {
             Write-Error 'ScriptAnalyzer errors detected'


### PR DESCRIPTION
## Summary
- fix PSScriptAnalyzer settings path so lint job runs in any working directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c112aa408331a3781f2fa085883d