### PR TITLE
Fix PSScriptAnalyzer settings path

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -24,7 +24,9 @@ runs:
       shell: pwsh
       run: |
           $settings = Join-Path $PWD 'PSScriptAnalyzerSettings.psd1'
-          $files = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1,*.psd1 -File | Select-Object -ExpandProperty FullName
+          $files = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
+              Where-Object { $_.FullName -ne $settings } |
+              Select-Object -ExpandProperty FullName
           $results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $settings
           $results | Format-Table
           if ($results | Where-Object Severity -eq 'Error') {

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -30,8 +30,8 @@ runs:
           $results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $settings
           $results | Format-Table
           if ($results | Where-Object Severity -eq 'Error') {
-            Write-Error 'ScriptAnalyzer errors detected'
-            exit 1
+              Write-Error 'ScriptAnalyzer errors detected'
+              exit 1
           }
     - name: Run Custom Script Analyzer
       shell: pwsh

--- a/scripts/CustomLint.ps1
+++ b/scripts/CustomLint.ps1
@@ -11,7 +11,7 @@ if (-not (Test-Path $SettingsPath)) {
 }
 
     $files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
-        Where-Object { $_.FullName -ne (Resolve-Path $SettingsPath) }
+        Where-Object { $_.FullName -ne (Resolve-Path $SettingsPath).Path }
     $results = $files |
         Select-Object -ExpandProperty FullName |
         Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath

--- a/scripts/CustomLint.ps1
+++ b/scripts/CustomLint.ps1
@@ -10,12 +10,12 @@ if (-not (Test-Path $SettingsPath)) {
     throw "Settings file not found: $SettingsPath"
 }
 
-    $files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
-        Where-Object { $_.FullName -ne (Resolve-Path $SettingsPath).Path }
-    $results = $files |
-        Select-Object -ExpandProperty FullName |
-        Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
-    $results | Format-Table
+$files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
+    Where-Object { $_.FullName -ne (Resolve-Path $SettingsPath) } |
+    Select-Object -ExpandProperty FullName
+
+$results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
+
 # Use Write-Output so callers can capture or redirect the formatted results
 $results | Format-Table | Out-String | Write-Output
 

--- a/scripts/CustomLint.ps1
+++ b/scripts/CustomLint.ps1
@@ -10,13 +10,12 @@ if (-not (Test-Path $SettingsPath)) {
     throw "Settings file not found: $SettingsPath"
 }
 
-$results = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
-    Select-Object -ExpandProperty FullName |
-    Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
-$results | Format-Table
-
-
-$results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
+    $files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
+        Where-Object { $_.FullName -ne (Resolve-Path $SettingsPath) }
+    $results = $files |
+        Select-Object -ExpandProperty FullName |
+        Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
+    $results | Format-Table
 # Use Write-Output so callers can capture or redirect the formatted results
 $results | Format-Table | Out-String | Write-Output
 


### PR DESCRIPTION
## Summary
- skip the settings file when invoking Script Analyzer
- fix CustomLint script to use the filtered file list

## Testing
- `Invoke-Pester` *(fails: Cleanup-Files script, Enable-PXE, Enable-RemoteDesktop, Enable-WinRM, Get-SystemInfo, Initialize-OpenTofu script, Install-Go, Install-Poetry, Install-Sysinternals, Install-ValidationTools, Node installation scripts, Reset-Machine script, Set-LabProfile, Setup-Directories)*
- `pytest -q` *(fails: test_load_index_contains_runner, test_resolve_path_missing, test_default_config_fallback, test_no_pycache_paths)*

------
https://chatgpt.com/codex/tasks/task_e_6849c12e44688331b807f1d1578d5e54