### PR TITLE
Parse lint output in failure issue

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -66,6 +66,13 @@ jobs:
             fi
           done < <(find artifacts -name junit.xml -print0)
 
+          while IFS= read -r -d '' f; do
+            out=$(python -m labctl.lint_failures "$f" --summary || true)
+            if [ -n "$out" ]; then
+              summary="$summary$out\n"
+            fi
+          done < <(find artifacts -path '*lint*' -name '*.txt' -print0)
+
           echo "failures<<EOF" >> "$GITHUB_OUTPUT"
           echo -e "$summary" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"

--- a/path-index.yaml
+++ b/path-index.yaml
@@ -31,6 +31,7 @@ py/labctl/config_files/default-config.json: py/labctl/config_files/default-confi
 py/labctl/config_files/full-config.json: py/labctl/config_files/full-config.json
 py/labctl/github_utils.py: py/labctl/github_utils.py
 py/labctl/issue_parser.py: py/labctl/issue_parser.py
+py/labctl/lint_failures.py: py/labctl/lint_failures.py
 py/labctl/path_index.py: py/labctl/path_index.py
 py/labctl/pester_failures.py: py/labctl/pester_failures.py
 py/labctl/pytest_failures.py: py/labctl/pytest_failures.py
@@ -41,6 +42,7 @@ py/tests/test_get_platform.py: py/tests/test_get_platform.py
 py/tests/test_github_utils.py: py/tests/test_github_utils.py
 py/tests/test_issue_parser.py: py/tests/test_issue_parser.py
 py/tests/test_kickstart_bootstrap.py: py/tests/test_kickstart_bootstrap.py
+py/tests/test_lint_failures.py: py/tests/test_lint_failures.py
 py/tests/test_path_index.py: py/tests/test_path_index.py
 py/tests/test_pester_failures.py: py/tests/test_pester_failures.py
 py/tests/test_pytest_failures.py: py/tests/test_pytest_failures.py

--- a/py/labctl/lint_failures.py
+++ b/py/labctl/lint_failures.py
@@ -1,0 +1,50 @@
+import argparse
+import re
+from pathlib import Path
+from typing import Iterable
+
+from .github_utils import create_issue
+
+
+def _collect_lines(path: Path) -> Iterable[str]:
+    if path.is_dir():
+        for p in sorted(path.rglob('*.txt')):
+            yield from _collect_lines(p)
+        return
+    with path.open('r', encoding='utf-8', errors='replace') as f:
+        for line in f:
+            yield line.rstrip()
+
+def summarize_warnings(path: Path) -> str:
+    pattern = re.compile(r"(warning|error)", re.IGNORECASE)
+    ruff_pattern = re.compile(r".+:\d+:\d+:")
+    lines = []
+    for line in _collect_lines(path):
+        if pattern.search(line) or ruff_pattern.match(line):
+            cleaned = line.strip()
+            if cleaned:
+                lines.append(cleaned)
+    # remove duplicates while preserving order
+    unique = list(dict.fromkeys(lines))
+    return "\n".join(unique)
+
+def report_warnings(path: Path) -> None:
+    summary = summarize_warnings(path)
+    if not summary:
+        return
+    for line in summary.splitlines():
+        create_issue("Lint warning or error", line)
+
+def _main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Report or summarize lint warnings")
+    parser.add_argument("path", type=Path, help="Path to log file or directory")
+    parser.add_argument("--summary", action="store_true", help="Print summary instead of creating issues")
+    args = parser.parse_args(argv)
+    if args.summary:
+        print(summarize_warnings(args.path))
+    else:
+        report_warnings(args.path)
+
+
+if __name__ == "__main__":
+    _main()

--- a/py/tests/test_lint_failures.py
+++ b/py/tests/test_lint_failures.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from labctl import lint_failures
+
+
+def test_summarize_warnings(tmp_path):
+    log = tmp_path / "lint.txt"
+    log.write_text(
+        "foo.py:1:1: F401 'os' imported but unused\n"
+        "Warning foo.ps1 12 Use of Write-Host\n"
+    )
+    summary = lint_failures.summarize_warnings(log)
+    lines = summary.splitlines()
+    assert "foo.py:1:1: F401 'os' imported but unused" in lines
+    assert any("Write-Host" in line for line in lines)
+
+
+def test_report_warnings(tmp_path, monkeypatch):
+    log = tmp_path / "lint.txt"
+    log.write_text("foo.py:1:1: F401 'os' imported but unused\n")
+    calls = []
+
+    def fake_issue(title, body):
+        calls.append(SimpleNamespace(title=title, body=body))
+
+    monkeypatch.setattr(lint_failures, "create_issue", fake_issue)
+    lint_failures.report_warnings(log)
+
+    assert len(calls) == 1
+    assert calls[0].title == "Lint warning or error"
+    assert "F401" in calls[0].body

--- a/py/tests/test_lint_failures.py
+++ b/py/tests/test_lint_failures.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import sys
 from types import SimpleNamespace
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+# Line removed as the package should be installed in editable mode for testing.
 
 from labctl import lint_failures
 


### PR DESCRIPTION
## Summary
- extract warnings/errors from lint logs
- parse lint output in issue-on-fail workflow
- cover new lint parser with tests
- update path index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c35ec57883318274bec02efe5582