### PR TITLE
Fix CustomLint script path list

### DIFF
--- a/tools/iso/CustomLint.ps1
+++ b/tools/iso/CustomLint.ps1
@@ -10,12 +10,11 @@ if (-not (Test-Path $SettingsPath)) {
     throw "Settings file not found: $SettingsPath"
 }
 
-$results = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
-    Select-Object -ExpandProperty FullName |
-    Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
-$results | Format-Table
+# Discover all PowerShell files to analyze
+$files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
+    Select-Object -ExpandProperty FullName
 
-
+# Run Script Analyzer against the collected files
 $results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
 # Use Write-Output so callers can capture or redirect the formatted results
 $results | Format-Table | Out-String | Write-Output
@@ -36,7 +35,7 @@ foreach ($file in $files) {
         if ($first -and $first.Extent.Text -match 'Invoke-WebRequest') {
             $hasFilter = $c.CommandElements | Where-Object { $_ -is [System.Management.Automation.Language.CommandParameterAst] -and $_.ParameterName -eq 'ParameterFilter' }
             if (-not $hasFilter) {
-                $mockIssues += "$file:$($c.Extent.StartLineNumber) Mock Invoke-WebRequest missing -ParameterFilter"
+                $mockIssues += "${file}:$($c.Extent.StartLineNumber) Mock Invoke-WebRequest missing -ParameterFilter"
             }
         }
     }

--- a/tools/iso/CustomLint.ps1
+++ b/tools/iso/CustomLint.ps1
@@ -35,6 +35,7 @@ foreach ($file in $files) {
         if ($first -and $first.Extent.Text -match 'Invoke-WebRequest') {
             $hasFilter = $c.CommandElements | Where-Object { $_ -is [System.Management.Automation.Language.CommandParameterAst] -and $_.ParameterName -eq 'ParameterFilter' }
             if (-not $hasFilter) {
+                # Use string interpolation (${file}) for clarity and maintainability
                 $mockIssues += "${file}:$($c.Extent.StartLineNumber) Mock Invoke-WebRequest missing -ParameterFilter"
             }
         }


### PR DESCRIPTION
## Summary
- fix `$files` variable usage in `CustomLint.ps1`
- correct string interpolation for mock issue reporting

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c64c995c8331bbff4748334abbb3