### PR TITLE
Update job artifact downloads

### DIFF
--- a/pwsh/lab_utils/Get-WindowsJobArtifacts.ps1
+++ b/pwsh/lab_utils/Get-WindowsJobArtifacts.ps1
@@ -31,12 +31,12 @@ if ($useGh) {
         $res = $artifacts | Where-Object { $_.name -match 'results.*windows-latest' }
         if ($res) {
             if ($cov) {
-                gh $cov.archive_download_url --output (Join-Path $tempDir 'coverage.zip')
+                gh api $cov.archive_download_url --output (Join-Path $tempDir 'coverage.zip')
                 if ($LASTEXITCODE -ne 0) {
                     Write-Host 'Failed to download coverage artifact.' -ForegroundColor Yellow
                 }
             }
-            gh $res.archive_download_url --output (Join-Path $tempDir 'results.zip')
+            gh api $res.archive_download_url --output (Join-Path $tempDir 'results.zip')
             if ($LASTEXITCODE -ne 0) {
                 Write-Host 'Failed to download results artifact.' -ForegroundColor Yellow
                 exit 1
@@ -57,9 +57,9 @@ if ($useGh) {
             $res = $artifacts | Where-Object { $_.name -match 'results.*windows-latest' }
             if ($res) {
                 if ($cov) {
-                    gh $cov.archive_download_url --output (Join-Path $tempDir 'coverage.zip')
+                    gh api $cov.archive_download_url --output (Join-Path $tempDir 'coverage.zip')
                 }
-                gh $res.archive_download_url --output (Join-Path $tempDir 'results.zip')
+                gh api $res.archive_download_url --output (Join-Path $tempDir 'results.zip')
                 $found = $true
                 break
             }

--- a/tests/Get-WindowsJobArtifacts.Tests.ps1
+++ b/tests/Get-WindowsJobArtifacts.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'Get-WindowsJobArtifacts' {
         Mock gh {} -ParameterFilter { $args[0] -eq 'auth' -and $args[1] -eq 'status' }
         Mock gh { '{"workflow_runs":[{"id":1}]}' } -ParameterFilter { $args[1] -like '*runs?*' }
         Mock gh { '{"artifacts":[{"name":"pester-coverage-windows-latest","archive_download_url":"cov"},{"name":"pester-results-windows-latest","archive_download_url":"res"}]}' } -ParameterFilter { $args[1] -like '*artifacts*' }
-        Mock gh {} -ParameterFilter { $args[0] -eq 'cov' -or $args[0] -eq 'res' }
+        Mock gh {} -ParameterFilter { $args[1] -eq 'cov' -or $args[1] -eq 'res' }
 
         & $scriptPath
 


### PR DESCRIPTION
## Summary
- update artifact download commands to use `gh api`
- adjust tests for new CLI invocation

## Testing
- `Invoke-Pester -Script tests/Get-WindowsJobArtifacts.Tests.ps1` *(fails: Could not find Command gh)*
- `pytest -q` *(fails: 1 failed, 32 passed in 0.25s)*

------
https://chatgpt.com/codex/tasks/task_e_6849c6578fe48331a3925baa0f771996