### PR TITLE
Handle null config with ArgumentException

### DIFF
--- a/pwsh/lab_utils/Format-Config.ps1
+++ b/pwsh/lab_utils/Format-Config.ps1
@@ -10,10 +10,12 @@ function Format-Config {
     begin {
         $hasInput = $false
 
-        # Preserve validation behavior when -Config $null is passed explicitly
+        # Throw if -Config $null is supplied explicitly so callers get a
+        # consistent ArgumentException regardless of how input is provided.
         if ($PSBoundParameters.ContainsKey('Config') -and $null -eq $Config) {
-            throw [System.Management.Automation.ParameterBindingValidationException]::new(
-                "Cannot validate argument on parameter 'Config'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+            throw [System.ArgumentException]::new(
+                'A configuration object must be provided via -Config or the pipeline.',
+                'Config'
             )
         }
     }

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -43,7 +43,12 @@ Describe 'Format-Config' {
     }
 
     It 'throws when Config is null' {
-        { Format-Config -Config $null } | Should -Throw -ErrorType [System.ArgumentException]
+        try {
+            Format-Config -Config $null
+            $false | Should -BeTrue
+        } catch {
+            $_.Exception | Should -BeOfType [System.ArgumentException]
+        }
     }
 
     It 'is a terminating error when Config is null' {


### PR DESCRIPTION
## Summary
- throw `System.ArgumentException` when `Format-Config` receives `$null`
- adjust failing test to check exception with try/catch
- ensure `Format-Config.Tests.ps1` passes

## Testing
- `Invoke-Pester -Script tests/Format-Config.Tests.ps1 -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_6849c64deea48331ab5bd0edd2860632