### PR TITLE
Fix example path in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: opentofu/setup-opentofu@v1
       - name: Init and validate
-        working-directory: example-infrastructure
+        working-directory: examples/hyperv
         run: |
           tofu init -input=false 2>&1 | tee init.log
           tofu validate 2>&1 | tee validate.log
@@ -21,14 +21,14 @@ jobs:
         with:
           name: linux-validate-logs
           path: |
-            example-infrastructure/init.log
-            example-infrastructure/validate.log
+            examples/hyperv/init.log
+            examples/hyperv/validate.log
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: linux-validate-artifacts
-          path: example-infrastructure/.terraform
+          path: examples/hyperv/.terraform
 
   windows-validate:
     runs-on: windows-latest
@@ -39,7 +39,7 @@ jobs:
           tofu_wrapper: false
       - name: Init and validate
         shell: pwsh
-        working-directory: example-infrastructure
+        working-directory: examples/hyperv
         run: |
           tofu init -input=false | Tee-Object -FilePath init.log
           tofu validate | Tee-Object -FilePath validate.log
@@ -49,12 +49,12 @@ jobs:
         with:
           name: windows-validate-logs
           path: |
-            example-infrastructure/init.log
-            example-infrastructure/validate.log
+            examples/hyperv/init.log
+            examples/hyperv/validate.log
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: windows-validate-artifacts
-          path: example-infrastructure/.terraform
+          path: examples/hyperv/.terraform
 

--- a/examples/hyperv/modules/README.md
+++ b/examples/hyperv/modules/README.md
@@ -9,4 +9,4 @@ This directory is created by `tofu init` and records which modules were pulled f
 
 ## Relationship to the examples
 
-The files under `example-infrastructure` demonstrate how to apply these modules. `vm_modules.tf` shows repeated invocations of the `vm` module to spin up different operating systems. `WAN-vSwitch.tf` defines the network switch directly for simplicity, but the same result could be achieved by calling the `network_switch` module. The `modules.json` file in this directory is generated automatically and lists the modules used after running `tofu init`.
+The files under `examples/hyperv` demonstrate how to apply these modules. `vm_modules.tf` shows repeated invocations of the `vm` module to spin up different operating systems. `WAN-vSwitch.tf` defines the network switch directly for simplicity, but the same result could be achieved by calling the `network_switch` module. The `modules.json` file in this directory is generated automatically and lists the modules used after running `tofu init`.

--- a/pwsh/runner_scripts/0010_Prepare-HyperVProvider.ps1
+++ b/pwsh/runner_scripts/0010_Prepare-HyperVProvider.ps1
@@ -344,7 +344,7 @@ $null = New-Item -ItemType Directory -Force -Path $infraRepoPath -ErrorAction Si
 
 Write-CustomLog "InfraRepoPath for hyperv provider: $infraRepoPath"
 
-# Determine provider version from example-infrastructure/main.tf
+# Determine provider version from examples/hyperv/main.tf
 try {
     $providerVersion = Get-HyperVProviderVersion
     Write-CustomLog "Using Hyper-V provider version $providerVersion"


### PR DESCRIPTION
## Summary
- update workflow path to `examples/hyperv`
- update module docs
- tweak hyperv provider script comment

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `PYTHONPATH=pwsh pytest -q` *(fails: 1 failed, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6849cbc15168833198776a69277f029e