### PR TITLE
Fix quick start paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 ## Quick start
 
 The easiest way to bootstrap a fresh Windows host is to run the project’s
-`kicker-bootstrap.ps1` script. It installs Git and the GitHub CLI if needed,
+`kicker-bootstrap.ps1` script located under `pwsh/`. It installs Git and the GitHub CLI if needed,
 clones this repository and then launches `runner.ps1`.
 
 
 ```
 
 
-Powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/main/kicker-bootstrap.ps1' -OutFile '.\kicker-bootstrap.ps1'; .\kicker-bootstrap.ps1 -Quiet"
+Powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/main/pwsh/kicker-bootstrap.ps1' -OutFile '.\kicker-bootstrap.ps1'; .\kicker-bootstrap.ps1 -Quiet"
 
 
 ```

--- a/docs/iso_tools.md
+++ b/docs/iso_tools.md
@@ -3,7 +3,7 @@
 The `tools/iso` directory contains scripts for building automated installation media.
 
 - **Customize-ISO.ps1** – Mounts a Windows ISO, injects a `bootstrap.ps1` script and an answer file, then rebuilds a bootable ISO using the Windows ADK.
-- **bootstrap.ps1** – Downloads `kicker-bootstrap.ps1` from this repository and runs it. Used inside customized ISOs.
+- **bootstrap.ps1** – Downloads `pwsh/kicker-bootstrap.ps1` from this repository and runs it. Used inside customized ISOs.
 - **autounattend - generic.xml** – Example unattended installation file for Windows Server.
 - **headlessunattend.xml** – Sample answer file for fully headless deployments.
 - **kickstart.cfg** – Example Kickstart file for automating Linux installations.

--- a/tools/iso/bootstrap.ps1
+++ b/tools/iso/bootstrap.ps1
@@ -4,7 +4,7 @@ param(
 
 Set-ExecutionPolicy -ExecutionPolicy Bypass
 
-$bootstrapUrl = "https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/$Branch/kicker-bootstrap.ps1"
+$bootstrapUrl = "https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/$Branch/pwsh/kicker-bootstrap.ps1"
 Invoke-WebRequest -Uri $bootstrapUrl -OutFile '.\kicker-bootstrap.ps1'
 
 if (Test-Path '.\kicker-bootstrap.ps1') {

--- a/tools/iso/kickstart.cfg
+++ b/tools/iso/kickstart.cfg
@@ -15,7 +15,7 @@ reboot --eject
 %end
 
 %post --log=/root/bootstrap.log
-curl -fsSL https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/kickstart-bootstrap.sh -o /root/kickstart-bootstrap.sh
+curl -fsSL https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/pwsh/kickstart-bootstrap.sh -o /root/kickstart-bootstrap.sh
 chmod +x /root/kickstart-bootstrap.sh
 /root/kickstart-bootstrap.sh
 %end


### PR DESCRIPTION
## Summary
- update README quick start instructions for new location of `kicker-bootstrap.ps1`
- adjust helper scripts and docs referencing bootstrap files

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Cleanup-Files script, 85 other tests)*
- `pytest -q` *(fails: ModuleNotFoundError: lab_utils)*

------
https://chatgpt.com/codex/tasks/task_e_6849cd43f1f48331b90c936e66e83518