### PR TITLE
Fix Python path tests and index shortcuts

### DIFF
--- a/py/labctl/path_index.py
+++ b/py/labctl/path_index.py
@@ -31,6 +31,10 @@ def load_index() -> dict:
         if index_path.exists() and yaml is not None:
             with index_path.open('r') as f:
                 _INDEX = yaml.safe_load(f) or {}
+            # add basename shortcuts for quick lookup
+            for key, rel in list(_INDEX.items()):
+                name = Path(key).name
+                _INDEX.setdefault(name, rel)
         else:
             _INDEX = {}
     return _INDEX

--- a/py/tests/test_get_platform.py
+++ b/py/tests/test_get_platform.py
@@ -2,7 +2,8 @@ import platform
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+# Add the PowerShell helper directory so `lab_utils` can be imported.
+sys.path.append(str(Path(__file__).resolve().parents[2] / "pwsh"))
 
 from lab_utils.get_platform import get_platform
 


### PR DESCRIPTION
## Summary
- ensure path_index loads shortcut keys for filenames
- adjust platform test path to include PowerShell helpers

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ce60f544833185a6e24ecd4dc4ea