### PR TITLE
Fix poetry install on Windows packaging job

### DIFF
--- a/.github/workflows/package-labctl.yml
+++ b/.github/workflows/package-labctl.yml
@@ -19,7 +19,9 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
       - name: Cache Poetry
         uses: actions/cache@v4
         with:

--- a/.github/workflows/package-labctl.yml
+++ b/.github/workflows/package-labctl.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry
+          python -m pip install poetry==1.4.0
       - name: Cache Poetry
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- fix 'Package labctl' workflow by installing Poetry with pip

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6849ce7eaebc833191c207eee8108b64