### PR TITLE
Fix PSScriptAnalyzer detection in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,8 @@ jobs:
       - name: Install PSScriptAnalyzer
         shell: pwsh
         run: |
-          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer -RequiredVersion 1.24.0)) {
+          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer |
+              Where-Object { $_.Version -ge [version]'1.24.0' })) {
             Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.24.0 -Scope CurrentUser -Force
           }
       - name: Install powershell-yaml

--- a/newsfragments/lint-workflow-requiredversion.bugfix
+++ b/newsfragments/lint-workflow-requiredversion.bugfix
@@ -1,0 +1,1 @@
+Fixes the Windows lint job by checking the installed PSScriptAnalyzer version without using the unsupported `RequiredVersion` parameter.


### PR DESCRIPTION
## Summary
- avoid the `-RequiredVersion` parameter which is not supported on Windows
- note the change in a newsfragment

## Testing
- `Invoke-Pester` *(fails: Cleanup-Files script, Install-ValidationTools, etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer', 'lab_utils')*

------
https://chatgpt.com/codex/tasks/task_e_6849ce9a13cc8331b8ae8f18b427464c