### PR TITLE
Fix default config path

### DIFF
--- a/docs/python-cli.md
+++ b/docs/python-cli.md
@@ -1,6 +1,6 @@
 # labctl Python CLI
 
-The `labctl` command line tool exposes cross-platform helpers written in Python. It reads its settings from a JSON or YAML configuration file, loading `config_files/default-config.json` when no explicit path is given.
+The `labctl` command line tool exposes cross-platform helpers written in Python. It reads its settings from a JSON or YAML configuration file, loading `configs/config_files/default-config.json` when no explicit path is given.
 All important scripts and modules are listed in `path-index.yaml` at the repository root. The file is kept up to date by a workflow that runs on each push to `main`, but you can run `python scripts/update_index.py` to rebuild it manually. The `labctl.path_index` module loads the file and provides `load_index()` and `resolve_path(key)` helpers.
 
 

--- a/path-index.yaml
+++ b/path-index.yaml
@@ -26,6 +26,7 @@ pwsh/lab_utils/Resolve-ProjectPath.ps1: pwsh/lab_utils/Resolve-ProjectPath.ps1
 pwsh/lab_utils/__init__.py: pwsh/lab_utils/__init__.py
 pwsh/lab_utils/get_platform.py: pwsh/lab_utils/get_platform.py
 pwsh/runner.ps1: pwsh/runner.ps1
+runner.ps1: pwsh/runner.ps1
 pwsh/runner_scripts/0000_Cleanup-Files.ps1: pwsh/runner_scripts/0000_Cleanup-Files.ps1
 pwsh/runner_scripts/0001_Reset-Git.ps1: pwsh/runner_scripts/0001_Reset-Git.ps1
 pwsh/runner_scripts/0002_Setup-Directories.ps1: pwsh/runner_scripts/0002_Setup-Directories.ps1

--- a/py/labctl/cli.py
+++ b/py/labctl/cli.py
@@ -14,7 +14,7 @@ from . import github_utils, issue_parser, update_index
 def default_config_path() -> Path:
     """Return the path to the default configuration file."""
 
-    resolved = resolve_path("config_files/default-config.json")
+    resolved = resolve_path("configs/config_files/default-config.json")
     if resolved:
         return resolved
     return Path(files("labctl").joinpath("config_files", "default-config.json"))


### PR DESCRIPTION
## Summary
- reference `configs/config_files` when resolving default config
- document the updated path
- ensure the repository index contains `runner.ps1`

## Testing
- `PYTHONPATH=$PWD/pwsh pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: BeforeAll \ AfterAll failed)*

------
https://chatgpt.com/codex/tasks/task_e_6849ce175fac8331abb406bbb81b7021