### PR TITLE
Use gh copilot extension in workflows

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -131,7 +131,7 @@ jobs:
                 body
               });
             }
-      - name: Set up Copilot
-        run: npm install -g @githubnext/github-copilot-cli
+      - name: Install Copilot extension
+        run: gh extension install github/gh-copilot --force
       - name: Copilot remediation tips
-        run: github-copilot-cli suggest --repo ${{ github.repository }}
+        run: gh copilot suggest "Suggest improvements" || true

--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -134,4 +134,5 @@ jobs:
       - name: Install Copilot extension
         run: gh extension install github/gh-copilot --force
       - name: Copilot remediation tips
-        run: gh copilot suggest "Suggest improvements" || true
+        run: |
+          gh copilot suggest "Suggest improvements" || echo "Warning: Copilot suggestion command failed, but continuing workflow."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,4 +72,4 @@ jobs:
       - name: Install Copilot extension
         run: gh extension install github/gh-copilot --force
       - name: Run Copilot suggestions
-        run: gh copilot suggest "Suggest improvements" || true
+        run: gh copilot suggest "Suggest improvements"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: |
           yamllint .github/workflows $(git ls-files '*.yml' '*.yaml')
-      - name: Set up Copilot
-        run: npm install -g @githubnext/github-copilot-cli
+      - name: Install Copilot extension
+        run: gh extension install github/gh-copilot --force
       - name: Run Copilot suggestions
-        run: github-copilot-cli suggest --repo ${{ github.repository }}
+        run: gh copilot suggest "Suggest improvements" || true

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Individual step scripts can also be invoked this way when debugging:
 pwsh -File pwsh/runner_scripts/0001_Reset-Git.ps1 -Config ./configs/config_files/default-config.json
 ```
 
-The lint workflow installs the GitHub Copilot CLI and runs `github-copilot-cli suggest`
+The lint workflow installs the GitHub Copilot extension and runs `gh copilot suggest`
 after linting. The command scans the repository and provides additional
 improvement ideas directly in the workflow logs.
 


### PR DESCRIPTION
## Summary
- switch to the GitHub CLI Copilot extension in lint and failure workflows
- update README to reference `gh copilot suggest`

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'lab_utils')*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cecc137083319a055aead814ce6a