### PR TITLE
Fix CustomLint script path

### DIFF
--- a/tests/CustomLint.Tests.ps1
+++ b/tests/CustomLint.Tests.ps1
@@ -2,7 +2,7 @@
 
 Describe 'CustomLint.ps1' {
     BeforeAll {
-        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'scripts' 'CustomLint.ps1'
+        $script:ScriptPath = Join-Path $PSScriptRoot '..' 'tools' 'iso' 'CustomLint.ps1'
     }
 
     It 'parses without errors' {
@@ -27,7 +27,11 @@ Describe 'CustomLint.ps1' {
 
     It 'returns exit code 0 when no errors' {
         Mock Invoke-ScriptAnalyzer { @() }
-        & $script:ScriptPath -Target $PSScriptRoot > $null
+        $goodDir = Join-Path $TestDrive 'clean'
+        New-Item -ItemType Directory -Path $goodDir | Out-Null
+        $good = Join-Path $goodDir 'good.ps1'
+        'Write-Host hello' | Set-Content $good
+        & $script:ScriptPath -Target $goodDir > $null
         $LASTEXITCODE | Should -Be 0
     }
 }

--- a/tools/iso/CustomLint.ps1
+++ b/tools/iso/CustomLint.ps1
@@ -1,28 +1,33 @@
 [CmdletBinding()]
 param(
     [string]$Target = '.',
-    [string]$SettingsPath = (Join-Path $PSScriptRoot '..' 'PSScriptAnalyzerSettings.psd1')
+    [string]$SettingsPath = (Join-Path $PSScriptRoot '..' '..' 'pwsh' 'PSScriptAnalyzerSettings.psd1')
 )
 
 $ErrorActionPreference = 'Stop'
+
 
 if (-not (Test-Path $SettingsPath)) {
     throw "Settings file not found: $SettingsPath"
 }
 
-$results = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
-    Select-Object -ExpandProperty FullName |
-    Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
-$results | Format-Table
+# Load analyzer settings from the specified file
+$settings = Import-PowerShellDataFile -Path $SettingsPath
+$include = $settings.Rules.IncludeRules
+$exclude = $settings.Rules.ExcludeRules
 
+# Discover all PowerShell files to analyze
+$files = Get-ChildItem -Path $Target -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
+    Select-Object -ExpandProperty FullName
 
-$results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -Settings $SettingsPath
+# Run Script Analyzer against the collected files
+$results = $files | Invoke-ScriptAnalyzer -Severity Error,Warning -IncludeRule $include -ExcludeRule $exclude
 # Use Write-Output so callers can capture or redirect the formatted results
 $results | Format-Table | Out-String | Write-Output
 
 $failed = $false
 if ($results | Where-Object Severity -eq 'Error') {
-    Write-Error 'ScriptAnalyzer errors detected'
+    Write-Error 'ScriptAnalyzer errors detected' -ErrorAction Continue
     $failed = $true
 }
 
@@ -36,15 +41,19 @@ foreach ($file in $files) {
         if ($first -and $first.Extent.Text -match 'Invoke-WebRequest') {
             $hasFilter = $c.CommandElements | Where-Object { $_ -is [System.Management.Automation.Language.CommandParameterAst] -and $_.ParameterName -eq 'ParameterFilter' }
             if (-not $hasFilter) {
-                $mockIssues += "$file:$($c.Extent.StartLineNumber) Mock Invoke-WebRequest missing -ParameterFilter"
+                $mockIssues += "${file}:$($c.Extent.StartLineNumber) Mock Invoke-WebRequest missing -ParameterFilter"
             }
         }
     }
 }
 if ($mockIssues) {
     $mockIssues | ForEach-Object { Write-Warning $_ }
-    Write-Error 'Mock lint errors detected'
+    Write-Error 'Mock lint errors detected' -ErrorAction Continue
     $failed = $true
 }
 
-if ($failed) { exit 1 }
+if ($failed) {
+    $global:LASTEXITCODE = 1
+    return
+}
+$global:LASTEXITCODE = 0


### PR DESCRIPTION
## Summary
- adjust CustomLint's default settings path
- load PSScriptAnalyzer settings and pass include/exclude rules
- preserve exit code without terminating the session
- update tests for new location and clean test directory

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script tests/CustomLint.Tests.ps1"`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration (Import-PowerShellDataFile 'tests/PesterConfiguration.psd1')"` *(fails: BeforeAll/AfterAll errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849c64c995c8331bbff4748334abbb3