### PR TITLE
Use path index in UI

### DIFF
--- a/py/labctl/ui.py
+++ b/py/labctl/ui.py
@@ -4,6 +4,8 @@ import json
 import os
 from pathlib import Path
 
+from .path_index import resolve_path
+
 from textual.app import App, ComposeResult
 from textual.widgets import Header, Footer, DataTable, TextLog, TabPane, TabbedContent, Markdown
 
@@ -59,10 +61,21 @@ class LabUI(App):
 def run_ui() -> None:
     """Launch the Textual UI."""
     repo_root = Path(__file__).resolve().parents[2]
-    script_dir = repo_root / "pwsh" / "runner_scripts"
+
+    script_dir = resolve_path("pwsh/runner_scripts")
+    if script_dir is None:
+        script_dir = repo_root / "pwsh" / "runner_scripts"
     scripts = sorted(p.name for p in script_dir.glob("????_*.ps1"))
+
     log_dir = Path(os.environ.get("LAB_LOG_DIR", Path.cwd()))
     log_path = log_dir / "lab.log"
-    default_cfg = repo_root / "configs" / "config_files" / "default-config.json"
-    recommended_cfg = repo_root / "configs" / "config_files" / "recommended-config.json"
+
+    default_cfg = resolve_path("configs/config_files/default-config.json")
+    if default_cfg is None:
+        default_cfg = repo_root / "configs" / "config_files" / "default-config.json"
+
+    recommended_cfg = resolve_path("configs/config_files/recommended-config.json")
+    if recommended_cfg is None:
+        recommended_cfg = repo_root / "configs" / "config_files" / "recommended-config.json"
+
     LabUI(scripts, log_path, default_cfg, recommended_cfg).run()

--- a/py/tests/test_ui.py
+++ b/py/tests/test_ui.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import importlib
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from labctl import path_index
+import labctl.ui as ui
+
+
+def test_run_ui_with_repo_root(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "pwsh" / "runner_scripts"
+    scripts_dir.mkdir(parents=True)
+    script = scripts_dir / "0001_Test.ps1"
+    script.write_text("Write-Host test")
+
+    cfg_dir = repo / "configs" / "config_files"
+    cfg_dir.mkdir(parents=True)
+    default_cfg = cfg_dir / "default-config.json"
+    default_cfg.write_text("{}")
+    recommended_cfg = cfg_dir / "recommended-config.json"
+    recommended_cfg.write_text("{}")
+
+    index = {
+        "pwsh/runner_scripts": "pwsh/runner_scripts",
+        "configs/config_files/default-config.json": "configs/config_files/default-config.json",
+        "configs/config_files/recommended-config.json": "configs/config_files/recommended-config.json",
+    }
+    import yaml
+    (repo / "path-index.yaml").write_text(yaml.safe_dump(index))
+
+    monkeypatch.setenv("LAB_REPO_ROOT", str(repo))
+    monkeypatch.setenv("LAB_LOG_DIR", str(tmp_path / "logs"))
+
+    monkeypatch.setattr(path_index, "_INDEX", {})
+    monkeypatch.setattr(path_index, "_repo_root", None)
+    importlib.reload(path_index)
+    importlib.reload(ui)
+
+    captured = {}
+
+    def fake_run(self):
+        captured["scripts"] = self.scripts
+        captured["log"] = self.log_path
+        captured["default"] = self.default_config
+        captured["recommended"] = self.recommended_config
+
+    monkeypatch.setattr(ui.LabUI, "run", fake_run)
+
+    ui.run_ui()
+
+    assert captured["default"] == default_cfg
+    assert captured["recommended"] == recommended_cfg
+    assert script.name in captured["scripts"]


### PR DESCRIPTION
## Summary
- use resolve_path() to find scripts and configs in the UI
- add a new pytest to verify `run_ui` respects LAB_REPO_ROOT

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d24639a48331a77e3342e6294383