### PR TITLE
Document LAB_REPO_ROOT usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ subcommands via `poetry run`. Set `InstallPoetry` in your configuration to have
 the version with `PoetryVersion`.
 
 Important script locations are tracked in `path-index.yaml`. A GitHub workflow regenerates it on each push to `main`, but you can also run `python scripts/update_index.py` manually. Use `labctl.path_index.resolve_path()` to look up paths from Python or the helper in `runner.ps1`.
+When running packaged tools, set the `LAB_REPO_ROOT` environment variable to point at your checkout so the CLI can locate `path-index.yaml` correctly.
 
 
 ```bash

--- a/docs/python-cli.md
+++ b/docs/python-cli.md
@@ -2,6 +2,7 @@
 
 The `labctl` command line tool exposes cross-platform helpers written in Python. It reads its settings from a JSON or YAML configuration file, loading `configs/config_files/default-config.json` when no explicit path is given.
 All important scripts and modules are listed in `path-index.yaml` at the repository root. The file is kept up to date by a workflow that runs on each push to `main`, but you can run `python scripts/update_index.py` to rebuild it manually. The `labctl.path_index` module loads the file and provides `load_index()` and `resolve_path(key)` helpers.
+Set `LAB_REPO_ROOT` if the CLI cannot determine the repository root when run from a packaged install.
 
 
 ## Subcommands


### PR DESCRIPTION
## Summary
- mention `LAB_REPO_ROOT` in the README Python CLI section
- add quick note about `LAB_REPO_ROOT` in Python CLI docs

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6849d24d34e48331a216e5d14decedc9