### PR TITLE
Improve Resolve-ProjectPath with index lookup

### DIFF
--- a/pwsh/lab_utils/Resolve-ProjectPath.ps1
+++ b/pwsh/lab_utils/Resolve-ProjectPath.ps1
@@ -15,7 +15,7 @@ function Resolve-ProjectPath {
         if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
             try { Import-Module powershell-yaml -ErrorAction Stop } catch {}
         }
-        try { $index = Get-Content -Raw -Path $indexPath | ConvertFrom-Yaml } catch { $index = @{} }
+        try { $index = [hashtable](Get-Content -Raw -Path $indexPath | ConvertFrom-Yaml) } catch { $index = @{} }
         if ($index.ContainsKey($Name)) { return (Join-Path $Root $index[$Name]) }
         foreach ($key in $index.Keys) {
             if ((Split-Path $key -Leaf) -eq $Name) {

--- a/pwsh/lab_utils/Resolve-ProjectPath.ps1
+++ b/pwsh/lab_utils/Resolve-ProjectPath.ps1
@@ -10,6 +10,20 @@ function Resolve-ProjectPath {
         $Root = (Resolve-Path $Root).Path
     }
 
+    $indexPath = Join-Path $Root 'path-index.yaml'
+    if (Test-Path $indexPath) {
+        if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+            try { Import-Module powershell-yaml -ErrorAction Stop } catch {}
+        }
+        try { $index = Get-Content -Raw -Path $indexPath | ConvertFrom-Yaml } catch { $index = @{} }
+        if ($index.ContainsKey($Name)) { return (Join-Path $Root $index[$Name]) }
+        foreach ($key in $index.Keys) {
+            if ((Split-Path $key -Leaf) -eq $Name) {
+                return (Join-Path $Root $index[$key])
+            }
+        }
+    }
+
     $match = Get-ChildItem -Path $Root -Recurse -File -Filter $Name -ErrorAction SilentlyContinue | Select-Object -First 1
     if ($null -ne $match) { return $match.FullName }
     return $null

--- a/pwsh/lab_utils/Resolve-ProjectPath.ps1
+++ b/pwsh/lab_utils/Resolve-ProjectPath.ps1
@@ -19,7 +19,9 @@ function Resolve-ProjectPath {
         if ($index.ContainsKey($Name)) { return (Join-Path $Root $index[$Name]) }
         foreach ($key in $index.Keys) {
             if ((Split-Path $key -Leaf) -eq $Name) {
-                return (Join-Path $Root $index[$key])
+                $normalizedPath = $index[$key] -split '[\\/]' | ForEach-Object { $_ }
+                $normalizedPath = $normalizedPath | Join-Path -Path $null
+                return (Join-Path $Root $normalizedPath)
             }
         }
     }

--- a/tests/Resolve-ProjectPath.Tests.ps1
+++ b/tests/Resolve-ProjectPath.Tests.ps1
@@ -19,4 +19,16 @@ Describe 'Resolve-ProjectPath' {
         $expected = Join-Path $dir2 'test.ps1'
         Resolve-ProjectPath -Name 'test.ps1' -Root $root | Should -Be $expected
     }
+
+    It 'resolves path from path-index.yaml' {
+        $root = Join-Path $TestDrive 'repo2'
+        $scripts = Join-Path $root 'scripts'
+        New-Item -ItemType Directory -Path $scripts -Force | Out-Null
+        $file = Join-Path $scripts 'script.ps1'
+        'hi' | Set-Content -Path $file
+        "scripts/script.ps1: scripts/script.ps1" | Set-Content -Path (Join-Path $root 'path-index.yaml')
+
+        $expected = Join-Path $root 'scripts' 'script.ps1'
+        Resolve-ProjectPath -Name 'script.ps1' -Root $root | Should -Be $expected
+    }
 }


### PR DESCRIPTION
## Summary
- support path-index.yaml in `Resolve-ProjectPath.ps1`
- add path-index test case for `Resolve-ProjectPath`

## Testing
- `Invoke-Pester -Path tests/Resolve-ProjectPath.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6849d248fa408331a287d1e2d26af4ba