### PR TITLE
Refine Download-Archive error handling

### DIFF
--- a/pwsh/lab_utils/Download-Archive.ps1
+++ b/pwsh/lab_utils/Download-Archive.ps1
@@ -11,7 +11,9 @@ function Download-Archive {
         gh api $Url --output $Destination
         if ($LASTEXITCODE -ne 0) {
             Write-Host "Failed to download $(Split-Path $Destination -Leaf) artifact." -ForegroundColor Yellow
-            if ($Required) { exit 1 }
+            if ($Required) {
+                throw "Download failed for required artifact: $(Split-Path $Destination -Leaf)."
+            }
         }
     }
     else {
@@ -21,7 +23,9 @@ function Download-Archive {
         }
         catch {
             Write-Host "Failed to download $(Split-Path $Destination -Leaf) artifact anonymously." -ForegroundColor Yellow
-            if ($Required) { exit 1 }
+            if ($Required) {
+                throw "Download failed for required artifact: $(Split-Path $Destination -Leaf)."
+            }
         }
     }
 }

--- a/tests/Download-Archive.Tests.ps1
+++ b/tests/Download-Archive.Tests.ps1
@@ -1,0 +1,36 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+Import-Module (Join-Path $PSScriptRoot '..' 'pwsh' 'lab_utils' 'Download-Archive.psm1') -Force
+
+InModuleScope Download-Archive {
+Describe 'Download-Archive' {
+    BeforeEach {
+        function global:gh {}
+        Mock gh {}
+        Mock Invoke-WebRequest {}
+        Mock Write-Host {}
+    }
+
+    It 'uses gh CLI when -UseGh' {
+        Download-Archive 'url' 'dest' -UseGh
+        Should -Invoke -CommandName gh -Times 1
+        Should -Invoke -CommandName Invoke-WebRequest -Times 0
+    }
+
+    It 'uses Invoke-WebRequest when -UseGh not specified' {
+        Download-Archive 'url' 'dest'
+        Should -Invoke -CommandName gh -Times 0
+        Should -Invoke -CommandName Invoke-WebRequest -Times 1
+    }
+
+    It 'throws when gh download fails and -Required' {
+        Mock gh { } -ParameterFilter { $args[0] -eq 'api' }
+        $global:LASTEXITCODE = 1
+        { Download-Archive 'url' 'dest' -Required -UseGh } | Should -Throw
+    }
+
+    It 'throws when Invoke-WebRequest fails and -Required' {
+        Mock Invoke-WebRequest { throw 'err' }
+        { Download-Archive 'url' 'dest' -Required } | Should -Throw
+    }
+}
+}


### PR DESCRIPTION
## Summary
- throw when Download-Archive fails instead of exiting
- cover Download-Archive with new Pester tests
- adjust Get-WindowsJobArtifacts tests to define mocked `gh` command

## Testing
- `pytest -q`
- `Invoke-Pester -Script tests/Download-Archive.Tests.ps1` *(fails: none)*
- `Invoke-Pester -Script tests/Get-WindowsJobArtifacts.Tests.ps1` *(fails: environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_6849d3014c048331a3efe238e20a07ee