### PR TITLE
Normalize path handling

### DIFF
--- a/path-index.yaml
+++ b/path-index.yaml
@@ -24,6 +24,7 @@ pwsh/lab_utils/LabSetup/Logger.ps1: pwsh/lab_utils/LabSetup/Logger.ps1
 pwsh/lab_utils/LabSetup/ScriptTemplate.ps1: pwsh/lab_utils/LabSetup/ScriptTemplate.ps1
 pwsh/lab_utils/Menu.ps1: pwsh/lab_utils/Menu.ps1
 pwsh/lab_utils/Network.ps1: pwsh/lab_utils/Network.ps1
+pwsh/lab_utils/PathUtils.ps1: pwsh/lab_utils/PathUtils.ps1
 pwsh/lab_utils/Resolve-ProjectPath.ps1: pwsh/lab_utils/Resolve-ProjectPath.ps1
 pwsh/lab_utils/__init__.py: pwsh/lab_utils/__init__.py
 pwsh/lab_utils/get_platform.py: pwsh/lab_utils/get_platform.py

--- a/pwsh/lab_utils/PathUtils.ps1
+++ b/pwsh/lab_utils/PathUtils.ps1
@@ -1,0 +1,8 @@
+function Normalize-RelativePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+    $segments = $Path -split '[\\/]+'
+    $segments | Join-Path -Path $null
+}

--- a/pwsh/lab_utils/PathUtils.ps1
+++ b/pwsh/lab_utils/PathUtils.ps1
@@ -1,7 +1,7 @@
 function Normalize-RelativePath {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$Path
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$Path
     )
     $segments = $Path -split '[\\/]+'
     $segments | Join-Path -Path $null

--- a/pwsh/lab_utils/Resolve-ProjectPath.ps1
+++ b/pwsh/lab_utils/Resolve-ProjectPath.ps1
@@ -1,3 +1,5 @@
+. (Join-Path $PSScriptRoot 'PathUtils.ps1')
+
 function Resolve-ProjectPath {
     [CmdletBinding()]
     param(
@@ -16,11 +18,13 @@ function Resolve-ProjectPath {
             try { Import-Module powershell-yaml -ErrorAction Stop } catch {}
         }
         try { $index = [hashtable](Get-Content -Raw -Path $indexPath | ConvertFrom-Yaml) } catch { $index = @{} }
-        if ($index.ContainsKey($Name)) { return (Join-Path $Root $index[$Name]) }
+        if ($index.ContainsKey($Name)) {
+            $normalizedPath = Normalize-RelativePath $index[$Name]
+            return (Join-Path $Root $normalizedPath)
+        }
         foreach ($key in $index.Keys) {
             if ((Split-Path $key -Leaf) -eq $Name) {
-                $normalizedPath = $index[$key] -split '[\\/]' | ForEach-Object { $_ }
-                $normalizedPath = $normalizedPath | Join-Path -Path $null
+                $normalizedPath = Normalize-RelativePath $index[$key]
                 return (Join-Path $Root $normalizedPath)
             }
         }

--- a/pwsh/runner.ps1
+++ b/pwsh/runner.ps1
@@ -21,10 +21,13 @@ if (Test-Path $indexPath) {
     try { $script:PathIndex = Get-Content -Raw -Path $indexPath | ConvertFrom-Yaml } catch { $script:PathIndex = @{} }
 }
 
+. (Join-Path (Join-Path $repoRoot 'lab_utils') 'PathUtils.ps1')
+
 function Resolve-IndexPath {
     param([string]$Key)
     if ($script:PathIndex.ContainsKey($Key)) {
-        return Join-Path $repoRoot $script:PathIndex[$Key]
+        $relative = Normalize-RelativePath $script:PathIndex[$Key]
+        return Join-Path $repoRoot $relative
     }
     return $null
 }

--- a/pwsh/runner.ps1
+++ b/pwsh/runner.ps1
@@ -21,7 +21,7 @@ if (Test-Path $indexPath) {
     try { $script:PathIndex = Get-Content -Raw -Path $indexPath | ConvertFrom-Yaml } catch { $script:PathIndex = @{} }
 }
 
-. (Join-Path (Join-Path $repoRoot 'lab_utils') 'PathUtils.ps1')
+. (Join-Path $repoRoot 'lab_utils' 'PathUtils.ps1')
 
 function Resolve-IndexPath {
     param([string]$Key)

--- a/tests/PathUtils.Tests.ps1
+++ b/tests/PathUtils.Tests.ps1
@@ -1,0 +1,19 @@
+. (Join-Path $PSScriptRoot 'TestDriveCleanup.ps1')
+
+Describe 'Normalize-RelativePath' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..' 'pwsh' 'lab_utils' 'PathUtils.ps1')
+    }
+
+    It 'joins mixed separators into platform path' {
+        $input = 'folder/subdir\\file.txt'
+        $expected = Join-Path (Join-Path 'folder' 'subdir') 'file.txt'
+        Normalize-RelativePath $input | Should -Be $expected
+    }
+
+    It 'handles trailing separators' {
+        $input = 'a/b/c/'
+        $expected = Join-Path (Join-Path 'a' 'b') 'c'
+        Normalize-RelativePath $input | Should -Be $expected
+    }
+}

--- a/tests/Resolve-ProjectPath.Tests.ps1
+++ b/tests/Resolve-ProjectPath.Tests.ps1
@@ -31,4 +31,16 @@ Describe 'Resolve-ProjectPath' {
         $expected = Join-Path $root 'scripts' 'script.ps1'
         Resolve-ProjectPath -Name 'script.ps1' -Root $root | Should -Be $expected
     }
+
+    It 'resolves direct index entry with normalized separators' {
+        $root = Join-Path $TestDrive 'repo3'
+        $scripts = Join-Path $root 'scripts'
+        New-Item -ItemType Directory -Path $scripts -Force | Out-Null
+        $file = Join-Path $scripts 'script.ps1'
+        'hi' | Set-Content -Path $file
+        "script.ps1: scripts/script.ps1" | Set-Content -Path (Join-Path $root 'path-index.yaml')
+
+        $expected = Join-Path $root 'scripts' 'script.ps1'
+        Resolve-ProjectPath -Name 'script.ps1' -Root $root | Should -Be $expected
+    }
 }


### PR DESCRIPTION
## Summary
- add `Normalize-RelativePath` helper
- refactor `Resolve-ProjectPath.ps1` and `runner.ps1` to use the helper
- cover `Normalize-RelativePath` with new Pester tests
- update `path-index.yaml`

## Testing
- `Invoke-Pester` *(fails: 48 passed, 88 failed)*
- `pytest -q` *(fails: ImportError: TextLog)*

------
https://chatgpt.com/codex/tasks/task_e_6849d4549a708331b4a82fa3f57d76b4