### PR TITLE
Fix packaging workflow

### DIFF
--- a/.github/workflows/package-labctl.yml
+++ b/.github/workflows/package-labctl.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry==1.4.0
+          python -m pip install poetry==1.6.1
       - name: Cache Poetry
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- use Poetry 1.6.1 in the packaging workflow

## Testing
- `poetry run pytest -q`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d9f876948331878c1ac357f97caf