### PR TITLE
Fix GH token export for artifact fetch

### DIFF
--- a/.github/workflows/issue-on-fail.yml
+++ b/.github/workflows/issue-on-fail.yml
@@ -42,6 +42,7 @@ jobs:
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
         run: |
+          export GH_TOKEN="${GH_TOKEN}"
           run_id="${RUN_ID:-${{ github.event.workflow_run.id }}}"
           gh run download "$run_id" -D artifacts || true
 


### PR DESCRIPTION
## Summary
- ensure GH_TOKEN is explicitly exported before calling `gh run download`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*
- `task test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dae19d50833196d36574a018f7e5