### PR TITLE
Fix PSScriptAnalyzer path in lint workflow

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Run Script Analyzer
       shell: pwsh
       run: |
-          $settings = Join-Path $PWD 'PSScriptAnalyzerSettings.psd1'
+          $settings = Join-Path $PWD 'pwsh/PSScriptAnalyzerSettings.psd1'
           $files = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
               Where-Object { $_.FullName -ne $settings } |
               Select-Object -ExpandProperty FullName

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,7 +80,7 @@ jobs:
         shell: pwsh
         run: |
           $log = $env:LOG_FILE
-          $settings = Join-Path $PWD 'PSScriptAnalyzerSettings.psd1'
+          $settings = Join-Path $PWD 'pwsh/PSScriptAnalyzerSettings.psd1'
           $files = Get-ChildItem -Path . -Recurse -Include *.ps1,*.psm1,*.psd1 -File |
               Where-Object { $_.FullName -ne $settings } |
               Select-Object -ExpandProperty FullName


### PR DESCRIPTION
## Summary
- point Script Analyzer to correct settings file

## Testing
- `Invoke-Pester` *(fails: Cleanup-Files script, 0002_Setup-Directories, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6849da62ca88833187a72fe664500b3d