### PR TITLE
Add troubleshooting guide for Copilot Codespaces

### DIFF
--- a/docs/copilot-codespaces.md
+++ b/docs/copilot-codespaces.md
@@ -1,0 +1,38 @@
+# Debugging tests in Codespaces with Copilot agent
+
+This guide explains how to use GitHub Codespaces together with Copilot in agent mode to troubleshoot failing tests.
+
+## Launch a Codespace
+
+1. Open the **Code** drop-down on the repository page and choose **Create codespace**.
+2. Wait for the container to build and connect.
+
+## Install dependencies
+
+Inside the codespace terminal run:
+
+```bash
+./tools/setup-tests.sh
+```
+
+This installs PowerShell modules and the Python packages required for the Pester and pytest suites.
+
+## Run the tests
+
+```bash
+pwsh -NoLogo -NoProfile -Command "Invoke-Pester"
+pytest py
+```
+
+Review any failures in the terminal output or in the generated `artifacts` folder.
+
+## Use Copilot agent mode
+
+1. Open the **Copilot Chat** view in VS Code.
+2. Enable **Agent** mode and ask Copilot for help, for example:
+   ```
+   /agent troubleshoot failing tests
+   ```
+3. Follow the suggestions to inspect logs, locate error messages and propose fixes.
+
+For manual steps on interpreting `testResults.xml` and `coverage.xml`, see [Troubleshooting CI](troubleshooting.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,4 +22,5 @@ The [root README](../README.md) provides quick start instructions. Additional gu
 - [Hyper-V provider configuration](hyperv-provider.md)
 - [Troubleshooting CI](troubleshooting.md)
 - [Testing guidelines](testing.md)
+- [Debugging with Copilot Codespaces](copilot-codespaces.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
   - Lab Utils: docs/lab_utils.md
   - ISO Tools: docs/iso_tools.md
   - Copilot Auto Fix: docs/copilot-auto-fix.md
+  - Copilot Codespaces: docs/copilot-codespaces.md
   - Python CLI: docs/python-cli.md
   - Troubleshooting: docs/troubleshooting.md
   - Changelog: docs/changelog.md


### PR DESCRIPTION
## Summary
- document how to debug failing tests with Copilot in Codespaces
- link new guide from the docs index and MkDocs navigation

## Testing
- `mkdocs build`
- `pytest -q` *(fails: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_6849dcde7bd88331bfdce8f37d0a2a29