### PR TITLE
Fix kicker bootstrap script URLs

### DIFF
--- a/newsfragments/fix-bootstrap-url.bugfix
+++ b/newsfragments/fix-bootstrap-url.bugfix
@@ -1,0 +1,1 @@
+Fix bootstrap script URLs.

--- a/pwsh/kicker-bootstrap.ps1
+++ b/pwsh/kicker-bootstrap.ps1
@@ -56,7 +56,7 @@ if (-not (Test-Path $loggerPath)) {
     if (-not (Test-Path $loggerDir)) {
         New-Item -ItemType Directory -Path $loggerDir -Force | Out-Null
     }
-    $loggerUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/lab_utils/LabRunner/Logger.ps1'
+    $loggerUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/pwsh/lab_utils/LabRunner/Logger.ps1'
     Invoke-WebRequest -Uri $loggerUrl -OutFile $loggerPath
 }
 try {
@@ -128,14 +128,14 @@ if (-not (Test-Path $labConfigScript)) {
     if (-not (Test-Path $labUtilsDir)) {
         New-Item -ItemType Directory -Path $labUtilsDir -Force | Out-Null
     }
-    $labConfigUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/lab_utils/Get-LabConfig.ps1'
+    $labConfigUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/pwsh/lab_utils/Get-LabConfig.ps1'
     Invoke-WebRequest -Uri $labConfigUrl -OutFile $labConfigScript
 }
 if (-not (Test-Path $formatScript)) {
     if (-not (Test-Path $labUtilsDir)) {
         New-Item -ItemType Directory -Path $labUtilsDir -Force | Out-Null
     }
-    $formatUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/lab_utils/Format-Config.ps1'
+    $formatUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/pwsh/lab_utils/Format-Config.ps1'
     Invoke-WebRequest -Uri $formatUrl -OutFile $formatScript
 }
 . $labConfigScript

--- a/pwsh/kicker-bootstrap.ps1
+++ b/pwsh/kicker-bootstrap.ps1
@@ -56,7 +56,7 @@ if (-not (Test-Path $loggerPath)) {
     if (-not (Test-Path $loggerDir)) {
         New-Item -ItemType Directory -Path $loggerDir -Force | Out-Null
     }
-    $loggerUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/main/pwsh/lab_utils/LabRunner/Logger.ps1'
+    $loggerUrl = "${baseUrl}main/pwsh/lab_utils/LabRunner/Logger.ps1"
     Invoke-WebRequest -Uri $loggerUrl -OutFile $loggerPath
 }
 try {


### PR DESCRIPTION
## Summary
- fix remote paths in `kicker-bootstrap.ps1`
- add towncrier newsfragment about bug fix

## Testing
- `pytest -q`
- `ruff check .`
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path pwsh -Recurse"` *(fails: `pwsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849e22ae9d48331afaeb8c6e8c78113