### PR TITLE
Fix kicker bootstrap base URL

### DIFF
--- a/pwsh/kicker-bootstrap.ps1
+++ b/pwsh/kicker-bootstrap.ps1
@@ -44,7 +44,7 @@ $script:ConsoleLevel    = $script:VerbosityLevels[$Verbosity]
 
 $targetBranch = 'main'
 $baseUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/'
-$defaultConfig = "${baseUrl}main/configs/config_files/default-config.json"
+$defaultConfig = "${baseUrl}${targetBranch}/configs/config_files/default-config.json"
 
 
 # example: https://raw.githubusercontent.com/wizzense/tofu-base-lab/refs/heads/main/configs/bootstrap-config.json

--- a/pwsh/kicker-bootstrap.ps1
+++ b/pwsh/kicker-bootstrap.ps1
@@ -43,7 +43,8 @@ $script:VerbosityLevels = @{ silent = 0; normal = 1; detailed = 2 }
 $script:ConsoleLevel    = $script:VerbosityLevels[$Verbosity]
 
 $targetBranch = 'main'
-$defaultConfig = "https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/main/configs/config_files/default-config.json"
+$baseUrl = 'https://raw.githubusercontent.com/wizzense/opentofu-lab-automation/refs/heads/'
+$defaultConfig = "${baseUrl}main/configs/config_files/default-config.json"
 
 
 # example: https://raw.githubusercontent.com/wizzense/tofu-base-lab/refs/heads/main/configs/bootstrap-config.json
@@ -72,7 +73,7 @@ if (-not (Test-Path $loggerPath)) {
     if (-not (Test-Path $loggerDir)) {
         New-Item -ItemType Directory -Path $loggerDir -Force | Out-Null
     }
-    $loggerUrl = "${baseUrl}main/pwsh/lab_utils/LabRunner/Logger.ps1"
+    $loggerUrl = "${baseUrl}${targetBranch}/pwsh/lab_utils/LabRunner/Logger.ps1"
     Invoke-WebRequest -Uri $loggerUrl -OutFile $loggerPath
 }
 try {

--- a/tests/Kicker-Bootstrap.Tests.ps1
+++ b/tests/Kicker-Bootstrap.Tests.ps1
@@ -53,4 +53,11 @@ Describe 'kicker-bootstrap utilities'  {
         $content = Get-Content $scriptPath -Raw
         $content | Should -Match 'stash push'
     }
+
+    It 'defines baseUrl for raw GitHub downloads' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'pwsh' 'kicker-bootstrap.ps1'
+        $content = Get-Content $scriptPath -Raw
+        $content | Should -Match '\$baseUrl\s*='
+        $content | Should -Match 'raw\.githubusercontent\.com'
+    }
 }


### PR DESCRIPTION
## Summary
- define `$baseUrl` constant in `kicker-bootstrap.ps1`
- fetch Logger.ps1 using the `targetBranch`
- test for baseUrl definition in Pester suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a09a07d108331b0033c12c9cb222d