### PR TITLE
Fix Join-Path usage in PowerShell scripts

### DIFF
--- a/pwsh/Modules/LabRunner/Expand-All.ps1
+++ b/pwsh/Modules/LabRunner/Expand-All.ps1
@@ -6,7 +6,7 @@ function Expand-All {
     )
     # Ensure logging helpers are available for each invocation
     if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
-        $logger = Join-Path $PSScriptRoot '..' 'LabRunner' 'Logger.ps1'
+        $logger = Join-Path (Join-Path (Join-Path $PSScriptRoot '..') 'LabRunner') 'Logger.ps1'
         if (Test-Path $logger) { . $logger }
         if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
             function Read-LoggedInput { param($Prompt) Read-Host $Prompt }

--- a/pwsh/Modules/LabRunner/Expand-All.ps1
+++ b/pwsh/Modules/LabRunner/Expand-All.ps1
@@ -6,7 +6,7 @@ function Expand-All {
     )
     # Ensure logging helpers are available for each invocation
     if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
-        $logger = Join-Path (Join-Path (Join-Path $PSScriptRoot '..') 'LabRunner') 'Logger.ps1'
+        $logger = Join-Path $PSScriptRoot '..\LabRunner\Logger.ps1'
         if (Test-Path $logger) { . $logger }
         if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
             function Read-LoggedInput { param($Prompt) Read-Host $Prompt }

--- a/pwsh/lab_utils/Expand-All.ps1
+++ b/pwsh/lab_utils/Expand-All.ps1
@@ -8,7 +8,7 @@ function Expand-All {
 
     # Ensure logging helpers are available for each invocation
     if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
-        $logger = Join-Path $PSScriptRoot '..' 'LabRunner' 'Logger.ps1'
+        $logger = Join-Path (Join-Path (Join-Path $PSScriptRoot '..') 'LabRunner') 'Logger.ps1'
         if (Test-Path $logger) { . $logger }
         if (-not (Get-Command Read-LoggedInput -ErrorAction SilentlyContinue)) {
             function Read-LoggedInput { param($Prompt) Read-Host $Prompt }

--- a/pwsh/runner.ps1
+++ b/pwsh/runner.ps1
@@ -21,7 +21,7 @@ if (Test-Path $indexPath) {
     try { $script:PathIndex = Get-Content -Raw -Path $indexPath | ConvertFrom-Yaml } catch { $script:PathIndex = @{} }
 }
 
-. (Join-Path $repoRoot 'lab_utils' 'PathUtils.ps1')
+. (Join-Path $repoRoot (Join-Path 'lab_utils' 'PathUtils.ps1'))
 
 function Resolve-IndexPath {
     param([string]$Key)
@@ -83,14 +83,14 @@ $configFilesDir = Resolve-IndexPath 'config_files'
 if (-not $configFilesDir) { $configFilesDir = Join-Path $repoRoot 'config_files' }
 
 if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
-    . (Join-Path $labUtilsDir 'LabRunner' 'Logger.ps1')
+    . (Join-Path $labUtilsDir (Join-Path 'LabRunner' 'Logger.ps1'))
 }
 $env:LAB_CONSOLE_LEVEL = $script:VerbosityLevels[$Verbosity]
-. (Join-Path $PSScriptRoot 'lab_utils' 'Get-LabConfig.ps1')
-. (Join-Path $PSScriptRoot 'lab_utils' 'Format-Config.ps1')
-. (Join-Path $PSScriptRoot 'lab_utils' 'Get-Platform.ps1')
-. (Join-Path $PSScriptRoot 'lab_utils' 'Resolve-ProjectPath.ps1')
-$menuPath = Join-Path $PSScriptRoot 'lab_utils' 'Menu.ps1'
+. (Join-Path $PSScriptRoot (Join-Path 'lab_utils' 'Get-LabConfig.ps1'))
+. (Join-Path $PSScriptRoot (Join-Path 'lab_utils' 'Format-Config.ps1'))
+. (Join-Path $PSScriptRoot (Join-Path 'lab_utils' 'Get-Platform.ps1'))
+. (Join-Path $PSScriptRoot (Join-Path 'lab_utils' 'Resolve-ProjectPath.ps1'))
+$menuPath = Join-Path $PSScriptRoot (Join-Path 'lab_utils' 'Menu.ps1')
 
 if (-not (Test-Path $menuPath)) {
     Write-Error "Menu module not found at $menuPath"


### PR DESCRIPTION
## Summary
- fix Join-Path calls to avoid unsupported positional parameters

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684a144b86bc83319a5a9fec79dd95e8