### PR TITLE
Fix PowerShell variable parsing error

### DIFF
--- a/pwsh/kicker-bootstrap.ps1
+++ b/pwsh/kicker-bootstrap.ps1
@@ -531,7 +531,8 @@ if (-not $runnerScriptName) {
 Set-Location $repoPath
 if (!(Test-Path $runnerScriptName)) {
     Write-Error "ERROR: Could not find $runnerScriptName in $repoPath. Exiting."
-    Write-Host "Directory listing for $repoPath:" -ForegroundColor Yellow
+    # Use ${repoPath} to avoid parsing error when followed by a colon
+    Write-Host "Directory listing for ${repoPath}:" -ForegroundColor Yellow
     Get-ChildItem -Path $repoPath -Recurse | Select-Object FullName
     Write-Host @"
 Possible causes:


### PR DESCRIPTION
## Summary
- ensure `$repoPath` variable isn't parsed with a trailing colon in `kicker-bootstrap.ps1`

## Testing
- `pytest`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_684a15bda5648331a990b7d108b65bf1