### PR TITLE
Fix config file lookup path

### DIFF
--- a/pwsh/lab_utils/Get-LabConfig.ps1
+++ b/pwsh/lab_utils/Get-LabConfig.ps1
@@ -2,7 +2,7 @@ function Get-LabConfig {
     [CmdletBinding()]
     param(
 
-        [string]$Path = (Join-Path $PSScriptRoot '..\config_files\default-config.json')
+        [string]$Path = (Join-Path $PSScriptRoot '..\..\configs\config_files\default-config.json')
     )
 
     if (-not (Test-Path $Path)) {
@@ -39,7 +39,7 @@ function Get-LabConfig {
         $dirs['RepoRoot']       = $repoRoot.Path
         $dirs['RunnerScripts']  = Join-Path $repoRoot 'runner_scripts'
         $dirs['UtilityScripts'] = Join-Path (Join-Path $repoRoot 'lab_utils') 'LabRunner'
-        $dirs['ConfigFiles']    = Join-Path $repoRoot 'config_files'
+        $dirs['ConfigFiles']    = Join-Path $repoRoot '..' 'configs' 'config_files'
         $dirs['InfraRepo']      = if ($config.InfraRepoPath) { $config.InfraRepoPath } else { 'C:\\Temp\\base-infra' }
 
         Add-Member -InputObject $config -MemberType NoteProperty -Name Directories -Value ([pscustomobject]$dirs) -Force

--- a/pwsh/runner.ps1
+++ b/pwsh/runner.ps1
@@ -34,8 +34,10 @@ function Resolve-IndexPath {
 
 # apply default ConfigFile if not provided
 if (-not $PSBoundParameters.ContainsKey('ConfigFile')) {
-    $ConfigFile = Resolve-IndexPath 'config_files/default-config.json'
-    if (-not $ConfigFile) { $ConfigFile = Join-Path $repoRoot 'config_files/default-config.json' }
+    $ConfigFile = Resolve-IndexPath 'configs/config_files/default-config.json'
+    if (-not $ConfigFile) {
+        $ConfigFile = Join-Path $repoRoot '..' 'configs' 'config_files' 'default-config.json'
+    }
 }
 
 
@@ -79,8 +81,10 @@ $labUtilsDir = Resolve-IndexPath 'lab_utils'
 if (-not $labUtilsDir) { $labUtilsDir = Join-Path $repoRoot 'lab_utils' }
 $runnerScriptsDir = Resolve-IndexPath 'runner_scripts'
 if (-not $runnerScriptsDir) { $runnerScriptsDir = Join-Path $repoRoot 'runner_scripts' }
-$configFilesDir = Resolve-IndexPath 'config_files'
-if (-not $configFilesDir) { $configFilesDir = Join-Path $repoRoot 'config_files' }
+$configFilesDir = Resolve-IndexPath 'configs/config_files'
+if (-not $configFilesDir) {
+    $configFilesDir = Join-Path $repoRoot '..' 'configs' 'config_files'
+}
 
 if (-not (Get-Command Write-CustomLog -ErrorAction SilentlyContinue)) {
     . (Join-Path $labUtilsDir (Join-Path 'LabRunner' 'Logger.ps1'))

--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'runner.ps1 executing 0200_Get-SystemInfo' {
             Copy-Item $runnerPath -Destination $tempDir
             Copy-Item (Join-Path $PSScriptRoot '..' 'pwsh' 'lab_utils') -Destination $tempDir -Recurse
             Copy-Item (Join-Path $PSScriptRoot '..' 'pwsh' 'lab_utils' 'LabRunner') -Destination (Join-Path $tempDir 'lab_utils' 'LabRunner') -Recurse
-            Copy-Item (Join-Path $PSScriptRoot '..' 'configs' 'config_files') -Destination (Join-Path $tempDir 'config_files') -Recurse
+            Copy-Item (Join-Path $PSScriptRoot '..' 'configs' 'config_files') -Destination (Join-Path $tempDir 'configs' 'config_files') -Recurse
             $scriptsDir = Join-Path $tempDir 'runner_scripts'
             $null = New-Item -ItemType Directory -Path $scriptsDir
             Copy-Item $script:ScriptPath -Destination $scriptsDir

--- a/tests/helpers/name-Pester.yaml
+++ b/tests/helpers/name-Pester.yaml
@@ -179,7 +179,7 @@ jobs:
       - name: Verify Node and packages
         shell: pwsh
         run: |
-          $cfg = Get-Content 'config_files/default-config.json' | ConvertFrom-Json
+          $cfg = Get-Content 'configs/config_files/default-config.json' | ConvertFrom-Json
           node --version
           $packages = $cfg.Node_Dependencies.GlobalPackages
           foreach ($pkg in $packages) {


### PR DESCRIPTION
## Summary
- update default config path to `../configs/config_files` in runner.ps1
- adjust helper to use same default location
- fix tests to copy config files to the new path

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: typer)*

------
https://chatgpt.com/codex/tasks/task_e_684a305b28908331b88a7253121cf895