### PR TITLE
Avoid noisy file listing during kicker run

### DIFF
--- a/pwsh/kicker-bootstrap.ps1
+++ b/pwsh/kicker-bootstrap.ps1
@@ -586,8 +586,10 @@ Write-Host "[DEBUG] ConfigFile: $ConfigFile" -ForegroundColor Cyan
 Write-Host "[DEBUG] repoPath: $repoPath" -ForegroundColor Cyan
 Write-Host "[DEBUG] runnerScriptName: $runnerScriptName" -ForegroundColor Cyan
 Write-Host "[DEBUG] runnerScriptPath: $runnerScriptPath" -ForegroundColor Cyan
-Write-Host "[DEBUG] Directory contents of repoPath (${repoPath}):" -ForegroundColor Cyan
-Get-ChildItem -Path $repoPath -Recurse | Select-Object FullName
+if ($ConsoleLevel -ge $script:VerbosityLevels['detailed']) {
+    Write-Host "[DEBUG] Directory contents of repoPath (${repoPath}):" -ForegroundColor Cyan
+    Get-ChildItem -Path $repoPath -Recurse | Select-Object FullName
+}
 
 if (!(Test-Path $runnerScriptPath)) {
     Write-Error "ERROR: Could not find runner script at $runnerScriptPath. Exiting."


### PR DESCRIPTION
## Summary
- only display repo contents when verbosity is `detailed`

## Testing
- `pytest -q`
- `./tools/setup-tests.sh` *(fails: PowerShell not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a330436a483318792716404d39cbc