### PR TITLE
Fix path index for pytest

### DIFF
--- a/py/labctl/path_index.py
+++ b/py/labctl/path_index.py
@@ -27,15 +27,20 @@ def load_index() -> dict:
     """Load path-index.yaml from repository root, if available."""
     global _INDEX
     if not _INDEX:
-        index_path = repo_root() / 'path-index.yaml'
-        if index_path.exists() and yaml is not None:
-            with index_path.open('r') as f:
-                data = yaml.safe_load(f) or {}
-            _INDEX = dict(data)
-            # also allow lookup by base filename
-            for key, val in data.items():
-                basename = Path(key).name
-                _INDEX.setdefault(basename, val)
+        root = repo_root()
+        candidates = [root / 'path-index.yaml',
+                      root / 'configs/project/path-index.yaml']
+
+        for index_path in candidates:
+            if index_path.exists() and yaml is not None:
+                with index_path.open('r') as f:
+                    data = yaml.safe_load(f) or {}
+                _INDEX = dict(data)
+                # also allow lookup by base filename
+                for key, val in data.items():
+                    basename = Path(key).name
+                    _INDEX.setdefault(basename, val)
+                break
         else:
             _INDEX = {}
     return _INDEX


### PR DESCRIPTION
## Summary
- adjust `load_index` fallback so pytest can find `path-index.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab17d5030833188317a635315adb4