### PR TITLE
Fix quoting in test files

### DIFF
--- a/tests/0006_Install-ValidationTools.Tests.ps1
+++ b/tests/0006_Install-ValidationTools.Tests.ps1
@@ -80,7 +80,7 @@ Describe '0006_Install-ValidationTools Tests' -Tag 'Installer' {
     Context 'Install-Cosign Function Tests' {
         It 'should be defined and accessible' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
-            $scriptContent | Should -Match 'function\s+[^']*'
+            $scriptContent | Should -Match 'function\s+[^'']*'
         }
                 It 'should support common parameters' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
@@ -97,7 +97,7 @@ Describe '0006_Install-ValidationTools Tests' -Tag 'Installer' {
     Context 'Find-Gpg Function Tests' {
         It 'should be defined and accessible' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
-            $scriptContent | Should -Match 'function\s+[^']*'
+            $scriptContent | Should -Match 'function\s+[^'']*'
         }
                 It 'should handle execution with valid parameters' -Skip:($SkipNonWindows) {
             # Add specific test logic for Find-Gpg

--- a/tests/0008_Install-OpenTofu.Tests.ps1
+++ b/tests/0008_Install-OpenTofu.Tests.ps1
@@ -80,7 +80,7 @@ Describe '0008_Install-OpenTofu Tests' -Tag 'Installer' {
     Context 'Install-OpenTofu Function Tests' {
         It 'should be defined and accessible' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
-            $scriptContent | Should -Match 'function\s+[^']*'
+            $scriptContent | Should -Match 'function\s+[^'']*'
         }
                 It 'should support common parameters' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw

--- a/tests/0010_Prepare-HyperVProvider.Tests.ps1
+++ b/tests/0010_Prepare-HyperVProvider.Tests.ps1
@@ -61,7 +61,7 @@ Describe '0010_Prepare-HyperVProvider Tests' -Tag 'Feature' {
     Context 'Convert-CerToPem Function Tests' {
         It 'should be defined and accessible' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
-            $scriptContent | Should -Match 'function\s+[^']*'
+            $scriptContent | Should -Match 'function\s+[^'']*'
         }
                 It 'should support common parameters' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
@@ -78,7 +78,7 @@ Describe '0010_Prepare-HyperVProvider Tests' -Tag 'Feature' {
     Context 'Convert-PfxToPem Function Tests' {
         It 'should be defined and accessible' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
-            $scriptContent | Should -Match 'function\s+[^']*'
+            $scriptContent | Should -Match 'function\s+[^'']*'
         }
                 It 'should support common parameters' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
@@ -95,7 +95,7 @@ Describe '0010_Prepare-HyperVProvider Tests' -Tag 'Feature' {
     Context 'Get-HyperVProviderVersion Function Tests' {
         It 'should be defined and accessible' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
-            $scriptContent | Should -Match 'function\s+[^']*'
+            $scriptContent | Should -Match 'function\s+[^'']*'
         }
                 It 'should support common parameters' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw

--- a/tests/0104_Install-CA.Tests.ps1
+++ b/tests/0104_Install-CA.Tests.ps1
@@ -78,7 +78,7 @@ Describe '0104_Install-CA Tests' -Tag 'Installer' {
     Context 'Install-CA Function Tests' {
         It 'should be defined and accessible' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
-            $scriptContent | Should -Match 'function\s+[^']*'
+            $scriptContent | Should -Match 'function\s+[^'']*'
         }
                 It 'should support common parameters' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw

--- a/tests/0106_Install-WAC.Tests.ps1
+++ b/tests/0106_Install-WAC.Tests.ps1
@@ -57,7 +57,7 @@ Describe '0106_Install-WAC Tests' -Tag 'Unknown' {
     Context 'Get-WacRegistryInstallation Function Tests' {
         It 'should be defined and accessible' -Skip:($SkipNonWindows) {
             $scriptContent = Get-Content $script:ScriptPath -Raw
-            $scriptContent | Should -Match 'function\s+[^']*'
+            $scriptContent | Should -Match 'function\s+[^'']*'
         }
                 It 'should handle execution with valid parameters' -Skip:($SkipNonWindows) {
             # Add specific test logic for Get-WacRegistryInstallation


### PR DESCRIPTION
## Summary
- escape single quotes in several tests to avoid parse errors

## Testing
- `Invoke-Pester -Configuration @{ Run = @{ Path = 'tests/0006_Install-ValidationTools.Tests.ps1' } }`
- `Invoke-Pester -Configuration @{ Run = @{ Path = 'tests/0008_Install-OpenTofu.Tests.ps1' } }`
- `Invoke-Pester -Configuration @{ Run = @{ Path = 'tests/0010_Prepare-HyperVProvider.Tests.ps1' } }`
- `Invoke-Pester -Configuration @{ Run = @{ Path = 'tests/0104_Install-CA.Tests.ps1' } }`
- `Invoke-Pester -Configuration @{ Run = @{ Path = 'tests/0106_Install-WAC.Tests.ps1' } }`
- `Invoke-Pester -Configuration @{ Run = @{ Path = 'tests' } }` *(fails: Could not find Mock for command Invoke-LabDownload)*

------
https://chatgpt.com/codex/tasks/task_e_684b109783a08331bdf8de7b8a9e1391