### PR TITLE
Handle stale files in health check

### DIFF
--- a/comprehensive-health-check.ps1
+++ b/comprehensive-health-check.ps1
@@ -21,8 +21,14 @@ $critical = 0
 
 foreach ($check in $checks) {
     if (Test-Path $check.Path) {
-        $healthy++
-        $results += [pscustomobject]@{ Check = $check.Name; Status = 'Healthy' }
+        $fileInfo = Get-Item $check.Path
+        if ($fileInfo.LastWriteTime -lt (Get-Date).AddDays(-180)) {
+            $warning++
+            $results += [pscustomobject]@{ Check = $check.Name; Status = 'Warning'; Reason = 'Stale file' }
+        } else {
+            $healthy++
+            $results += [pscustomobject]@{ Check = $check.Name; Status = 'Healthy' }
+        }
     } else {
         $critical++
         $results += [pscustomobject]@{ Check = $check.Name; Status = 'Critical' }


### PR DESCRIPTION
## Summary
- add logic to set `$warning` for stale files older than 180 days
- include results in health report

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b122bf3fc8331bad9e64cd5bc65ba