### PR TITLE
Fix YAML error in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,16 +26,14 @@ jobs:
         shell: bash
         run: |
           if ! command -v pwsh >/dev/null 2>&1; then
-            if [["$RUNNER_OS" == "Linux"]]; then
+            if [[ "$RUNNER_OS" == "Linux" ]]; then
               sudo apt-get update
-              sudo apt-get install -y wget apt-transport-https \
-                software-properties-common
-              wget -q https://packages.microsoft.com/config/ubuntu/22.04/\
-packages-microsoft-prod.deb
+              sudo apt-get install -y wget apt-transport-https software-properties-common
+              wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
               sudo dpkg -i packages-microsoft-prod.deb
               sudo apt-get update
               sudo apt-get install -y powershell
-            elif [["$RUNNER_OS" == "macOS"]]; then
+            elif [[ "$RUNNER_OS" == "macOS" ]]; then
               brew install --cask powershell
             fi
           fi
@@ -52,26 +50,22 @@ packages-microsoft-prod.deb
           path: |
             C:\Users\runneradmin\Documents\WindowsPowerShell\Modules
             C:\Users\runneradmin\Documents\PowerShell\Modules
-          key: windows-pwsh-modules-${{ hashFiles(\
-'tests/PesterConfiguration.psd1') }}
+          key: windows-pwsh-modules-${{ hashFiles('tests/PesterConfiguration.psd1') }}
           restore-keys: windows-pwsh-modules-
       - name: Cache PowerShell modules (Posix)
         if: runner.os != 'Windows'
         uses: actions/cache@v4
         with:
           path: ~/.local/share/powershell/Modules
-          key: ${{ runner.os }}-pwsh-modules-${{ hashFiles(\
-'tests/PesterConfiguration.psd1') }}
+          key: ${{ runner.os }}-pwsh-modules-${{ hashFiles('tests/PesterConfiguration.psd1') }}
           restore-keys: ${{ runner.os }}-pwsh-modules-
       - name: Install PSScriptAnalyzer
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           try {
-            if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer |\
-                Where-Object { $_.Version -ge [version]'1.22.0' })) {
-              Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 \
--Scope CurrentUser -Force
+            if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer | Where-Object { $_.Version -ge [version]'1.22.0' })) {
+              Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force
             }
             Write-Host "PSScriptAnalyzer ready" -ForegroundColor Green
           } catch {
@@ -83,10 +77,8 @@ packages-microsoft-prod.deb
         run: |
           $ErrorActionPreference = 'Stop'
           try {
-            Install-Module -Name powershell-yaml -Force \
--Scope CurrentUser
-            Write-Host "powershell-yaml installed successfully" \
--ForegroundColor Green
+            Install-Module -Name powershell-yaml -Force -Scope CurrentUser
+            Write-Host "powershell-yaml installed successfully" -ForegroundColor Green
           } catch {
             Write-Error "Failed to install powershell-yaml: $_"
             exit 1


### PR DESCRIPTION
## Summary
- cleanup PowerShell install script in lint workflow
- inline cache key expressions
- drop incorrect line continuations

## Testing
- `ruff check .`
- `yamllint .github/workflows $(git ls-files '*.yml' '*.yaml')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684b17bb2df083318e0fb2102d7ca53b