### PR TITLE
Add Copilot repository instructions doc

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,9 @@ This is a cross-platform OpenTofu (Terraform alternative) lab automation project
 - ** test files** for validation
 - **Cross-platform deployment** via Python scripts
 
+For guidance on writing your own repository instructions, see
+[docs/copilot_docs/repository-custom-instructions.md](../docs/copilot_docs/repository-custom-instructions.md).
+
 ## Current Architecture
 
 ### Module Locations (CRITICAL - Always Use These Paths)

--- a/.github/copilot/COPILOT-CONFIG.md
+++ b/.github/copilot/COPILOT-CONFIG.md
@@ -92,3 +92,4 @@ To validate the entire codebase:
 For more information, refer to:
 - `/docs/TESTING.md`: Detailed testing framework documentation
 - `/docs/CODEFIXER-GUIDE.md`: Comprehensive guide to the CodeFixer module
+- `/docs/copilot_docs/repository-custom-instructions.md`: How Copilot uses `.github/copilot-instructions.md`

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,7 +31,19 @@
       "text": "Reference module names in scope when applicable: codefixer, labrunner, backupmanager, etc."
     }
   ],
+  "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
+    {
+      "text": "Summarize key changes and mention affected modules."
+    },
+    {
+      "text": "Highlight new features or bug fixes in the description."
+    }
+  ],
   "github.copilot.instructionFiles": [
+    {
+      "pattern": "**/*",
+      "instructionFile": ".github/copilot-instructions.md"
+    },
     {
       "pattern": "pwsh/modules/**/*.ps1",
       "instructionFile": ".github/instructions/powershell-standards.instructions.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,13 @@ pwsh/modules/
 - Cross-platform launcher scripts maintained
 - Documentation auto-generated from manifest
 
+## Repository Custom Instructions
+Copilot loads `.github/copilot-instructions.md` automatically through the VS Code
+setting `github.copilot.chat.codeGeneration.useInstructionFiles`. Update this
+file to guide Copilot responses for the project. See
+[docs/copilot_docs/repository-custom-instructions.md](docs/copilot_docs/repository-custom-instructions.md)
+for details.
+
 ---
 *This file is automatically updated by the maintenance system*
 *Last auto-update: 2025-06-14 16:45:01*

--- a/COPILOT-SETUP.md
+++ b/COPILOT-SETUP.md
@@ -18,6 +18,7 @@ The project includes extensive Copilot customization for:
 ### Main Configuration
 - **`.github/copilot-instructions.md`**: Primary Copilot instructions with project context
 - **`.vscode/settings.json`**: VS Code Copilot configuration and instruction file references
+- **`repository-custom-instructions.md`**: Guide to adding repository instructions for Copilot (see `docs/copilot_docs/repository-custom-instructions.md`)
 
 ### Instruction Files (`.github/instructions/`)
 - **`powershell-standards.instructions.md`**: PowerShell coding standards and patterns

--- a/docs/copilot_docs/repository-custom-instructions.md
+++ b/docs/copilot_docs/repository-custom-instructions.md
@@ -1,0 +1,33 @@
+# Repository Custom Instructions for GitHub Copilot
+
+This guide explains how to provide GitHub Copilot with additional context for this repository.
+
+## Overview
+
+Repository custom instructions let you store project guidelines in `.github/copilot-instructions.md`. These instructions are automatically included with Copilot Chat prompts on GitHub.com, Visual Studio, and VS Code.
+
+## Creating the instructions file
+
+1. In the root of the repository, create `.github/copilot-instructions.md`.
+2. Add short, self-contained instructions in Markdown.
+3. Save the file to immediately enable the instructions for Copilot.
+
+### Example
+
+```
+We use Bazel instead of Maven, so reference Bazel commands for Java builds.
+Use double quotes and tabs for JavaScript code samples.
+All tasks are tracked in Jira.
+```
+
+## Tips for writing instructions
+
+- Keep each instruction concise and avoid conflicting guidelines.
+- Avoid large external references for complex repositories.
+- Use blank lines to improve readability; whitespace is ignored.
+
+For more background see GitHub's "Adding repository custom instructions for GitHub Copilot" documentation.
+
+## Using Repository Instructions
+
+You can toggle repository instructions in Copilot Chat. Click the **gear** icon in the chat panel and choose **Enable custom instructions** or **Disable custom instructions**. When enabled, the contents of `.github/copilot-instructions.md` are automatically appended to your prompts so Copilot responds with project-specific guidance.


### PR DESCRIPTION
## Summary
- document how to use repository instructions for Copilot
- mention repository instructions in main docs
- ensure `.github/copilot-instructions.md` is loaded in VS Code settings
- document how to toggle Copilot instructions
- add link to instruction guide in Copilot config
- configure PR description instructions in VS Code settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_684f8ee9af2483319a35924e4ecae742