### PR TITLE
Fix Pester import paths

### DIFF
--- a/tests/0000_Cleanup-Files.Tests.ps1
+++ b/tests/0000_Cleanup-Files.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0000_Cleanup-Files Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0001_Reset-Git.Tests.ps1
+++ b/tests/0001_Reset-Git.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0001_Reset-Git Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0002_Setup-Directories.Tests.ps1
+++ b/tests/0002_Setup-Directories.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0002_Setup-Directories Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0006_Install-ValidationTools.Tests.ps1
+++ b/tests/0006_Install-ValidationTools.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0006_Install-ValidationTools Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0007_Install-Go.Tests.ps1
+++ b/tests/0007_Install-Go.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0007_Install-Go Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0008_Install-OpenTofu.Tests.ps1
+++ b/tests/0008_Install-OpenTofu.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0008_Install-OpenTofu Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0009_Initialize-OpenTofu.Tests.ps1
+++ b/tests/0009_Initialize-OpenTofu.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0009_Initialize-OpenTofu Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0010_Prepare-HyperVProvider.Tests.ps1
+++ b/tests/0010_Prepare-HyperVProvider.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0010_Prepare-HyperVProvider Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0100_Enable-WinRM.Tests.ps1
+++ b/tests/0100_Enable-WinRM.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0100_Enable-WinRM Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0101_Enable-RemoteDesktop.Tests.ps1
+++ b/tests/0101_Enable-RemoteDesktop.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0101_Enable-RemoteDesktop Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0102_Configure-Firewall.Tests.ps1
+++ b/tests/0102_Configure-Firewall.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0102_Configure-Firewall Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0103_Change-ComputerName.Tests.ps1
+++ b/tests/0103_Change-ComputerName.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0103_Change-ComputerName Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0104_Install-CA.Tests.ps1
+++ b/tests/0104_Install-CA.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0104_Install-CA Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0105_Install-HyperV.Tests.ps1
+++ b/tests/0105_Install-HyperV.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0105_Install-HyperV Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0106_Install-WAC.Tests.ps1
+++ b/tests/0106_Install-WAC.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0106_Install-WAC Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0111_Disable-TCPIP6.Tests.ps1
+++ b/tests/0111_Disable-TCPIP6.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0111_Disable-TCPIP6 Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0112_Enable-PXE.Tests.ps1
+++ b/tests/0112_Enable-PXE.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0112_Enable-PXE Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0113_Config-DNS.Tests.ps1
+++ b/tests/0113_Config-DNS.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0113_Config-DNS Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0114_Config-TrustedHosts.Tests.ps1
+++ b/tests/0114_Config-TrustedHosts.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0114_Config-TrustedHosts Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0200_Get-SystemInfo.Tests.ps1
+++ b/tests/0200_Get-SystemInfo.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0200_Get-SystemInfo Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0201_Install-NodeCore.Tests.ps1
+++ b/tests/0201_Install-NodeCore.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0201_Install-NodeCore Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0202_Install-NodeGlobalPackages.Tests.ps1
+++ b/tests/0202_Install-NodeGlobalPackages.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0202_Install-NodeGlobalPackages Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0203_Install-npm.Tests.ps1
+++ b/tests/0203_Install-npm.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0203_Install-npm Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0204_Install-Poetry.Tests.ps1
+++ b/tests/0204_Install-Poetry.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0204_Install-Poetry Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0205_Install-Sysinternals.Tests.ps1
+++ b/tests/0205_Install-Sysinternals.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0205_Install-Sysinternals Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0206_Install-Python.Tests.ps1
+++ b/tests/0206_Install-Python.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0206_Install-Python Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0207_Install-Git.Tests.ps1
+++ b/tests/0207_Install-Git.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0207_Install-Git Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0208_Install-DockerDesktop.Tests.ps1
+++ b/tests/0208_Install-DockerDesktop.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0208_Install-DockerDesktop Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0209_Install-7Zip.Tests.ps1
+++ b/tests/0209_Install-7Zip.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0209_Install-7Zip Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0210_Install-VSCode.Tests.ps1
+++ b/tests/0210_Install-VSCode.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0210_Install-VSCode Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0211_Install-VSBuildTools.Tests.ps1
+++ b/tests/0211_Install-VSBuildTools.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0211_Install-VSBuildTools Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0212_Install-AzureCLI.Tests.ps1
+++ b/tests/0212_Install-AzureCLI.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0212_Install-AzureCLI Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0213_Install-AWSCLI.Tests.ps1
+++ b/tests/0213_Install-AWSCLI.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0213_Install-AWSCLI Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0214_Install-Packer.Tests.ps1
+++ b/tests/0214_Install-Packer.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0214_Install-Packer Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0215_Install-Chocolatey.Tests.ps1
+++ b/tests/0215_Install-Chocolatey.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0215_Install-Chocolatey Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/0216_Set-LabProfile.Tests.ps1
+++ b/tests/0216_Set-LabProfile.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '0216_Set-LabProfile Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/9999_Reset-Machine.Tests.ps1
+++ b/tests/9999_Reset-Machine.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe '9999_Reset-Machine Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/BadRunnerScripts.Simple.Tests.ps1
+++ b/tests/BadRunnerScripts.Simple.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'BadRunnerScripts.Simple Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/BadRunnerScripts.Tests.ps1
+++ b/tests/BadRunnerScripts.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'BadRunnerScripts Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Cleanup-Files.Tests.ps1
+++ b/tests/Cleanup-Files.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Cleanup-Files Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/CommonInstallers.Tests.ps1
+++ b/tests/CommonInstallers.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'CommonInstallers Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Config-DNS.Tests.ps1
+++ b/tests/Config-DNS.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Config-DNS Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Config-TrustedHosts.Tests.ps1
+++ b/tests/Config-TrustedHosts.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Config-TrustedHosts Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Configure-Firewall.Tests.ps1
+++ b/tests/Configure-Firewall.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Configure-Firewall Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/CustomLint.Tests.ps1
+++ b/tests/CustomLint.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'CustomLint Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Customize-ISO.Tests.ps1
+++ b/tests/Customize-ISO.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Customize-ISO Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Download-Archive.Tests.ps1
+++ b/tests/Download-Archive.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Download-Archive Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Enable-PXE.Tests.ps1
+++ b/tests/Enable-PXE.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Enable-PXE Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Enable-RemoteDesktop.Tests.ps1
+++ b/tests/Enable-RemoteDesktop.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Enable-RemoteDesktop Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Enable-WinRM.Tests.ps1
+++ b/tests/Enable-WinRM.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Enable-WinRM Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/EscapePathArgument.Tests.ps1
+++ b/tests/EscapePathArgument.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'EscapePathArgument Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Expand-All.Tests.ps1
+++ b/tests/Expand-All.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Expand-All Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Format-Config.Tests.ps1
+++ b/tests/Format-Config.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Format-Config Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Get-HyperVProviderVersion.Tests.ps1
+++ b/tests/Get-HyperVProviderVersion.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Get-HyperVProviderVersion Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Get-LabConfig.Tests.ps1
+++ b/tests/Get-LabConfig.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Get-LabConfig Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Get-Platform.Tests.ps1
+++ b/tests/Get-Platform.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Get-Platform Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Get-SystemInfo.Tests.ps1
+++ b/tests/Get-SystemInfo.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Get-SystemInfo Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Get-WindowsJobArtifacts.Tests.ps1
+++ b/tests/Get-WindowsJobArtifacts.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Get-WindowsJobArtifacts Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Hypervisor.Tests.ps1
+++ b/tests/Hypervisor.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Hypervisor Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Initialize-OpenTofu.Tests.ps1
+++ b/tests/Initialize-OpenTofu.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Initialize-OpenTofu Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Install-CA.Tests.ps1
+++ b/tests/Install-CA.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Install-CA Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Install-Go.Tests.ps1
+++ b/tests/Install-Go.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Install-Go Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Install-OpenTofu.Tests.ps1
+++ b/tests/Install-OpenTofu.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Install-OpenTofu Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Install-Poetry.Tests.ps1
+++ b/tests/Install-Poetry.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Install-Poetry Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Install-Sysinternals.Tests.ps1
+++ b/tests/Install-Sysinternals.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Install-Sysinternals Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Install-ValidationTools.Tests.ps1
+++ b/tests/Install-ValidationTools.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Install-ValidationTools Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Install-npm.Tests.ps1
+++ b/tests/Install-npm.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Install-npm Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Invoke-LabDownload.Tests.ps1
+++ b/tests/Invoke-LabDownload.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Invoke-LabDownload Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/InvokeOpenTofuInstaller.Tests.ps1
+++ b/tests/InvokeOpenTofuInstaller.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'InvokeOpenTofuInstaller Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Kickstart-Bootstrap.Tests.ps1
+++ b/tests/Kickstart-Bootstrap.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Kickstart-Bootstrap Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Logger.Tests.ps1
+++ b/tests/Logger.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Logger Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Menu.Tests.ps1
+++ b/tests/Menu.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Menu Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Network.Tests.ps1
+++ b/tests/Network.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Network Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/NodeScripts.Tests.ps1
+++ b/tests/NodeScripts.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'NodeScripts Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/OpenTofuInstaller.Tests.ps1
+++ b/tests/OpenTofuInstaller.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'OpenTofuInstaller Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/PathUtils.Tests.ps1
+++ b/tests/PathUtils.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'PathUtils Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/PrepareHyperVProvider.Tests.ps1
+++ b/tests/PrepareHyperVProvider.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'PrepareHyperVProvider Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Reset-Git.Tests.ps1
+++ b/tests/Reset-Git.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Reset-Git Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Reset-Machine.Tests.ps1
+++ b/tests/Reset-Machine.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Reset-Machine Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Resolve-ProjectPath.Tests.ps1
+++ b/tests/Resolve-ProjectPath.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Resolve-ProjectPath Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/RunnerScripts.Tests.ps1
+++ b/tests/RunnerScripts.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'RunnerScripts Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/ScriptTemplate.Tests.ps1
+++ b/tests/ScriptTemplate.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'ScriptTemplate Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Set-LabProfile.Tests.ps1
+++ b/tests/Set-LabProfile.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Set-LabProfile Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/Setup-Directories.Tests.ps1
+++ b/tests/Setup-Directories.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'Setup-Directories Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/kicker-bootstrap.Tests.ps1
+++ b/tests/kicker-bootstrap.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'kicker-bootstrap Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/runner.Tests.ps1
+++ b/tests/runner.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'runner Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {

--- a/tests/setup-test-env.Tests.ps1
+++ b/tests/setup-test-env.Tests.ps1
@@ -3,8 +3,8 @@
 
 Describe 'setup-test-env Tests' {
     BeforeAll {
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/LabRunner/" -Force -Force -Force -Force -Force -Force -Force
-        Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation//pwsh/modules/CodeFixer/" -Force -Force -Force -Force -Force -Force -Force
+        Import-Module (Resolve-ProjectPath -Name 'LabRunner') -Force
+        Import-Module (Resolve-ProjectPath -Name 'CodeFixer') -Force
     }
 
     Context 'Module Loading' {


### PR DESCRIPTION
## Summary
- use TestHelpers and Resolve-ProjectPath to load modules in tests

## Testing
- `python launcher.py validate` *(fails: IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_684faa5156f88331847ebaf72103af82