### PR TITLE
fix(tests): update runner script path

### DIFF
--- a/tests/helpers/TestHelpers.ps1
+++ b/tests/helpers/TestHelpers.ps1
@@ -65,7 +65,7 @@ function Resolve-ProjectPath {
     
     # Common path mappings within the project
     $pathMappings = @{
-        'runner_scripts' = 'pwsh/modules/CodeFixerrunner_scripts'
+        'runner_scripts' = 'pwsh/runner_scripts'
         'LabRunner' = 'pwsh/modules/LabRunner'
         'CodeFixer' = 'pwsh/modules/CodeFixer'
         'pwsh' = 'pwsh'
@@ -91,7 +91,7 @@ function Resolve-ProjectPath {
     # Try common script locations
     $commonPaths = @(
         "pwsh/runner_scripts/$Name",
-        "pwsh/modules/CodeFixerrunner_scripts/$Name", 
+        "pwsh/runner_scripts/$Name",
         "pwsh/modules/LabRunner/$Name",
         "scripts/$Name",
         "tests/$Name"


### PR DESCRIPTION
## Summary
- correct path for `runner_scripts` helper in `TestHelpers.ps1`
- update fallback path list accordingly

## Testing
- `pwsh -NoLogo -NoProfile -Command "& { ./scripts/testing/Validate-PreCommit.ps1 }"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684faa6230848331bdc7c43d15e73c98