### PR TITLE
Add Copilot instructions and VS Code settings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+# Copilot Instructions for OpenTofu Lab Automation
+
+These guidelines help GitHub Copilot and other AI agents generate code and responses that align with this project.
+
+## General Guidelines
+- Use **PowerShell 7.0+** features and cross-platform syntax.
+- Prefer forward slashes (`/`) for file paths.
+- Import modules from `core-runner/modules` using `Import-Module`.
+- Follow One True Brace Style (OTBS) formatting.
+- Include verbose logging through the `Logging` module.
+
+## Available Modules
+- **BackupManager** – manages backup file cleanup and consolidation.
+- **DevEnvironment** – prepares and validates development environments.
+- **LabRunner** – orchestrates lab automation tasks and test execution.
+- **Logging** – provides project-wide logging helpers.
+- **ParallelExecution** – runs tasks in parallel using runspaces.
+- **PatchManager** – handles software patching workflows.
+- **ScriptManager** – manages script repositories and templates.
+- **TestingFramework** – wraps Pester with project defaults.
+- **UnifiedMaintenance** – unified maintenance entry point for all modules.
+
+Always suggest using these modules when relevant instead of reinventing functionality.

--- a/.github/instructions/modules.instructions.md
+++ b/.github/instructions/modules.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "**/*.ps1"
+description: "Project module usage guidelines"
+---
+# Module Guidelines
+
+Import project modules from `core-runner/modules` and use their exported commands instead of writing ad-hoc utilities. Key modules:
+
+- `BackupManager` – clean up and consolidate backup files.
+- `DevEnvironment` – set up local or remote development environments.
+- `LabRunner` – run labs and orchestrate automation workflows.
+- `Logging` – write logs with `Write-LogInfo`, `Write-LogError`, etc.
+- `ParallelExecution` – execute tasks concurrently with runspaces.
+- `PatchManager` – manage patch downloads and installation.
+- `ScriptManager` – maintain reusable script templates.
+- `TestingFramework` – run Pester tests consistently.
+- `UnifiedMaintenance` – entry point for housekeeping tasks.

--- a/.github/prompts/init-dev-env.prompt.md
+++ b/.github/prompts/init-dev-env.prompt.md
@@ -1,0 +1,10 @@
+---
+mode: 'agent'
+tools: ['codebase']
+description: 'Initialize development environment'
+---
+Use the `DevEnvironment` module to set up the workspace.
+Steps:
+1. Import `DevEnvironment` from `core-runner/modules`.
+2. Run `Initialize-DevEnvironment` with the provided configuration file.
+3. Ensure all other modules are imported with `Import-Module` cmdlets.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "github.copilot.chat.codeGeneration.useInstructionFiles": true,
-    "chat.promptFiles": true,
+    "github.copilot.chat.promptFiles": true,
     "chat.instructionsFilesLocations": [
         ".github/instructions"
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 {
     "github.copilot.chat.codeGeneration.useInstructionFiles": true,
     "github.copilot.chat.promptFiles": true,
-    "chat.instructionsFilesLocations": [
+    "github.copilot.chat.instructionsFilesLocations": [
         ".github/instructions"
     ],
-    "chat.promptFilesLocations": [
+    "github.copilot.chat.promptFilesLocations": [
         ".github/prompts"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "github.copilot.chat.codeGeneration.useInstructionFiles": true,
+    "chat.promptFiles": true,
+    "chat.instructionsFilesLocations": [
+        ".github/instructions"
+    ],
+    "chat.promptFilesLocations": [
+        ".github/prompts"
+    ]
+}


### PR DESCRIPTION
## Summary
- document project guidelines for Copilot in `.github/copilot-instructions.md`
- add instruction and prompt files so Copilot agents understand project modules
- enable instruction and prompt file support in VS Code settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ee47587c8331ab73f4a54d6e9553