### PR TITLE
Update runner scripts path

### DIFF
--- a/core-runner/modules/LabRunner/Get-LabConfig.ps1
+++ b/core-runner/modules/LabRunner/Get-LabConfig.ps1
@@ -36,7 +36,7 @@ function Get-LabConfig {
         }
 
         $dirs'RepoRoot'       = $repoRoot.Path
-        $dirs'RunnerScripts'  = Join-Path $repoRoot 'runner_scripts'
+        $dirs'RunnerScripts'  = Join-Path $repoRoot 'core-runner/core_app/scripts'
         $dirs'UtilityScripts' = Join-Path (Join-Path $repoRoot 'lab_utils') 'LabRunner'
         $dirs'ConfigFiles'    = Join-Path $repoRoot 'config_files'
         $dirs'InfraRepo'      = if ($config.InfraRepoPath) { $config.InfraRepoPath } else { 'C:\\Temp\\base-infra' }


### PR DESCRIPTION
## Summary
- fix path for runner scripts in LabRunner Get-LabConfig

## Testing
- `PWSH_MODULES_PATH=$(pwd)/core-runner/modules pwsh -NoProfile -File tests/unit/scripts/Get-LabConfig.Tests.ps1` *(fails: ModuleToProcess not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f05372b083319550c6cb2f41ce3d