### PR TITLE
Fix WinRM script path and structure

### DIFF
--- a/core-runner/core_app/scripts/0100_Enable-WinRM.ps1
+++ b/core-runner/core_app/scripts/0100_Enable-WinRM.ps1
@@ -4,7 +4,8 @@
 
 
 
-Import-Module '/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation\pwsh/modules/LabRunner/' -ForceWrite-CustomLog "Starting $MyInvocation.MyCommand"
+Import-Module "$env:PROJECT_ROOT/core-runner/modules/LabRunner/" -Force
+Write-CustomLog "Starting $($MyInvocation.MyCommand.Name)"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
 
@@ -21,8 +22,9 @@ Invoke-LabStep -Config $Config -Body {
         # WinRM QuickConfig
         Enable-PSRemoting -Force
         Write-CustomLog 'Enable-PSRemoting executed'
-    
+
         # Optionally configure additional authentication methods, etc.:
         # e.g.: Set-Item -Path WSMan:\localhost\Service\Auth\Basic -Value $true
     }
-
+}
+Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"


### PR DESCRIPTION
## Summary
- update the WinRM enabling script to load modules from PROJECT_ROOT
- ensure logging calls are on separate lines
- close the Invoke-LabStep block and log completion

## Testing
- `pwsh -noprofile -c 'Invoke-ScriptAnalyzer -Path core-runner/core_app/scripts/0100_Enable-WinRM.ps1'`
- `pwsh -noprofile -Command \"$env:PWSH_MODULES_PATH='$PWD/core-runner/modules'; $env:PSModulePath='$PWD/core-runner/modules:' + $env:PSModulePath; Invoke-Pester -Output Detailed -Path tests/unit/scripts/0100_Enable-WinRM.Tests.ps1\"`

------
https://chatgpt.com/codex/tasks/task_e_6852f054b84483319978c4a1320ee1fd