### PR TITLE
Fix 0101_Enable-RemoteDesktop script

### DIFF
--- a/core-runner/core_app/scripts/0101_Enable-RemoteDesktop.ps1
+++ b/core-runner/core_app/scripts/0101_Enable-RemoteDesktop.ps1
@@ -4,7 +4,8 @@
 
 
 
-Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation\pwsh/modules/LabRunner/" -ForceWrite-CustomLog "Starting $MyInvocation.MyCommand"
+Import-Module "$env:PROJECT_ROOT/core-runner/modules/LabRunner/" -Force
+Write-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
 
@@ -24,4 +25,8 @@ if ($Config.AllowRemoteDesktop -eq $true) {
     }
 }
 else {
+    Write-CustomLog 'Remote Desktop remains disabled as per configuration.'
+}
 
+Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
+}


### PR DESCRIPTION
## Summary
- fix Import-Module path in 0101_Enable-RemoteDesktop
- close control flow and log completion
- run ScriptAnalyzer
- run Pester tests for the script

## Testing
- `Invoke-ScriptAnalyzer -Path core-runner/core_app/scripts/0101_Enable-RemoteDesktop.ps1 -Settings tests/config/PSScriptAnalyzerSettings.psd1`
- `Invoke-Pester -CI -Script tests/unit/scripts/0101_Enable-RemoteDesktop.Tests.ps1 -Passthru`

------
https://chatgpt.com/codex/tasks/task_e_6852f057fa7c8331a914b15116e5b994