### PR TITLE
Fix incomplete admin scripts

### DIFF
--- a/core-runner/core_app/scripts/0100_Enable-WinRM.ps1
+++ b/core-runner/core_app/scripts/0100_Enable-WinRM.ps1
@@ -1,14 +1,16 @@
-#Requires -Version 7
+#Requires -Version 7.0
 
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [object]$Config
+)
 
+Import-Module "$env:PROJECT_ROOT/core-runner/modules/LabRunner/" -Force
+Write-CustomLog "Starting $($MyInvocation.MyCommand.Name)"
 
-
-
-Import-Module '/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation\pwsh/modules/LabRunner/' -ForceWrite-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
-
-
 
     # Check if WinRM is already configured
     $winrmStatus = Get-Service -Name WinRM -ErrorAction SilentlyContinue
@@ -21,8 +23,10 @@ Invoke-LabStep -Config $Config -Body {
         # WinRM QuickConfig
         Enable-PSRemoting -Force
         Write-CustomLog 'Enable-PSRemoting executed'
-    
+
         # Optionally configure additional authentication methods, etc.:
         # e.g.: Set-Item -Path WSMan:\localhost\Service\Auth\Basic -Value $true
     }
+}
 
+Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"

--- a/core-runner/core_app/scripts/0101_Enable-RemoteDesktop.ps1
+++ b/core-runner/core_app/scripts/0101_Enable-RemoteDesktop.ps1
@@ -1,27 +1,37 @@
-#Requires -Version 7
+#Requires -Version 7.0
 
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [object]$Config
+)
 
+Import-Module "$env:PROJECT_ROOT/core-runner/modules/LabRunner/" -Force
+Write-CustomLog "Starting $($MyInvocation.MyCommand.Name)"
 
-
-
-Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation\pwsh/modules/LabRunner/" -ForceWrite-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
 
-# Check current Remote Desktop status
-$currentStatus = Get-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name "fDenyTSConnections"
+    # Check current Remote Desktop status
+    $currentStatus = Get-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name 'fDenyTSConnections'
 
-if ($Config.AllowRemoteDesktop -eq $true) {
-    if ($currentStatus.fDenyTSConnections -eq 0) {
-        Write-CustomLog "Remote Desktop is already enabled."
-    }
-    else {
-        Write-CustomLog "Enabling Remote Desktop via Set-ItemProperty"
-        Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' `
-                         -Name "fDenyTSConnections" `
-                         -Value 0
-        Write-CustomLog "Remote Desktop enabled"
+    if ($Config.AllowRemoteDesktop -eq $true) {
+        if ($currentStatus.fDenyTSConnections -eq 0) {
+            Write-CustomLog 'Remote Desktop is already enabled.'
+        } else {
+            Write-CustomLog 'Enabling Remote Desktop via Set-ItemProperty'
+            Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name 'fDenyTSConnections' -Value 0
+            Write-CustomLog 'Remote Desktop enabled'
+        }
+    } else {
+        if ($currentStatus.fDenyTSConnections -eq 1) {
+            Write-CustomLog 'Remote Desktop is already disabled.'
+        } else {
+            Write-CustomLog 'Disabling Remote Desktop via Set-ItemProperty'
+            Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name 'fDenyTSConnections' -Value 1
+            Write-CustomLog 'Remote Desktop disabled'
+        }
     }
 }
-else {
 
+Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"

--- a/core-runner/core_app/scripts/0102_Configure-Firewall.ps1
+++ b/core-runner/core_app/scripts/0102_Configure-Firewall.ps1
@@ -1,22 +1,31 @@
-#Requires -Version 7
+#Requires -Version 7.0
 
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [object]$Config
+)
 
+Import-Module "$env:PROJECT_ROOT/core-runner/modules/LabRunner/" -Force
+Write-CustomLog "Starting $($MyInvocation.MyCommand.Name)"
 
-
-
-Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation\pwsh/modules/LabRunner/" -ForceWrite-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
 
-Write-CustomLog "Configuring Firewall rules..."
+    Write-CustomLog "Configuring Firewall rules..."
 
-if ($null -ne $Config.FirewallPorts) {
-    foreach ($port in $Config.FirewallPorts) {
-        Write-CustomLog " - Opening TCP port $port"
-        New-NetFirewallRule -DisplayName "Open Port $port" `
-                            -Direction Inbound `
-                            -Protocol TCP `
-                            -LocalPort $port `
-                            -Action Allow | Out-Null}
-} else {
+    if ($null -ne $Config.FirewallPorts) {
+        foreach ($port in $Config.FirewallPorts) {
+            Write-CustomLog " - Opening TCP port $port"
+            New-NetFirewallRule -DisplayName "Open Port $port" `
+                                -Direction Inbound `
+                                -Protocol TCP `
+                                -LocalPort $port `
+                                -Action Allow | Out-Null
+        }
+    } else {
+        Write-CustomLog 'No FirewallPorts specified. Skipping.'
+    }
+}
 
+Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"

--- a/core-runner/core_app/scripts/0105_Install-HyperV.ps1
+++ b/core-runner/core_app/scripts/0105_Install-HyperV.ps1
@@ -1,46 +1,51 @@
-#Requires -Version 7
+#Requires -Version 7.0
 
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [object]$Config
+)
 
+Import-Module "$env:PROJECT_ROOT/core-runner/modules/LabRunner/" -Force
+Write-CustomLog "Starting $($MyInvocation.MyCommand.Name)"
 
-
-
-Import-Module "/C:\Users\alexa\OneDrive\Documents\0. wizzense\opentofu-lab-automation\pwsh/modules/LabRunner/" -ForceWrite-CustomLog "Starting $MyInvocation.MyCommand"
 Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
 
-if ($Config.InstallHyperV -eq $true) {
-    Write-CustomLog "Checking if Hyper-V is already installed..."
+    if ($Config.InstallHyperV -eq $true) {
+        Write-CustomLog "Checking if Hyper-V is already installed..."
 
-    # Get the installation state of Hyper-V
-    $feature = Get-WindowsFeature -Name Hyper-V
+        # Get the installation state of Hyper-V
+        $feature = Get-WindowsFeature -Name Hyper-V
 
-    if ($feature -and $feature.Installed) {
-        Write-CustomLog "Hyper-V is already installed. Skipping installation."
-        exit 0
-    }
-
-    Write-CustomLog "Hyper-V is not installed. Proceeding with installation..."
-
-    $enableMgtTools = $true
-    if ($Config.PSObject.Properties.Name -contains 'HyperV' -and
-        $Config.HyperV.PSObject.Properties.Name -contains 'EnableManagementTools') {
-        $enableMgtTools = bool$Config.HyperV.EnableManagementTools
-    }
-    $restart = $false  # Change to $true if you want an automatic restart
-
-    try {
-
-        if ($restart) {
-            Install-WindowsFeature -Name "Hyper-V" -IncludeManagementTools:$enableMgtTools -Restart -ErrorAction Continue
-        } else {
-            Install-WindowsFeature -Name "Hyper-V" -IncludeManagementTools:$enableMgtTools -ErrorAction Continue
+        if ($feature -and $feature.Installed) {
+            Write-CustomLog "Hyper-V is already installed. Skipping installation."
+            return
         }
+
+        Write-CustomLog "Hyper-V is not installed. Proceeding with installation..."
+
+        $enableMgtTools = $true
+        if ($Config.PSObject.Properties.Name -contains 'HyperV' -and
+            $Config.HyperV.PSObject.Properties.Name -contains 'EnableManagementTools') {
+            $enableMgtTools = [bool]$Config.HyperV.EnableManagementTools
+        }
+        $restart = $false  # Change to $true if you want an automatic restart
+
+        try {
+            if ($restart) {
+                Install-WindowsFeature -Name 'Hyper-V' -IncludeManagementTools:$enableMgtTools -Restart -ErrorAction Continue
+            } else {
+                Install-WindowsFeature -Name 'Hyper-V' -IncludeManagementTools:$enableMgtTools -ErrorAction Continue
+            }
+        } catch {
+            Write-CustomLog 'Only works on Windows Server.'
+        }
+
+        Write-CustomLog 'Hyper-V installation complete. A restart is typically required to finalize installation.'
+    } else {
+        Write-CustomLog 'InstallHyperV flag is disabled. Skipping installation.'
     }
-    catch {
-        Write-CustomLog "Only works on Windows Server."
-    }
+}
 
-
-    Write-CustomLog "Hyper-V installation complete. A restart is typically required to finalize installation."
-} else {
-
+Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"


### PR DESCRIPTION
## Summary
- clean up module imports and logging for admin scripts
- add missing else blocks and closing braces
- ensure each script logs completion

## Testing
- `pwsh -NoProfile -Command Invoke-ScriptAnalyzer -Path 'core-runner/core_app/scripts/010*.ps1' -Recurse -Settings 'tests/config/PSScriptAnalyzerSettings.psd1'`
- `pwsh -NoProfile -Command Invoke-Pester -Script 'tests/unit/scripts/0101_Enable-RemoteDesktop.Tests.ps1' -Output Detailed`
- `pwsh -NoProfile -Command Invoke-Pester -Script 'tests/unit/scripts/0100_Enable-WinRM.Tests.ps1' -Output Detailed`
- `pwsh -NoProfile -Command Invoke-Pester -Script 'tests/unit/scripts/0102_Configure-Firewall.Tests.ps1' -Output Detailed`
- `pwsh -NoProfile -Command Invoke-Pester -Script 'tests/unit/scripts/0105_Install-HyperV.Tests.ps1' -Output Detailed`


------
https://chatgpt.com/codex/tasks/task_e_6852f0594f5c8331be23ac93e212aa5c