### PR TITLE
Fix coverage paths in extensible test runner

### DIFF
--- a/tests/helpers/Invoke-ExtensibleTests.ps1
+++ b/tests/helpers/Invoke-ExtensibleTests.ps1
@@ -301,7 +301,7 @@ try {
     
     if ($EnableCodeCoverage) {
         $pesterConfig.CodeCoverage.Enabled = $true
-        $pesterConfig.CodeCoverage.Path = @('pwsh/runner_scripts', 'pwsh/modules')
+        $pesterConfig.CodeCoverage.Path = @('core-runner/core_app/scripts', 'core-runner/modules')
         $pesterConfig.CodeCoverage.OutputPath = Join-Path $OutputPath 'coverage.xml'
     }
     


### PR DESCRIPTION
## Summary
- update `Invoke-ExtensibleTests.ps1` to use new script locations
- ensure coverage includes `core-runner/modules`

## Testing
- `Invoke-Pester -Path tests/unit/scripts -CodeCoverage @('core-runner/core_app/scripts','core-runner/modules')`
- `pwsh -File tests/helpers/Invoke-ExtensibleTests.ps1 -EnableCodeCoverage -OutputPath tests/results` *(fails: Missing ')' in function parameter list)*

------
https://chatgpt.com/codex/tasks/task_e_6852f05e29f083318fee7c2ad21da8da