### PR TITLE
Fix script path for auto test generation

### DIFF
--- a/tests/Setup-TestingFramework.ps1
+++ b/tests/Setup-TestingFramework.ps1
@@ -133,7 +133,7 @@ function Initialize-TestGeneration {
  Write-Host "`nGenerating tests for existing scripts..." -ForegroundColor Yellow
  
  $scriptDirs = @(
- (Join-Path $PSScriptRoot '..' 'pwsh' 'runner_scripts'),
+ (Join-Path $PSScriptRoot '..' 'core-runner' 'core_app' 'scripts'),
  (Join-Path $PSScriptRoot '..' 'pwsh' 'lab_utils'),
  (Join-Path $PSScriptRoot '..' 'pwsh')
  )


### PR DESCRIPTION
## Summary
- adjust script path for test generation in Setup-TestingFramework.ps1
- run Pester tests

## Testing
- `Invoke-Pester -Configuration @{Run=@{Path="tests/unit"}}`

------
https://chatgpt.com/codex/tasks/task_e_6852f06108b08331a12689ee3b25a9d0