### PR TITLE
Fix path in name-Pester YAML

### DIFF
--- a/tests/helpers/name-Pester.yaml
+++ b/tests/helpers/name-Pester.yaml
@@ -168,13 +168,13 @@ jobs:
         shell: pwsh
         run: 
           $cfg = Get-Content 'configs/config_files/default-config.json'  ConvertFrom-Json
-          . ./pwsh/runner_scripts/0201_Install-NodeCore.ps1
+          . ./core-runner/core_app/scripts/0201_Install-NodeCore.ps1
           Install-NodeCore -Config $cfg
       - name: Install global packages
         shell: pwsh
         run: 
           $cfg = Get-Content 'configs/config_files/default-config.json'  ConvertFrom-Json
-          . ./pwsh/runner_scripts/0202_Install-NodeGlobalPackages.ps1
+          . ./core-runner/core_app/scripts/0202_Install-NodeGlobalPackages.ps1
           Install-NodeGlobalPackages -Config $cfg
       - name: Verify Node and packages
         shell: pwsh


### PR DESCRIPTION
## Summary
- update script paths in `tests/helpers/name-Pester.yaml`

## Testing
- `Invoke-Pester -Configuration (Import-PowerShellDataFile 'tests/config/PesterConfiguration.psd1')` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0654cac83319da91f81ee53041d