### PR TITLE
Update AutoTestGenerator paths

### DIFF
--- a/tests/helpers/New-AutoTestGenerator.ps1
+++ b/tests/helpers/New-AutoTestGenerator.ps1
@@ -3,21 +3,21 @@
 Automatically generates Pester tests for new PowerShell scripts
 
 .DESCRIPTION
-This script monitors the pwsh/ directory for new scripts and automatically:
+This script monitors the core-runner/core_app/scripts directory for new scripts and automatically:
 - Creates corresponding .Tests.ps1 files
 - Generates boilerplate test code based on script analysis
 - Follows naming conventions and test patterns
 - Integrates with the extensible test framework
 
 .EXAMPLE
-./New-AutoTestGenerator.ps1 -WatchDirectory "pwsh/runner_scripts"
+./New-AutoTestGenerator.ps1 -WatchDirectory "core-runner/core_app/scripts"
 
 .EXAMPLE
-./New-AutoTestGenerator.ps1 -ScriptPath "pwsh/runner_scripts/0301_Install-NewTool.ps1" -Force
+./New-AutoTestGenerator.ps1 -ScriptPath "core-runner/core_app/scripts/0301_Install-NewTool.ps1" -Force
 #>
 
 param(
-    string$WatchDirectory = "pwsh",
+    string$WatchDirectory = "core-runner/core_app/scripts",
     string$ScriptPath,
     string$OutputDirectory = "tests",
     switch$Force,
@@ -388,7 +388,7 @@ function Format-ScriptName {
     # Ensure we have both verb and noun
     if (-not $noun) { $noun = 'Task' }
     
-            $runnerScriptsPath = Join-Path $PSScriptRoot ".." ".." "pwsh" "runner_scripts"
+            $runnerScriptsPath = Join-Path $PSScriptRoot ".." ".." "core-runner" "core_app" "scripts"
         if (Test-Path $runnerScriptsPath) {
             $existingScripts = Get-ChildItem $runnerScriptsPath -Filter "*.ps1" | Where-Object{ $_.Name -match '^0-9{4}_' } | ForEach-Object{ int($_.Name.Substring(0,4)) } | Sort-Object$nextNumber = if ($existingScripts.Count -gt 0) { $existingScripts-1 + 1    } else { 100    }
         } else {


### PR DESCRIPTION
## Summary
- update watch directory defaults to `core-runner/core_app/scripts`
- adjust path handling in `Format-ScriptName`
- update usage examples

## Testing
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Configuration tests/config/PesterConfiguration.psd1'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0659a0483318c8856f595696d05