### PR TITLE
Fix Pester block termination

### DIFF
--- a/tests/helpers/CommonInstallers.Tests.ps1
+++ b/tests/helpers/CommonInstallers.Tests.ps1
@@ -4,6 +4,7 @@
 Describe 'CommonInstallers Tests' {
     BeforeAll {
         Import-Module "$env:PWSH_MODULES_PATH/LabRunner/" -Force
+    }
 
     Context 'Module Loading' {
         It 'should load required modules' {


### PR DESCRIPTION
## Summary
- fix closing braces in `CommonInstallers.Tests.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -Command "echo 'testing'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f07215408331b893d5971bc12a64