### PR TITLE
Fix cleanup test script path

### DIFF
--- a/tests/unit/scripts/0000_Cleanup-Files.Tests.ps1
+++ b/tests/unit/scripts/0000_Cleanup-Files.Tests.ps1
@@ -12,7 +12,7 @@
 BeforeAll {
     # Set up paths
     $script:ProjectRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    $script:ScriptPath = Join-Path $ProjectRoot "pwsh\core_app\scripts\0000_Cleanup-Files.ps1"
+    $script:ScriptPath = Join-Path $ProjectRoot "core-runner/core_app/scripts/0000_Cleanup-Files.ps1"
     $script:LabRunnerPath = Join-Path $ProjectRoot "pwsh\modules\LabRunner"
     
     # Mock the LabRunner module functions


### PR DESCRIPTION
## Summary
- fix script path in `0000_Cleanup-Files.Tests.ps1`

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester tests/unit/scripts/0000_Cleanup-Files.Tests.ps1 -EnableExit:$false"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f074a4a48331bc5ea8ee89b151e5