### PR TITLE
Ensure PSScriptAnalyzer available for system tests

### DIFF
--- a/tests/Setup-TestingFramework.ps1
+++ b/tests/Setup-TestingFramework.ps1
@@ -40,10 +40,11 @@ if (Test-Path (Join-Path $helpersPath 'TestHelpers.ps1')) {
 function Install-RequiredModules {
  Write-Host "`nInstalling required PowerShell modules..." -ForegroundColor Yellow
  
- $modules = @(
- @{ Name = 'Pester'; Version = '5.7.1'; Scope = 'CurrentUser' }
- @{ Name = 'powershell-yaml'; Scope = 'CurrentUser' }
- )
+    $modules = @(
+        @{ Name = 'Pester'; Version = '5.7.1'; Scope = 'CurrentUser' }
+        @{ Name = 'powershell-yaml'; Scope = 'CurrentUser' }
+        @{ Name = 'PSScriptAnalyzer'; Scope = 'CurrentUser' }
+    )
  
  foreach ($module in $modules) {
  try {


### PR DESCRIPTION
## Summary
- install `PSScriptAnalyzer` as part of Setup-TestingFramework.ps1

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Script ./tests/system/system/SystematicValidation.Tests.ps1 -Output Detailed"`

------
https://chatgpt.com/codex/tasks/task_e_6852f07fe83c8331b280def25de9e243