### PR TITLE
Fix default-config.json

### DIFF
--- a/configs/default-config.json
+++ b/configs/default-config.json
@@ -71,7 +71,7 @@
   "GitHubCLIInstallerUrl": "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_windows_amd64.msi",
   "RepoUrl": "https://github.com/wizzense/opentofu-lab-automation.git",
   "LocalPath": "C:/temp",
-  "RunnerScriptName": "pwsh/runner.ps1",
+  "RunnerScriptName": "core-runner/core_app/core-runner.ps1",
   "ConfigFile": "./config_files/default-config.json",
   "Go": {
     "InstallerUrl": "https://go.dev/dl/go1.24.1.windows-amd64.msi"
@@ -99,7 +99,4 @@
       "InstallerUrl": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-x64.msi"
     }
   }
-}
-}
-}
 }


### PR DESCRIPTION
## Summary
- fix invalid JSON in `configs/default-config.json`
- update `RunnerScriptName` to use the core-runner path

## Testing
- `python -m json.tool configs/default-config.json`

------
https://chatgpt.com/codex/tasks/task_e_6852f08fbea083318326ffb6a278d48e