### PR TITLE
Clean up Reset-Machine script

### DIFF
--- a/core-runner/core_app/scripts/9999_Reset-Machine.ps1
+++ b/core-runner/core_app/scripts/9999_Reset-Machine.ps1
@@ -44,4 +44,3 @@ Invoke-LabStep -Config $Config -Body {
 }
 
 Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
-


### PR DESCRIPTION
## Summary
- trim the trailing prompt text from `9999_Reset-Machine.ps1`
- keep cleanup message at the end of script

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Script tests/unit/scripts/9999_Reset-Machine.Tests.ps1"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0a603a08331881f75f6bff99998