### PR TITLE
Fix trailing spaces in Set-LabProfile script

### DIFF
--- a/core-runner/core_app/scripts/0216_Set-LabProfile.ps1
+++ b/core-runner/core_app/scripts/0216_Set-LabProfile.ps1
@@ -15,26 +15,26 @@ function Set-LabProfile {
         [Parameter(Mandatory)]
         [object]$Config
     )
-    
+
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
-    
+
     if ($Config.SetupLabProfile -eq $true) {
         $profilePath = $PROFILE.CurrentUserAllHosts
         $profileDir = Split-Path $profilePath
-        
+
         if (-not (Test-Path $profileDir)) {
             if ($PSCmdlet.ShouldProcess($profileDir, 'Create profile directory')) {
                 New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
             }
         }
-        
+
         $repoRoot = Resolve-Path -Path (Join-Path $PSScriptRoot '..')
         $content = @"
 # OpenTofu Lab Automation profile
 `$env:PATH = "$repoRoot;`$env:PATH"
 `$env:PSModulePath = "$repoRoot/pwsh/modules;`$env:PSModulePath"
 "@
-        
+
         if ($PSCmdlet.ShouldProcess($profilePath, 'Create PowerShell profile')) {
             Set-Content -Path $profilePath -Value $content
             Write-CustomLog "PowerShell profile created at $profilePath"


### PR DESCRIPTION
## Summary
- clean up `0216_Set-LabProfile.ps1` by trimming trailing whitespace

## Testing
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester -Configuration @{ Run = @{ Path = 'tests/unit/scripts/0216_Set-LabProfile.Tests.ps1' }; Output = @{ Verbosity = 'Normal' } }` *(fails: Logging module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0a708cc833187af266e466b3a53