### PR TITLE
Fix truncated Packer install script

### DIFF
--- a/core-runner/core_app/scripts/0214_Install-Packer.ps1
+++ b/core-runner/core_app/scripts/0214_Install-Packer.ps1
@@ -17,15 +17,14 @@ Invoke-LabStep -Config $Config -Body {
             Write-CustomLog "Installing Packer..."
             $url = 'https://releases.hashicorp.com/packer/1.9.4/packer_1.9.4_windows_amd64.zip'
             $dest = Join-Path $env:ProgramFiles 'Packer'
-            
             Invoke-LabDownload -Uri $url -Prefix 'packer' -Extension '.zip' -Action {
                 param($zip)
-                
-                if (-not (Test-Path $dest)) { 
+
+                if (-not (Test-Path $dest)) {
                     New-Item -ItemType Directory -Path $dest -Force | Out-Null
                 }
                 Expand-Archive -Path $zip -DestinationPath $dest -Force
-                
+
                 # Add to PATH
                 $env:PATH = "$env:PATH;$dest"
             }


### PR DESCRIPTION
## Summary
- clean up line breaks in `0214_Install-Packer.ps1`
- run Pester tests

## Testing
- `Invoke-Pester tests/unit/scripts/0214_Install-Packer.Tests.ps1 -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_6852f0a981088331853f317712743444