### PR TITLE
Fix trailing line in Node package installer

### DIFF
--- a/core-runner/core_app/scripts/0202_Install-NodeGlobalPackages.ps1
+++ b/core-runner/core_app/scripts/0202_Install-NodeGlobalPackages.ps1
@@ -86,4 +86,3 @@ Invoke-LabStep -Config $Config -Body {
 }
 
 Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
-


### PR DESCRIPTION
## Summary
- remove stray newline at the end of `0202_Install-NodeGlobalPackages.ps1`

## Testing
- `pwsh -NoLogo -Command '$env:PWSH_MODULES_PATH = (Resolve-Path "core-runner/modules").Path; Invoke-Pester -Output Detailed tests/unit/scripts/0202_Install-NodeGlobalPackages.Tests.ps1'`


------
https://chatgpt.com/codex/tasks/task_e_6852f0b02cac8331ba7b420a79ff505d