### PR TITLE
Fix trailing prompt in Install-NodeCore

### DIFF
--- a/core-runner/core_app/scripts/0201_Install-NodeCore.ps1
+++ b/core-runner/core_app/scripts/0201_Install-NodeCore.ps1
@@ -65,5 +65,4 @@ Invoke-LabStep -Config $Config -Body {
         Write-CustomLog "InstallNode flag is disabled. Skipping Node.js installation."
     }
 }
-
 Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"


### PR DESCRIPTION
## Summary
- remove stray blank line at the end of `0201_Install-NodeCore.ps1`

## Testing
- `Invoke-Pester -Script tests/unit/scripts/0201_Install-NodeCore.Tests.ps1 -Output Detailed` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0b120e48331ad31fab62a3d9e09