### PR TITLE
Fix Install-CA script header

### DIFF
--- a/core-runner/core_app/scripts/0104_Install-CA.ps1
+++ b/core-runner/core_app/scripts/0104_Install-CA.ps1
@@ -1,60 +1,71 @@
-#Requires -Version 7
+#Requires -Version 7.0
 
-
-
-
-
-Impo    [object]$Config
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [object]$Config
 )
 
-    Invoke-LabStep -Config $Config -Body {
+Import-Module "$env:PROJECT_ROOT/core-runner/modules/LabRunner/" -Force
+Write-CustomLog "Starting $($MyInvocation.MyCommand.Name)"
+
+Invoke-LabStep -Config $Config -Body {
     Write-CustomLog "Running $($MyInvocation.MyCommand.Name)"
 
-if ($Config.InstallCA -eq $true) {
-Write-CustomLog "Checking for existing Certificate Authority (Standalone Root CA)..."
+    if ($Config.InstallCA -eq $true) {
+        Write-CustomLog "Checking for existing Certificate Authority (Standalone Root CA)..."
 
-# Only proceed if you actually want to install a CA.
-if ($null -eq $Config.CertificateAuthority) {
-    Write-CustomLog "No CA config found. Skipping CA installation."
-    return
-}
-
-$CAName        = $Config.CertificateAuthority.CommonName
-$ValidityYears = $Config.CertificateAuthority.ValidityYears
-$rol        Write-CustomLog "A Certificate Authority is already configured. Skipping installation."
-        return
-    }
-
-    Write-CustomLog "CA role is installed but no CA is configured. Proceeding with installation."
-} else {
-    Write-CustomLog "Installing Certificate Authority role..."
-    if ($PSCmdlet.ShouldProcess('ADCS role', 'Install CA Windows feature')) {
-        Install-WindowsFeature Adcs-Cert-Authority -IncludeManagementTools -ErrorAction Stop
-    }
-}
-
-# If the script reaches this point, it means no existing CA is detected, and installation should proceed.
-Write-CustomLog "Configuring CA: $CAName with $($ValidityYears) year validity..."
-
-if ($PSCmdlet.ShouldProcess($CAName, 'Configure Standalone Root CA')) {
-    # Resolve the cmdlet after any Pester mocks have been defined
-
-    $installCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
-    if (-not $installCmd) {
-        if (Get-Module -ListAvailable -Name ADCSDeployment) {
-            $installCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
+        # Only proceed if you actually want to install a CA.
+        if ($null -eq $Config.CertificateAuthority) {
+            Write-CustomLog "No CA config found. Skipping CA installation."
+            return
         }
+
+        $CAName        = $Config.CertificateAuthority.CommonName
+        $ValidityYears = $Config.CertificateAuthority.ValidityYears
+
+        $role = Get-WindowsFeature -Name 'ADCS-Cert-Authority'
+        if ($role -and $role.Installed) {
+            if (Get-Service -Name 'CertSvc' -ErrorAction SilentlyContinue) {
+                Write-CustomLog "A Certificate Authority is already configured. Skipping installation."
+                return
+            } else {
+                Write-CustomLog "CA role is installed but no CA is configured. Proceeding with installation."
+            }
+        } else {
+            Write-CustomLog "Installing Certificate Authority role..."
+            if ($PSCmdlet.ShouldProcess('ADCS role', 'Install CA Windows feature')) {
+                Install-WindowsFeature Adcs-Cert-Authority -IncludeManagementTools -ErrorAction Stop
+            }
+        }
+
+        # If the script reaches this point, it means no existing CA is detected, and installation should proceed.
+        Write-CustomLog "Configuring CA: $CAName with $($ValidityYears) year validity..."
+
+        if ($PSCmdlet.ShouldProcess($CAName, 'Configure Standalone Root CA')) {
+            # Resolve the cmdlet after any Pester mocks have been defined
+            $installCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
+            if (-not $installCmd) {
+                if (Get-Module -ListAvailable -Name ADCSDeployment) {
+                    $installCmd = Get-Command Install-AdcsCertificationAuthority -ErrorAction SilentlyContinue
+                }
+            }
+            if (-not $installCmd) {
+                Write-CustomLog 'Install-AdcsCertificationAuthority command not found. Ensure AD CS features are available.'
+                return
+            }
+            & $installCmd `
+                -CAType StandaloneRootCA `
+                -CACommonName $CAName `
+                -KeyLength 2048 `
+                -HashAlgorithm SHA256 `
+                -ValidityPeriod Years `
+                -ValidityPeriodUnits $ValidityYears `
+                -Force
+        }
+    } else {
+        Write-CustomLog 'InstallCA flag is disabled. Skipping installation.'
     }
-    if (-not $installCmd) {
-        Write-CustomLog 'Install-AdcsCertificationAuthority command not found. Ensure AD CS features are available.'
-        return
-    }
-    & $installCmd `
-        -CAType StandaloneRootCA `
-        -CACommonName $CAName `
-        -KeyLength 2048 `
-        -HashAlgorithm SHA256 `
-        -ValidityPeriod Years `
-        -ValidityPeriodUnits $ValidityYears `
-        -Force
 }
+
+Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"


### PR DESCRIPTION
## Summary
- fix `0104_Install-CA.ps1` header and syntax
- ensure module imports from `$env:PROJECT_ROOT`

## Testing
- `pwsh -NoProfile ./tests/Run-AllModuleTests.ps1` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0b85f7c8331aea525fcffa01acb