### PR TITLE
Fix trailing text in cleanup script

### DIFF
--- a/core-runner/core_app/scripts/0000_Cleanup-Files.ps1
+++ b/core-runner/core_app/scripts/0000_Cleanup-Files.ps1
@@ -54,5 +54,3 @@ Invoke-LabStep -Config $Config -Body {
     }
     Write-CustomLog "Completed $($MyInvocation.MyCommand.Name)"
 }
-
-


### PR DESCRIPTION
## Summary
- remove stray newline from cleanup script

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests/unit/scripts/0000_Cleanup-Files.Tests.ps1 -Output Detailed"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0bdae0083318622b5b4a66063be