### PR TITLE
Centralize PWSH_MODULES_PATH setup for tests

### DIFF
--- a/tests/Invoke-DynamicTests.ps1
+++ b/tests/Invoke-DynamicTests.ps1
@@ -1,8 +1,6 @@
 #!/usr/bin/env pwsh
-# Ensure environment variables are set for admin-friendly module discovery
-if (-not $env:PWSH_MODULES_PATH) {
-    $env:PWSH_MODULES_PATH = Join-Path (Split-Path $PSScriptRoot -Parent) "core-runner/modules"
-}
+# Load shared test helpers for environment setup
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 #Requires -Version 7.0
 
 <#

--- a/tests/Invoke-IntelligentTests.ps1
+++ b/tests/Invoke-IntelligentTests.ps1
@@ -1,8 +1,6 @@
 #!/usr/bin/env pwsh
-# Ensure environment variables are set for admin-friendly module discovery
-if (-not $env:PWSH_MODULES_PATH) {
-    $env:PWSH_MODULES_PATH = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) "core-runner/modules"
-}
+# Load shared test helpers for environment setup
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 #Requires -Version 7.0
 
 <#

--- a/tests/Run-MasterTests.ps1
+++ b/tests/Run-MasterTests.ps1
@@ -1,8 +1,6 @@
 #!/usr/bin/env pwsh
-# Ensure environment variables are set for admin-friendly module discovery
-if (-not $env:PWSH_MODULES_PATH) {
-    $env:PWSH_MODULES_PATH = Join-Path (Split-Path $PSScriptRoot -Parent) "core-runner/modules"
-}
+# Load shared test helpers for environment setup
+. (Join-Path $PSScriptRoot 'helpers' 'TestHelpers.ps1')
 #Requires -Version 7.0
 
 <#

--- a/tests/pester/LintingTests.Tests.ps1
+++ b/tests/pester/LintingTests.Tests.ps1
@@ -1,9 +1,5 @@
-# Ensure environment variables are set for admin-friendly module discovery
-if (-not $env:PWSH_MODULES_PATH) {
-
-    $env:PWSH_MODULES_PATH = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) "core-runner/modules"
-
-}
+# Load shared test helpers for environment setup
+. (Join-Path $PSScriptRoot '..' 'helpers' 'TestHelpers.ps1')
 Describe 'Code Quality and Linting Tests' {
     BeforeAll {
         # Import parallel execution module using admin-friendly module discovery

--- a/tests/pester/ModuleTests.Tests.ps1
+++ b/tests/pester/ModuleTests.Tests.ps1
@@ -1,7 +1,5 @@
-# Ensure environment variables are set for admin-friendly module discovery
-if (-not $env:PWSH_MODULES_PATH) {
-    $env:PWSH_MODULES_PATH = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) "core-runner/modules"
-}
+# Load shared test helpers for environment setup
+. (Join-Path $PSScriptRoot '..' 'helpers' 'TestHelpers.ps1')
 Describe 'UnifiedMaintenance Module Tests' {
     BeforeAll {
         $ModulePath = './core-runner/modules/UnifiedMaintenance/UnifiedMaintenance.psm1'

--- a/tests/pester/ProjectStructure.Tests.ps1
+++ b/tests/pester/ProjectStructure.Tests.ps1
@@ -1,9 +1,5 @@
-# Ensure environment variables are set for admin-friendly module discovery
-if (-not $env:PWSH_MODULES_PATH) {
-
-    $env:PWSH_MODULES_PATH = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) "core-runner/modules"
-
-}
+# Load shared test helpers for environment setup
+. (Join-Path $PSScriptRoot '..' 'helpers' 'TestHelpers.ps1')
 Describe 'Project Structure and Integration Tests' {
     Context 'Project Directory Structure' {
         It 'Should have all required top-level directories' {


### PR DESCRIPTION
## Summary
- use shared TestHelpers script for test environment setup
- simplify multiple test scripts by removing duplicate logic

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Configuration ./tests/config/PesterConfiguration.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853029dc75c83318cabee87d4c03c93