### PR TITLE
Add VS Code Copilot instructions

### DIFF
--- a/.vscode/copilot-instructions.md
+++ b/.vscode/copilot-instructions.md
@@ -1,0 +1,23 @@
+# Copilot Instructions for OpenTofu Lab Automation
+
+These guidelines help GitHub Copilot and other AI agents generate code and responses that align with this project.
+
+## General Guidelines
+- Use **PowerShell 7.0+** features and cross-platform syntax.
+- Prefer forward slashes (`/`) for file paths.
+- Import modules from `core-runner/modules` using `Import-Module`.
+- Follow One True Brace Style (OTBS) formatting.
+- Include verbose logging through the `Logging` module.
+
+## Available Modules
+- **BackupManager** – manages backup file cleanup and consolidation.
+- **DevEnvironment** – prepares and validates development environments.
+- **LabRunner** – orchestrates lab automation tasks and test execution.
+- **Logging** – provides project-wide logging helpers.
+- **ParallelExecution** – runs tasks in parallel using runspaces.
+- **PatchManager** – handles software patching workflows.
+- **ScriptManager** – manages script repositories and templates.
+- **TestingFramework** – wraps Pester with project defaults.
+- **UnifiedMaintenance** – unified maintenance entry point for all modules.
+
+Always suggest using these modules when relevant instead of reinventing functionality.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
     ],
     "github.copilot.chat.promptFilesLocations": [
         ".github/prompts"
+    ],
+    "github.copilot.experimental.codeGeneration.instructions": [
+        ".vscode/copilot-instructions.md"
     ]
 }


### PR DESCRIPTION
## Summary
- copy project Copilot instructions into `.vscode`
- reference the instructions file in workspace settings

## Testing
- `pwsh -NoLogo -NoProfile -Command "./tests/Run-MasterTests.ps1 -TestSuite Smoke"` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a71a99488331a665d68df34d773d