### PR TITLE
Add prompt placeholders and fix docs

### DIFF
--- a/.github/prompts/prompts-pester.md
+++ b/.github/prompts/prompts-pester.md
@@ -1,0 +1,5 @@
+---
+mode: 'agent'
+description: 'Pester testing prompts'
+---
+This placeholder will contain prompts for generating and managing Pester tests.

--- a/.github/prompts/prompts-powershell.md
+++ b/.github/prompts/prompts-powershell.md
@@ -1,0 +1,5 @@
+---
+mode: 'agent'
+description: 'PowerShell development prompts'
+---
+This placeholder will contain prompts and templates for PowerShell module development.

--- a/.github/prompts/prompts-review.md
+++ b/.github/prompts/prompts-review.md
@@ -1,0 +1,5 @@
+---
+mode: 'agent'
+description: 'Code review prompts'
+---
+This placeholder will contain prompts for performing automated code reviews and quality analysis.

--- a/.github/prompts/prompts-troubleshooting.md
+++ b/.github/prompts/prompts-troubleshooting.md
@@ -1,0 +1,5 @@
+---
+mode: 'agent'
+description: 'Troubleshooting prompts'
+---
+This placeholder will contain prompts for diagnosing and resolving common issues.

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -67,6 +67,7 @@ Comprehensive instructions for GitHub Copilot including:
 
 #### Specialized Prompt Files
 
+These prompt files are stored in the `.github/prompts` directory.
 **`prompts-powershell.md`**
 
 - Module development prompts
@@ -169,7 +170,7 @@ Ready-to-use PowerShell code snippets:
 
 ### Adding New Prompts
 
-Create new prompt files in the `.vscode` directory following the existing pattern:
+Create new prompt files in the `.github/prompts` directory following the existing pattern:
 
 - Use descriptive headings
 - Include specific, actionable instructions


### PR DESCRIPTION
## Summary
- add placeholder prompt files for specialized Copilot guidance
- clarify path to prompt files in VS Code README

## Testing
- `pwsh -NoLogo -Command Invoke-Pester -Configuration @{Run=@{Exit=$false}}` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a71b21a0833192dda0ee848bebc6