### PR TITLE
Remove Python CLI workspace folder

### DIFF
--- a/opentofu-lab-automation.code-workspace
+++ b/opentofu-lab-automation.code-workspace
@@ -21,10 +21,6 @@
             "path": "./opentofu"
         },
         {
-            "name": "Python CLI",
-            "path": "./py"
-        },
-        {
             "name": "Tests",
             "path": "./tests"
         },


### PR DESCRIPTION
## Summary
- remove the obsolete `Python CLI` folder from `opentofu-lab-automation.code-workspace`

## Testing
- `jq . opentofu-lab-automation.code-workspace`

------
https://chatgpt.com/codex/tasks/task_e_6853a71bc7e88331bbf9cf21608d849b