### PR TITLE
Fix Get-LabConfig and add tests

### DIFF
--- a/core-runner/modules/LabRunner/Get-LabConfig.ps1
+++ b/core-runner/modules/LabRunner/Get-LabConfig.ps1
@@ -1,8 +1,10 @@
-function Get-LabConfig {
-    CmdletBinding()
-    param(
 
-        string$Path = (Join-Path $PSScriptRoot '..\default-config.json')
+# Retrieves and normalizes the lab configuration file.
+function Get-LabConfig {
+    [CmdletBinding()]
+    param(
+        # Path to the JSON or YAML configuration file
+        [string]$Path = (Join-Path $PSScriptRoot '..\default-config.json')
     )
 
     if (-not (Test-Path $Path)) {
@@ -10,48 +12,43 @@ function Get-LabConfig {
     }
 
     try {
-
+        # Read the file content in one go
         $content = Get-Content -Raw -Path $Path
+
+        # Choose parser based on file extension
         if ($Path -match '\.ya?ml$') {
             if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-                try {
-                    Import-Module powershell-yaml -ErrorAction Stop
-                }
-                catch {
+                try { Import-Module powershell-yaml -ErrorAction Stop } catch {
                     throw "YAML support requires the 'powershell-yaml' module. Install it with 'Install-Module powershell-yaml'."
                 }
             }
-            $config = $content  ConvertFrom-Yaml
+            $config = $content | ConvertFrom-Yaml
         }
         else {
-            $config = $content | ConvertFrom-Json}
+            $config = $content | ConvertFrom-Json
+        }
 
+        # Build useful paths relative to the repository root
         $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
         $dirs     = @{}
-        if ($config.PSObject.Properties'Directories') {
-            # Preserve any user-defined directory settings
-            $config.Directories.PSObject.Properties | ForEach-Object{
-                $dirs$_.Name = $_.Value
+
+        # Preserve any user-defined directory settings
+        if ($config.PSObject.Properties['Directories']) {
+            $config.Directories.PSObject.Properties | ForEach-Object {
+                $dirs[$_.Name] = $_.Value
             }
         }
 
-        $dirs'RepoRoot'       = $repoRoot.Path
-        $dirs'RunnerScripts'  = Join-Path $repoRoot 'core-runner/core_app/scripts'
-        $dirs'UtilityScripts' = Join-Path (Join-Path $repoRoot 'lab_utils') 'LabRunner'
-        $dirs'ConfigFiles'    = Join-Path $repoRoot 'config_files'
-        $dirs'InfraRepo'      = if ($config.InfraRepoPath) { $config.InfraRepoPath } else { 'C:\\Temp\\base-infra' }
+        $dirs['RepoRoot']       = $repoRoot.Path
+        $dirs['RunnerScripts']  = Join-Path $repoRoot 'core-runner/core_app/scripts'
+        $dirs['UtilityScripts'] = Join-Path (Join-Path $repoRoot 'lab_utils') 'LabRunner'
+        $dirs['ConfigFiles']    = Join-Path $repoRoot 'config_files'
+        $dirs['InfraRepo']      = if ($config.InfraRepoPath) { $config.InfraRepoPath } else { 'C:\\Temp\\base-infra' }
 
-        Add-Member -InputObject $config -MemberType NoteProperty -Name Directories -Value (pscustomobject$dirs) -Force
+        Add-Member -InputObject $config -MemberType NoteProperty -Name Directories -Value ([pscustomobject]$dirs) -Force
         return $config
     }
     catch {
         throw "Failed to parse config file $Path. $_"
-
-
     }
 }
-
-
-
-
-

--- a/tests/unit/scripts/Get-LabConfig.Tests.ps1
+++ b/tests/unit/scripts/Get-LabConfig.Tests.ps1
@@ -3,18 +3,37 @@
 
 Describe 'Get-LabConfig Tests' {
     BeforeAll {
-        Import-Module "$env:PWSH_MODULES_PATH/LabRunner/" -Force}
+        # Dot-source the script directly for testing
+        $script:ScriptPath = Join-Path $env:PROJECT_ROOT 'core-runner/modules/LabRunner/Get-LabConfig.ps1'
+        . $script:ScriptPath
 
-    Context 'Module Loading' {
-        It 'should load required modules' {
-            Get-Module LabRunner | Should -Not -BeNullOrEmpty
+        # Create sample JSON and YAML config files
+        $script:JsonPath = Join-Path $TestDrive 'config.json'
+        @{ LabName = 'JsonLab' } | ConvertTo-Json | Set-Content -Path $script:JsonPath -Encoding UTF8
+
+        $script:YamlPath = Join-Path $TestDrive 'config.yaml'
+        "LabName: YamlLab" | Set-Content -Path $script:YamlPath -Encoding UTF8
+    }
+
+    Context 'Script Validation' {
+        It 'script should exist' {
+            $script:ScriptPath | Should -Exist
         }
     }
 
-    Context 'Functionality Tests' {
-        It 'should execute without errors' {
-            # Basic test implementation
-            $true | Should -BeTrue
+    Context 'JSON Loading' {
+        It 'should parse JSON config' {
+            $result = Get-LabConfig -Path $script:JsonPath
+            $result.LabName | Should -Be 'JsonLab'
+            $result.Directories | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'YAML Loading' {
+        It 'should parse YAML config' {
+            $result = Get-LabConfig -Path $script:YamlPath
+            $result.LabName | Should -Be 'YamlLab'
+            $result.Directories | Should -Not -BeNullOrEmpty
         }
     }
 


### PR DESCRIPTION
## Summary
- fix parameter types and YAML parsing in Get-LabConfig.ps1
- add inline comments and clean whitespace
- add Pester tests for JSON and YAML handling

## Testing
- `pwsh -NoProfile -File tests/Run-AllModuleTests.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853addc14088331ac137eb255e72188